### PR TITLE
Fix error handling for wp_remote_retrieve_body()

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -120,8 +120,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 			$types_body = wp_remote_retrieve_body( $types_response );
 
-			if ( is_wp_error( $types_body ) ) {
-				return $types_body;
+			if ( empty( $types_body ) ) {
+				return new \WP_Error( 'no-response-body', esc_html__( 'Response body is empty', 'distributor' ) );
 			}
 
 			$types_body_array = json_decode( $types_body, true );
@@ -201,8 +201,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$posts_body = wp_remote_retrieve_body( $posts_response );
 
-		if ( is_wp_error( $posts_body ) ) {
-			return $posts_body;
+		if ( empty( $posts_body ) ) {
+			return new \WP_Error( 'no-response-body', esc_html__( 'Response body is empty', 'distributor' ) );
 		}
 
 		$posts           = json_decode( $posts_body, true );
@@ -350,8 +350,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( is_wp_error( $body ) ) {
-			return $body;
+		if ( empty( $body ) ) {
+			return new \WP_Error( 'no-response-body', esc_html__( 'Response body is empty', 'distributor' ) );
 		}
 
 		$body_array = json_decode( $body, true );
@@ -430,8 +430,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( is_wp_error( $body ) ) {
-			return $body;
+		if ( empty( $body ) ) {
+			return new \WP_Error( 'no-response-body', esc_html__( 'Response body is empty', 'distributor' ) );
 		}
 
 		$body_array = json_decode( $body, true );
@@ -476,7 +476,7 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( is_wp_error( $response ) || is_wp_error( $body ) ) {
+		if ( is_wp_error( $response ) || empty( $body ) ) {
 			$output['errors']['no_external_connection'] = 'no_external_connection';
 			return $output;
 		}
@@ -528,7 +528,7 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 		$types_body = wp_remote_retrieve_body( $types_response );
 
-		if ( is_wp_error( $types_response ) || is_wp_error( $types_body ) ) {
+		if ( is_wp_error( $types_response ) || empty( $types_body ) ) {
 			$output['errors']['no_types'] = 'no_types';
 		} else {
 			$types = json_decode( $types_body, true );

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -488,7 +488,7 @@ class NetworkSiteConnection extends Connection {
 
 				$body = wp_remote_retrieve_body( $response );
 
-				if ( ! is_wp_error( $body ) ) {
+				if ( ! empty( $body ) ) {
 					try {
 						$body_array = json_decode( $body, true );
 


### PR DESCRIPTION
The `wp_remote_retrieve_body()` function does not return a `WP_Error` object on error.