### PR TITLE
Run meta value through maybe_unserialize to avoid unexpected re-seria…

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -123,6 +123,7 @@ class NetworkSiteConnection extends Connection {
 				foreach ( $post->meta as $meta_key => $meta_array ) {
 					foreach ( $meta_array as $meta ) {
 						if ( ! in_array( $meta_key, $blacklisted_meta ) ) {
+							$meta = maybe_unserialize( $meta );
 							update_post_meta( $new_post, $meta_key, $meta );
 						}
 					}


### PR DESCRIPTION
PR is a result of an unexpected scenario where serialized meta is reserialized while still serialized. It's safer to `maybe_unserialize()` and allow WordPress to re-serialize a possible array.