### PR TITLE
Fix displaying selected internal pull connection

### DIFF
--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -346,7 +346,7 @@ function dashboard() {
 								$name     = untrailingslashit( $connection->site->domain . $connection->site->path );
 								$id       = $connection->site->blog_id;
 
-								if ( is_a( $connection_now, '\Distributor\InternalConnection' ) && (int) $connection_now->site->blog_id === (int) $id ) {
+								if ( !is_a( $connection_now, '\Distributor\ExternalConnection' ) && (int) $connection_now->site->blog_id === (int) $id ) {
 									$selected = true;
 								}
 								?>


### PR DESCRIPTION
`\Distributor\InternalConnection` is not an actual class that the internal connections pull from. Since the other conditional statements in the dashboard function are checking if connection is `'\Distributor\ExternalConnection'`, I updated the selected option conditional to check if it is not an external connection.

Fixes #166