### PR TITLE
Feature/create missing terms filter

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -203,12 +203,12 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 			$term = get_term_by( 'slug', $term_array['slug'], $taxonomy );
 
 			// Create terms on remote site if they don't exist
-			$create_terms = apply_filters( 'dt_create_missing_terms', true );
+			$create_missing_terms = apply_filters( 'dt_create_missing_terms', true );
 
 			if ( empty( $term ) ) {
 
 				// Bail if terms shouldn't be created
-				if ( false === $create_terms ) {
+				if ( false === $create_missing_terms ) {
 					continue;
 				}
 


### PR DESCRIPTION
If terms are missing on a syndicated site, they are created by default. Some use cases may require to only use terms that already exist on the site a post is being syndicated to. This filter allows this to be toggled if need be.