### PR TITLE
Add original media ID to distributed media item meta

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -260,6 +260,7 @@ function set_media( $post_id, $media ) {
 		}
 
 		update_post_meta( $image_id, 'dt_original_media_url', $media_item['source_url'] );
+		update_post_meta( $image_id, 'dt_original_media_id', $media_item['id'] );
 
 		if ( $media_item['featured'] ) {
 			$found_featured_image = true;


### PR DESCRIPTION
Save old media ID so it can be used to make the connection from meta fields containing it, related to #81 and possibly #77.