### PR TITLE
Fix syndicatable() front end check for supported post type

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -46,6 +46,10 @@ function syndicatable() {
 		if ( ! is_single() ) {
 			return false;
 		}
+
+		if ( ! in_array( get_post_type(), \Distributor\Utils\distributable_post_types(), true ) ) {
+			return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
On the front end the syndicatable() function assumes all public post types are syndicatable.