### PR TITLE
Prefix distributable_post_types filter

### DIFF
--- a/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
+++ b/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
@@ -89,7 +89,7 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 		$args[ self::API_REDIRECT_URI ] = $redirect_uri;
 
 		// Display any authorization or token errors.
-		do_action( 'oauth_admin_notices' );
+		do_action( 'dt_oauth_admin_notices' );
 
 		// If anything is missing, we aren't authorized - show the credentials form.
 		if (

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -153,7 +153,7 @@ function distributable_post_types() {
 	 * @since 1.0.0
 	 * @param array Post types that are distributable. Default 'all post types except dt_ext_connection and dt_subscription'.
 	 */
-	return apply_filters( 'distributable_post_types', array_diff( $post_types, [ 'dt_ext_connection', 'dt_subscription' ] ) );
+	return apply_filters( 'dt_distributable_post_types', array_diff( $post_types, [ 'dt_ext_connection', 'dt_subscription' ] ) );
 }
 
 /**


### PR DESCRIPTION
The `distributable_post_types` should prefixed to `dt_distributable_post_types`. This could be a breaking change for some users.