### PR TITLE
Require PHP version 5.6 - throw an error if the plugin is activated on an older version.

### DIFF
--- a/distributor.php
+++ b/distributor.php
@@ -47,6 +47,18 @@ spl_autoload_register(
 );
 
 /**
+ * Require PHP version 5.6 - throw an error if the plugin is activated on an older version.
+ */
+register_activation_hook( __FILE__, function() {
+	if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+		wp_die(
+			__( 'Distributor requires PHP version 5.6.', 'distributor' ),
+			__( 'Error Activating', 'distributor' )
+		);
+	}
+} );
+
+/**
  * Tell the world this site supports Distributor. We need this for external connections.
  */
 add_action(


### PR DESCRIPTION
before this change if you activated the plugin on a system running php 5.5, you would get a php fatal:

https://cl.ly/2J0o2F2N3Q47

the plugin is also active and must be deleted manually or php upgraded before wp can be used (fatal on every load)

after this pr, you get this screen when trying to activate:

https://cl.ly/1m090c0q1M0F

the plugin is not activated, so you can still use wp
