### PR TITLE
Fix "As Draft" feature: correct use of `postStatus` data point

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -126,8 +126,8 @@ function ajax_push() {
 					$push_args['remote_post_id'] = (int) $connection_map['external'][ (int) $connection['id'] ]['post_id'];
 				}
 
-				if ( ! empty( $_POST['post_status'] ) ) {
-					$push_args['post_status'] = $_POST['post_status'];
+				if ( ! empty( $_POST['postStatus'] ) ) {
+					$push_args['post_status'] = $_POST['postStatus'];
 				}
 
 				$remote_id = $external_connection->push( intval( $_POST['postId'] ), $push_args );
@@ -163,8 +163,8 @@ function ajax_push() {
 				$push_args['remote_post_id'] = (int) $connection_map['internal'][ (int) $connection['id'] ]['post_id'];
 			}
 
-			if ( ! empty( $_POST['post_status'] ) ) {
-				$push_args['post_status'] = esc_attr( $_POST['post_status'] );
+			if ( ! empty( $_POST['postStatus'] ) ) {
+				$push_args['post_status'] = esc_attr( $_POST['postStatus'] );
 			}
 
 			$remote_id = $internal_connection->push( intval( $_POST['postId'] ), $push_args );


### PR DESCRIPTION
* Correct use of postStatus data point passed from push.js when pushing a post
* Fixes an issue where distributing a published post and marking 'As Draft' did not work as expected: before this change the post was distributed as published
* This was broken a few weeks ago in a code cleanup commit, the JS variable was changed from `post_status` to `postStatus`, but the PHP side was not changed and thus was looking for a variable that did not get set. See https://github.com/10up/distributor/commit/2e710ecaad47d0f53645965d0ec5055055c45aa9#diff-5e8c48045607c6056856e7b22f735aa2R151

### Testing
* Publish a post
* Distribute the post to another site, leaving 'As Draft' checked

### Expected Result
* The destination post is set as a draft

### Actual result
* The post is published when distributed