### PR TITLE
Add some filters

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -361,7 +361,7 @@ function format_media_post( $media_post ) {
 	$media_item['source_url']    = wp_get_attachment_url( $media_post->ID );
 	$media_item['meta']          = get_post_meta( $media_post->ID );
 
-	return apply_filters( 'dt_media_item_args', $media_item, $media_post->ID );
+	return apply_filters( 'dt_media_item_formatted', $media_item, $media_post->ID );
 }
 
 /**


### PR DESCRIPTION
- `dt_get_media_details`
- `dt_media_item_formatted`
	These two filter allow me to easily remove any theme specific attachment sizes during distribution.
- `dt_sync_meta`
	Allows for control over sync of each individual meta key

Here's example code for all three:

```php
<?php

function drop_theme_media_sizes($size_key) {
  $theme_name = explode(" ", strtolower(wp_get_theme()->display('Name')))[0];
  return (strpos($size_key, $theme_name) === false);
}

// Remove theme specific media sizes
function filter_theme_attachment_sizes($attachment_metadata, $attachment_id) {
  $attachment_metadata['sizes'] = array_filter($attachment_metadata['sizes'], __NAMESPACE__ . '\drop_theme_sizes', ARRAY_FILTER_USE_KEY);
  return $attachment_metadata;
}

function filter_theme_media_item_meta($media_item, $attachment_id) {
  $attachment_meta = unserialize($media_item['meta']['_wp_attachment_metadata'][0]);
  $attachment_meta['sizes'] = array_filter($attachment_meta['sizes'], __NAMESPACE__ . '\drop_theme_sizes', ARRAY_FILTER_USE_KEY);
  $media_item['meta']['_wp_attachment_metadata'][0] = serialize($attachment_meta);
  return $media_item;
}

add_filter('dt_get_media_details', __NAMESPACE__ . '\filter_theme_attachment_sizes', 10, 2);
add_filter('dt_media_item_formatted', __NAMESPACE__ . '\filter_theme_media_item_meta', 10, 2);

// Wipe out Yoast canonical URL if its prefix is the home_url of the current WordPress install.
function meta_filter($returnBool, $meta_key, $meta_value, $post_id) {
  if($meta_key === '_yoast_wpseo_canonical' && (strpos($meta_value, home_url()) === 0) {
    return false;
  }

  return $returnBool;
}

add_filter('dt_sync_meta', __NAMESPACE__ . '\meta_filter', 10, 4);


```