### PR TITLE
Refer to post as object instead of array

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -45,7 +45,7 @@ function setup() {
 function filter_distributor_content( $prepared_post, $request ) {
 
 	if ( \Distributor\Utils\is_using_gutenberg() && isset( $request['distributor_raw_content'] ) ) {
-		if ( gutenberg_can_edit_post_type( $prepared_post['post_type'] ) ) {
+		if ( gutenberg_can_edit_post_type( $prepared_post->post_type ) ) {
 			$prepared_post->post_content = $request['distributor_raw_content'];
 		}
 	}


### PR DESCRIPTION
When filtering the post content for Distributor, we need to refer to the post as an object not an array.