### PR TITLE
Update meta handling - when meta is array of items, examine them each

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -33,7 +33,6 @@ function set_meta( $post_id, $meta ) {
 
 	foreach ( $meta as $meta_key => $meta_value ) {
 		if ( is_string( $meta_value ) ) {
-						error_log( json_encode( $meta_value, JSON_PRETTY_PRINT ) );
 			if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
 				$meta_value = maybe_unserialize( $meta_value );
 				update_post_meta( $post_id, $meta_key, $meta_value );
@@ -41,7 +40,6 @@ function set_meta( $post_id, $meta ) {
 		} else {
 			$meta_array = (array) $meta_value;
 			foreach ( $meta_array as $meta_item_value ) {
-						error_log( json_encode( $meta_value, JSON_PRETTY_PRINT ) );
 				if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
 					$meta_item_value = maybe_unserialize( $meta_item_value );
 					update_post_meta( $post_id, $meta_key, $meta_item_value );


### PR DESCRIPTION
## Fixes
Fixes an issue that broke media pushing since https://github.com/10up/distributor/commit/6f139b85f575ccbf01a90294ce9dd26c6e73f57d

## Testing
I am testing using an external connection (eg uses REST API)
* create a post with a featured image
* distribute post to an external site
on the external site, open the created media item in the media library, click edit item

**Expected result:**
The edit media screen works as expected

**Actual result:**
An error message is shown: `Image data does not exist. Please re-upload the image.`

Checking the database, I discovered the media had invalid post meta, with slashed quotes around meta keys:

![](https://cl.ly/2S0u451x1S0B/Image%202018-02-22%20at%204.59.17%20PM.png)

## Changes
When processing meta, strings are given the new treatment , everything else gets the old treatment, casting as array and iterating each item.