### PR TITLE
Fix dt_blacklisted_meta filter doc

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -186,7 +186,7 @@ function blacklisted_meta() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array Post types that are distributable. Default 'dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _edit_lock, _edit_last'.
+	 * @param array Blacklisted meta keys. Default 'dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _edit_lock, _edit_last'.
 	 */
 	return apply_filters( 'dt_blacklisted_meta', [ 'dt_unlinked', 'dt_connection_map', 'dt_subscription_update', 'dt_subscriptions', 'dt_subscription_signature', 'dt_original_post_id', 'dt_original_post_url', 'dt_original_blog_id', 'dt_syndicate_time', '_wp_attached_file', '_edit_lock', '_edit_last' ] );
 }


### PR DESCRIPTION
Update description of array passed to the dt_blacklisted_meta, it referred to post types in stead of post meta.