### PR TITLE
Fix Sync Log Storage (Backwards Compat Break)

### DIFF
--- a/includes/classes/ExternalConnection.php
+++ b/includes/classes/ExternalConnection.php
@@ -61,7 +61,13 @@ abstract class ExternalConnection extends Connection {
 	}
 
 	/**
-	 * Log a sync
+	 * Log a sync.
+	 *
+	 * {
+	 * 	old_post_id: new_post_id (false means skipped)
+	 * }
+	 *
+	 * This let's us grab all the IDs of posts we've PULLED from a given connection
 	 *
 	 * @param  array $item_id_mappings Mapping array to store.
 	 * @since  0.8

--- a/includes/classes/ExternalConnection.php
+++ b/includes/classes/ExternalConnection.php
@@ -64,7 +64,7 @@ abstract class ExternalConnection extends Connection {
 	 * Log a sync.
 	 *
 	 * {
-	 * 	old_post_id: new_post_id (false means skipped)
+	 *  old_post_id: new_post_id (false means skipped)
 	 * }
 	 *
 	 * This let's us grab all the IDs of posts we've PULLED from a given connection

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -254,9 +254,9 @@ class NetworkSiteConnection extends Connection {
 	 * Log a sync. Unfortunately have to use options. We store like this:
 	 *
 	 * {
-	 * 	original_connection_id: {
-	 * 		old_post_id: new_post_id (false means skipped)
-	 * 	}
+	 *  original_connection_id: {
+	 *      old_post_id: new_post_id (false means skipped)
+	 *  }
 	 * }
 	 *
 	 * This let's us grab all the IDs of posts we've PULLED from a given site

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -368,7 +368,21 @@ class PullListTable extends \WP_List_Table {
 		if ( is_a( $connection_now, '\Distributor\ExternalConnection' ) ) {
 			$this->sync_log = get_post_meta( $connection_now->id, 'dt_sync_log', true );
 		} else {
-			$this->sync_log = get_site_option( 'dt_sync_log_' . $connection_now->site->blog_id, array() );
+			$this->sync_log = [];
+
+			/**
+			 * Backwards compat code for dealing with old style sync log in site options
+			 */
+			$old_sync_log = get_site_option( 'dt_sync_log_' . $connection_now->site->blog_id, array() );
+			$sync_log = get_option( 'dt_sync_log', [] );
+
+			if ( ! empty( $sync_log[ $connection_now->site->blog_id ] ) ) {
+				$this->sync_log = $connection_now->site->blog_id;
+			}
+
+			foreach ( $old_sync_log as $remote_post_id => $post_id ) {
+
+			}
 		}
 
 		if ( empty( $this->sync_log ) ) {

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -370,18 +370,10 @@ class PullListTable extends \WP_List_Table {
 		} else {
 			$this->sync_log = [];
 
-			/**
-			 * Backwards compat code for dealing with old style sync log in site options
-			 */
-			$old_sync_log = get_site_option( 'dt_sync_log_' . $connection_now->site->blog_id, array() );
 			$sync_log = get_option( 'dt_sync_log', [] );
 
 			if ( ! empty( $sync_log[ $connection_now->site->blog_id ] ) ) {
-				$this->sync_log = $connection_now->site->blog_id;
-			}
-
-			foreach ( $old_sync_log as $remote_post_id => $post_id ) {
-
+				$this->sync_log = $sync_log[ $connection_now->site->blog_id ];
 			}
 		}
 


### PR DESCRIPTION
This fixes #165.

The purpose of the "sync log" is to store which posts have been pulled/skipped. This has to be handled on a site by site, connection by connection basis.

For external connections, we store in post meta `dt_sync_log` for the external connection like so:
```
[
  remote_post_id => post_id|false
]
```

For internal connections, we currently store in a site option `dt_sync_log_REMOTE_BLOG_ID` like so:
```
[
  remote_post_id => post_id|false
]
```

What we are doing for external connection works fine. However, for internal connections when a post has been pulled into one blog on the network, it shows as pulled for all blogs.

The way we are storing the sync log is fundamentally wrong for internal connections. For every post, we need to know where it came from and where it went. In our current system, we only store where it came from. Because of the lack of info, there is no way to fix this while preserving backwards compatibility.

This PR stores the sync log in an option for each site (site option is not needed) `dt_sync_log`. Data is stored like so:
```
[
  blog_id => [
    remote_post_id => post_id|false
  ]
]
```

This contains all the info we need to properly support this functionality.

The backwards compatibility issue is that all people before this skipping or pulling posts will see those posts available for pull again.