### PR TITLE
Make distributable post statuses filterable

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -20,7 +20,6 @@ function setup() {
 	);
 }
 
-
 /**
  * Check if post is syndicatable
  *
@@ -32,15 +31,9 @@ function syndicatable() {
 		return false;
 	}
 
-	// Only published posts can be distributed.
-	/**
-	 * Filter whether drafts are distributable.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param bool false Whether drafts can be distributed.
-	 */
-	if ( 'publish' !== get_post_status() && ! apply_filters( 'dt_drafts_can_be_distributed', false ) ) {
+	global $post;
+
+	if ( ! in_array( $post->post_status, \Distributor\Utils\distributable_post_statuses(), true ) ) {
 		return false;
 	}
 
@@ -56,10 +49,6 @@ function syndicatable() {
 		}
 	} else {
 		if ( ! is_single() ) {
-			return false;
-		}
-
-		if ( ! in_array( get_post_type(), \Distributor\Utils\distributable_post_types(), true ) ) {
 			return false;
 		}
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -149,6 +149,24 @@ function distributable_post_types() {
 	return apply_filters( 'distributable_post_types', array_diff( $post_types, [ 'dt_ext_connection', 'dt_subscription' ] ) );
 }
 
+/**
+ * Return post statuses that are allowed to be distributed.
+ *
+ * @since  1.0
+ * @return array
+ */
+function distributable_post_statuses() {
+
+	/**
+	 * Filter the post statuses that are allowed to be distributed.
+	 *
+	 * By default only published posts can be distributed.
+	 *
+	 * @param array Post statuses.
+	 */
+	return apply_filters( 'dt_distributable_post_statuses', array( 'publish' ) );
+}
+
 function blacklisted_meta() {
 	/**
 	 * Filter meta keys that are blacklisted.


### PR DESCRIPTION
The changes in #110 resulted in only allowing published posts to be distributed, with a possible exception for drafts via a filter.

This pull request adds a filterable `distributable_post_statuses()` utility function similar to `distributable_post_types()`. It is used in the `syndicatable()` function and replaces the previously added `dt_drafts_can_be_distributed` filter.