### PR TITLE
Fix og:url in Yoast for external WordPress connections

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -689,6 +689,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	public static function canonicalize_front_end() {
 		add_filter( 'get_canonical_url', array( '\Distributor\ExternalConnections\WordPressExternalConnection', 'canonical_url' ), 10, 2 );
 		add_filter( 'wpseo_canonical', array( '\Distributor\ExternalConnections\WordPressExternalConnection', 'wpseo_canonical_url' ) );
+		add_filter( 'wpseo_opengraph_url', array( '\Distributor\ExternalConnections\WordPressExternalConnection', 'wpseo_og_url' ) );
 		add_filter( 'the_author', array( '\Distributor\ExternalConnections\WordPressExternalConnection', 'the_author_distributed' ) );
 		add_filter( 'author_link', array( '\Distributor\ExternalConnections\WordPressExternalConnection', 'author_posts_url_distributed' ), 10, 3 );
 	}
@@ -811,5 +812,20 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 
 		return self::canonical_url( $canonical_url, $post );
+	}
+
+	/**
+	 * Handles the og:url change for distributed content when Yoast SEO is in use
+	 *
+	 * @param string $og_url The Yoast WPSEO deduced OG URL which is a result of wpseo_canonical_url
+	 *
+	 * @return string $og_url The updated distributor friendly URL
+	 */
+	public static function wpseo_og_url( $og_url ) {
+		if ( is_singular() ) {
+			$og_url = get_permalink();
+		}
+
+		return $og_url;
 	}
 }


### PR DESCRIPTION
This is the same fix as #66 but for WordPressExternalConnection instead of NetworkSiteConnection.