### PR TITLE
Ensure auth headers are not lost before a types request.

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -98,15 +98,11 @@ class WordPressExternalConnection extends ExternalConnection {
 
 			if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 				$types_response = vip_safe_wp_remote_get(
-					$types_path, array(
-						$this->auth_handler->format_get_args( array( 'timeout' => 5 ) ),
-					)
+					$types_path, $this->auth_handler->format_get_args( array( 'timeout' => 5 ) )
 				);
 			} else {
 				$types_response = wp_remote_get(
-					$types_path, array(
-						$this->auth_handler->format_get_args( array( 'timeout' => 5 ) ),
-					)
+					$types_path, $this->auth_handler->format_get_args( array( 'timeout' => 5 ) )
 				);
 			}
 


### PR DESCRIPTION
The extra `array()` wrapper was causing the auth headers to not actually be passed as expected. Shout out to @cmmarslender the 🐐 for helping me find this.