### PR TITLE
Adds composer.json type attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "10up/distributor",
+  "type": "wordpress-plugin",
   "authors": [
   	{
   		"name": "Taylor Lovett",


### PR DESCRIPTION
Add type attribute to composer.json to specify the plugin get's installed in the plugins folder for WP. Handles #80