### PR TITLE
Restore support for arrays when storing meta

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -125,7 +125,7 @@ function set_meta( $post_id, $meta ) {
 				update_post_meta( $post_id, $meta_key, $meta_value );
 			}
 		} else {
-			$meta_array = (array) $meta_value;
+			$meta_array  = (array) $meta_value;
 			$meta_values = array();
 			foreach ( $meta_array as $meta_item_value ) {
 				if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
@@ -498,7 +498,7 @@ function format_media_post( $media_post ) {
 	$media_item['meta']          = get_post_meta( $media_post->ID );
 
 	// Convert media meta items back into single values.
-	foreach( $media_item['meta'] as $key => $media_item_value ) {
+	foreach ( $media_item['meta'] as $key => $media_item_value ) {
 		$media_item['meta'][ $key ] = $media_item_value[0];
 	}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -119,7 +119,7 @@ function set_meta( $post_id, $meta ) {
 	$blacklisted_meta = blacklisted_meta();
 
 	foreach ( $meta as $meta_key => $meta_value ) {
-		if ( is_string( $meta_value ) ) {
+		if ( ! is_array( $meta_value ) ) {
 			if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
 				$meta_value = maybe_unserialize( $meta_value );
 				update_post_meta( $post_id, $meta_key, $meta_value );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -496,6 +496,11 @@ function format_media_post( $media_post ) {
 	$media_item['source_url']    = wp_get_attachment_url( $media_post->ID );
 	$media_item['meta']          = get_post_meta( $media_post->ID );
 
+	// Convert media meta items back into single values.
+	foreach( $media_item['meta'] as $key => $media_item_value ) {
+		$media_item['meta'][ $key ] = $media_item_value[0];
+	}
+
 	return apply_filters( 'dt_media_item_formatted', $media_item, $media_post->ID );
 }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -126,12 +126,13 @@ function set_meta( $post_id, $meta ) {
 			}
 		} else {
 			$meta_array = (array) $meta_value;
+			$meta_values = array();
 			foreach ( $meta_array as $meta_item_value ) {
 				if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
-					$meta_item_value = maybe_unserialize( $meta_item_value );
-					update_post_meta( $post_id, $meta_key, $meta_item_value );
+					$meta_values[] = maybe_unserialize( $meta_item_value );
 				}
 			}
+			update_post_meta( $post_id, $meta_key, $meta_values );
 		}
 	}
 }

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -14,8 +14,16 @@ class UtilsTest extends \TestCase {
 	public function test_set_meta_simple() {
 		\WP_Mock::userFunction(
 			'update_post_meta', [
-				'times'  => 2,
+				'times'  => 1,
 				'args'   => [ 1, 'key', 'value' ],
+				'return' => [],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'update_post_meta', [
+				'times'  => 1,
+				'args'   => [ 1, 'key', [ 'value' ] ],
 				'return' => [],
 			]
 		);
@@ -413,8 +421,8 @@ class UtilsTest extends \TestCase {
 				'times'  => 1,
 				'args'   => [ $media_post->ID ],
 				'return' => [
-					'meta1' => true,
-					'meta2' => false,
+					'meta1' => [ true ],
+					'meta2' => [ false ],
 				],
 			]
 		);


### PR DESCRIPTION
I ran into #191 this morning and started poking around. It looks like the meta handling changed in #67 because of how featured media meta was breaking during storage.

https://github.com/10up/distributor/blob/30474c9c34834b43e3c51ed422b5a1bd5fbf108b/includes/utils.php#L484

I think that can be traced to the above line, which retrieves all meta for the media item and returns each key as an array by default. This mimics `get_post_meta( $post_id, 'my_key', false );` rather than `get_post_meta( $post_id, 'my_key', true );` and I'm guessing led to issue reported and fixed in #67.

This PR:
* Loops through the media meta and pulls only the first array value for each meta key. This probably needs to also `count()` the existing size just in case somebody is truly storing multiple keys/values.
* Restores support for arrays when setting meta.