### PR TITLE
Check response code after remotely getting posts

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -199,6 +199,22 @@ class WordPressExternalConnection extends ExternalConnection {
 			return $posts_response;
 		}
 
+		$response_code = wp_remote_retrieve_response_code( $posts_response );
+
+		if ( 200 !== $response_code ) {
+
+			if ( 404 === $response_code ) {
+				return new \WP_Error( 'bad-endpoint', esc_html__( 'Could not connect to API endpoint.', 'distributor' ) );
+			}
+
+			$posts_body = json_decode( wp_remote_retrieve_body( $posts_response ), true );
+
+			$code    = empty( $posts_body['code'] ) ? 'endpoint-error' : esc_html( $posts_body['code'] );
+			$message = empty( $posts_body['message'] ) ? esc_html__( 'API endpoint error.', 'distributor' ) : esc_html( $posts_body['message'] );
+
+			return new \WP_Error( $code, $message );
+		}
+
 		$posts_body = wp_remote_retrieve_body( $posts_response );
 
 		if ( empty( $posts_body ) ) {


### PR DESCRIPTION
Remotely getting posts via `WordPressExternalConnection` may not be successful, eg. because of authentication errors (which is what brought this issue to light for me).

Note: This fix assumes that a successful API request will respond with a `200` response code.