### PR TITLE
#85 - fix php warnings for missing argument for "format_get_args()"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 node_modules
 .DS_Store
+.idea*

--- a/includes/classes/Authentication.php
+++ b/includes/classes/Authentication.php
@@ -36,7 +36,7 @@ abstract class Authentication {
 	 * @since  .8
 	 * @return array
 	 */
-	public function format_get_args( $args, $context = array() ) {
+	public function format_get_args( $args = array(), $context = array() ) {
 		return apply_filters( 'dt_auth_format_get_args', $args, $context, $this );
 	}
 

--- a/includes/classes/Authentications/WordPressBasicAuth.php
+++ b/includes/classes/Authentications/WordPressBasicAuth.php
@@ -97,7 +97,7 @@ class WordPressBasicAuth extends Authentication {
 	 * @since  0.8
 	 * @return array
 	 */
-	public function format_get_args( $args, $context = array() ) {
+	public function format_get_args( $args = array(), $context = array() ) {
 		if ( ! empty( $this->username ) && ! empty( $this->base64_encoded ) ) {
 			if ( empty( $args['headers'] ) ) {
 				$args['headers'] = array();

--- a/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
+++ b/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
@@ -280,7 +280,7 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 	 * @since  1.1.0
 	 * @return array
 	 */
-	public function format_get_args( $args, $context = array() ) {
+	public function format_get_args( $args = array(), $context = array() ) {
 		$saved_access_token = isset( $this->{self::ACCESS_TOKEN_KEY} ) ?
 			$this->{self::ACCESS_TOKEN_KEY} :
 			false;

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -47,7 +47,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	 *
 	 * @param  array $args
 	 * @since  0.8
-	 * @return array|WP_Post
+	 * @return array|\WP_Post|\WP_Error
 	 */
 	public function remote_get( $args = array() ) {
 		$id = ( empty( $args['id'] ) ) ? false : $args['id'];
@@ -164,7 +164,7 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$context = 'view';
 
-		$prelim_get_args = $this->auth_handler->format_get_args( array() );
+		$prelim_get_args = $this->auth_handler->format_get_args();
 
 		/**
 		 * See if we are trying to authenticate
@@ -310,7 +310,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	 * @param  int   $post_id
 	 * @param  array $args
 	 * @since  0.8
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
 	public function push( $post_id, $args = array() ) {
 		if ( empty( $post_id ) ) {
@@ -605,7 +605,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	 *
 	 * @param  array
 	 * @since  0.8
-	 * @return WP_Post
+	 * @return \WP_Post
 	 */
 	private function to_wp_post( $post ) {
 		$obj = new \stdClass();
@@ -694,7 +694,7 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		// Return as is if not on a singular page - taken from rel_canonical()
 		if ( ! is_singular() ) {
-			$canonical_url;
+			return $canonical_url;
 		}
 
 		$id = get_queried_object_id();


### PR DESCRIPTION
Closes #85  

- This adjusts the args expected by `format_get_args` to default $args to an empty array if it's not provided in the use of the method. 
- also adjusts some minor docblock statements to make IDE's a bit happier
- also adjusts .gitignore to ignore .idea files