### PR TITLE
Doc corrections: $new_post is ID, not obj or array

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -93,7 +93,7 @@ class NetworkSiteConnection extends Connection {
 			 * Allow plugins to override the default {@see \Distributor\Utils\set_media()} function.
 			 *
 			 * @param bool               true      If Distributor should set the post media.
-			 * @param WP_Post            $new_post The newly created post.
+			 * @param int		         $new_post The newly created post ID.
 			 * @param array              $media    List of media items attached to the post, formatted by {@see \Distributor\Utils\prepare_media()}.
 			 * @param int                $post_id  The original post ID.
 			 * @param array              $args     The arguments passed into wp_insert_post.
@@ -107,7 +107,7 @@ class NetworkSiteConnection extends Connection {
 		/**
 		 * Action triggered when a post is pushed via distributor.
 		 *
-		 * @param WP_Post            $new_post   The newly created post.
+		 * @param int		         $new_post   The newly created post ID.
 		 * @param int                $post_id    The original post ID.
 		 * @param array              $args       The arguments passed into wp_insert_post.
 		 * @param ExternalConnection $this       The distributor connection being pushed to.
@@ -211,7 +211,7 @@ class NetworkSiteConnection extends Connection {
 			 *
 			 * @since 1.0
 			 *
-			 * @param array              $new_post   The new post that was pulled.
+			 * @param int	             $new_post   The new post ID that was pulled.
 			 * @param ExternalConnection $this       The distributor connection pulling the post.
 			 * @param array              $post_array The original post data retrieved via the connection.
 			 */


### PR DESCRIPTION
Doc blocks for push() and pull() specified $new_post as object or array. It should be the ID, which is what wp_insert_post() returns.