### PR TITLE
Check for WP_Error in NetworkSiteConnection::log_sync()

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -188,7 +188,7 @@ class NetworkSiteConnection extends Connection {
 		$sync_log = get_site_option( 'dt_sync_log_' . $this->site->blog_id, array() );
 
 		foreach ( $item_id_mappings as $old_item_id => $new_item_id ) {
-			if ( empty( $new_item_id ) ) {
+			if ( empty( $new_item_id ) || is_wp_error( $new_item_id ) ) {
 				$sync_log[ $old_item_id ] = false;
 			} else {
 				$sync_log[ $old_item_id ] = (int) $new_item_id;


### PR DESCRIPTION
The NetworkSiteConnection `pull()` method [may add a `WP_Error` object](https://github.com/10up/distributor/blob/master/includes/classes/InternalConnections/NetworkSiteConnection.php#L101) to its list of created posts, which is [passed along](https://github.com/10up/distributor/blob/master/includes/pull-ui.php#L215) via `$post_id_mappings` to `log_sync()` by `process_actions()` in pull-ui.php.