### PR TITLE
Move authentication signature checks into `rest_authentication_errors` hook 

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -24,7 +24,7 @@ class SubscriptionsController extends \WP_REST_Controller {
 		$this->rest_base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
 
 		$this->meta = new \WP_REST_Post_Meta_Fields( $this->post_type );
-		add_filter( 'rest_authentication_errors', array( $this, 'dt_verify_signature_authentication' );
+		add_filter( 'rest_authentication_errors', array( $this, 'dt_verify_signature_authentication' ) );
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/10up/distributor/issues/73

* move the signature test out of this individual endpoints, instead hooking to `rest_authentication_errors`.
* when the signature is included in the request, use it for authentication.
* Initial pass, needs testing to confirm this works as expected.