### PR TITLE
Fix PHPCS errors.

### DIFF
--- a/distributor.php
+++ b/distributor.php
@@ -21,9 +21,9 @@ define( 'DT_VERSION', '1.2.3' );
 define( 'DT_PLUGIN_FILE', preg_replace( '#^.*plugins/(.*)$#i', '$1', __FILE__ ) );
 
 // Define a constant if we're network activated to allow plugin to respond accordingly.
-$plugins = get_site_option( 'active_sitewide_plugins' );
+$active_plugins = get_site_option( 'active_sitewide_plugins' );
 
-if ( is_multisite() && isset( $plugins[ plugin_basename( __FILE__ ) ] ) ) {
+if ( is_multisite() && isset( $active_plugins[ plugin_basename( __FILE__ ) ] ) ) {
 	define( 'DT_IS_NETWORK', true );
 } else {
 	define( 'DT_IS_NETWORK', false );
@@ -56,7 +56,8 @@ spl_autoload_register(
  * Require PHP version 5.6 - throw an error if the plugin is activated on an older version.
  */
 register_activation_hook(
-	__FILE__, function() {
+	__FILE__,
+	function() {
 		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 			wp_die(
 				esc_html__( 'Distributor requires PHP version 5.6.', 'distributor' ),
@@ -70,7 +71,8 @@ register_activation_hook(
  * Tell the world this site supports Distributor. We need this for external connections.
  */
 add_action(
-	'send_headers', function() {
+	'send_headers',
+	function() {
 		if ( ! headers_sent() ) {
 			header( 'X-Distributor: yes' );
 		}
@@ -81,7 +83,8 @@ add_action(
  * Set Distributor header in all API responses.
  */
 add_filter(
-	'rest_post_dispatch', function( $response ) {
+	'rest_post_dispatch',
+	function( $response ) {
 		$response->header( 'X-Distributor', 'yes' );
 
 		return $response;
@@ -137,7 +140,8 @@ if ( class_exists( 'Puc_v4_Factory' ) ) {
  * Register connections
  */
 add_action(
-	'init', function() {
+	'init',
+	function() {
 		\Distributor\Connections::factory()->register( '\Distributor\ExternalConnections\WordPressExternalConnection' );
 		\Distributor\Connections::factory()->register( '\Distributor\ExternalConnections\WordPressDotcomExternalConnection' );
 		if (
@@ -152,7 +156,8 @@ add_action(
 		) {
 			\Distributor\Connections::factory()->register( '\Distributor\InternalConnections\NetworkSiteConnection' );
 		}
-	}, 1
+	},
+	1
 );
 
 /**

--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -44,7 +44,9 @@ class SubscriptionsController extends \WP_REST_Controller {
 	public function register_routes() {
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
@@ -76,7 +78,9 @@ class SubscriptionsController extends \WP_REST_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/receive', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/receive',
+			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'receive_item' ),
@@ -98,7 +102,9 @@ class SubscriptionsController extends \WP_REST_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/delete', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/delete',
+			array(
 				array(
 					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_item' ),

--- a/includes/classes/Authentication.php
+++ b/includes/classes/Authentication.php
@@ -113,7 +113,8 @@ abstract class Authentication {
 		// Store the message for output at the top of the authorization form
 		self::$error_message = $error_message;
 		add_action(
-			'auth_admin_notices', function() {
+			'auth_admin_notices',
+			function() {
 				?>
 		<div class="notice notice-error is-dismissible">
 			<p>

--- a/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
+++ b/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
@@ -443,7 +443,8 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 
 			// Allow wp_safe_redirect to redirect to the .com authorization endpoint.
 			add_filter(
-				'allowed_redirect_hosts', function( $content ) {
+				'allowed_redirect_hosts',
+				function( $content ) {
 					$content[] = 'public-api.wordpress.com';
 					return $content;
 				}

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -114,10 +114,13 @@ class WordPressExternalConnection extends ExternalConnection {
 					 * @param  object $this The authentication class.
 					 */
 					return apply_filters(
-						'dt_remote_get', [
+						'dt_remote_get',
+						[
 							'items'       => array(),
 							'total_items' => 0,
-						], $args, $this
+						],
+						$args,
+						$this
 					);
 				}
 
@@ -150,11 +153,16 @@ class WordPressExternalConnection extends ExternalConnection {
 			if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 				$types_response = vip_safe_wp_remote_get(
 					$types_path,
-					false, 3, 3, 10, $this->auth_handler->format_get_args()
+					false,
+					3,
+					3,
+					10,
+					$this->auth_handler->format_get_args()
 				);
 			} else {
 				$types_response = wp_remote_get(
-					$types_path, $this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) )
+					$types_path,
+					$this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) )
 				);
 			}
 
@@ -255,7 +263,11 @@ class WordPressExternalConnection extends ExternalConnection {
 				 * @param  object $this       The authentication class.
 				 */
 				apply_filters( 'dt_remote_get_url', $posts_url, $args, $this ),
-				false, 3, 3, 10, $this->auth_handler->format_get_args()
+				false,
+				3,
+				3,
+				10,
+				$this->auth_handler->format_get_args()
 			);
 		} else {
 			$posts_response = wp_remote_get( apply_filters( 'dt_remote_get_url', $posts_url, $args, $this ), $this->auth_handler->format_get_args( array( 'timeout' => 45 ) ) );
@@ -305,10 +317,13 @@ class WordPressExternalConnection extends ExternalConnection {
 			}
 
 			return apply_filters(
-				'dt_remote_get', [
+				'dt_remote_get',
+				[
 					'items'       => $formatted_posts,
 					'total_items' => $total_posts,
-				], $args, $this
+				],
+				$args,
+				$this
 			);
 		} else {
 			return apply_filters( 'dt_remote_get', $this->to_wp_post( $posts ), $args, $this );
@@ -437,11 +452,16 @@ class WordPressExternalConnection extends ExternalConnection {
 		if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 			$response = vip_safe_wp_remote_get(
 				$types_path,
-				false, 3, 3, 10, $this->auth_handler->format_get_args()
+				false,
+				3,
+				3,
+				10,
+				$this->auth_handler->format_get_args()
 			);
 		} else {
 			$response = wp_remote_get(
-				$types_path, $this->auth_handler->format_get_args(
+				$types_path,
+				$this->auth_handler->format_get_args(
 					array(
 						'timeout' => self::$timeout,
 					)
@@ -505,7 +525,11 @@ class WordPressExternalConnection extends ExternalConnection {
 			if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 				$post_exists_response = vip_safe_wp_remote_get(
 					$existing_post_url,
-					false, 3, 3, 10, $this->auth_handler->format_get_args()
+					false,
+					3,
+					3,
+					10,
+					$this->auth_handler->format_get_args()
 				);
 			} else {
 				$post_exists_response = wp_remote_get( $existing_post_url, $this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) ) );
@@ -521,7 +545,8 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 
 		$response = wp_remote_post(
-			$type_url, $this->auth_handler->format_post_args(
+			$type_url,
+			$this->auth_handler->format_post_args(
 				array(
 					/**
 					 * Filter the timeout used when calling WordPressExternalConnection::push.
@@ -603,7 +628,11 @@ class WordPressExternalConnection extends ExternalConnection {
 		if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 			$response = vip_safe_wp_remote_get(
 				untrailingslashit( $this->base_url ),
-				false, 3, 3, 10, $this->auth_handler->format_get_args()
+				false,
+				3,
+				3,
+				10,
+				$this->auth_handler->format_get_args()
 			);
 		} else {
 			$response = wp_remote_get( untrailingslashit( $this->base_url ), $this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) ) );
@@ -655,7 +684,11 @@ class WordPressExternalConnection extends ExternalConnection {
 		if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 			$types_response = vip_safe_wp_remote_get(
 				$types_path,
-				false, 3, 3, 10, $this->auth_handler->format_get_args()
+				false,
+				3,
+				3,
+				10,
+				$this->auth_handler->format_get_args()
 			);
 		} else {
 			$types_response = wp_remote_get( $types_path, $this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) ) );
@@ -693,7 +726,11 @@ class WordPressExternalConnection extends ExternalConnection {
 							if ( function_exists( 'vip_safe_wp_remote_get' ) && \Distributor\Utils\is_vip_com() ) {
 								$type_response = vip_safe_wp_remote_get(
 									$link,
-									false, 3, 3, 10, $this->auth_handler->format_get_args()
+									false,
+									3,
+									3,
+									10,
+									$this->auth_handler->format_get_args()
 								);
 							} else {
 								$type_response = wp_remote_get( $link, $this->auth_handler->format_get_args( array( 'timeout' => self::$timeout ) ) );
@@ -710,7 +747,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 						if ( in_array( 'POST', $routes[ $route ]['methods'], true ) ) {
 							$type_response = wp_remote_post(
-								$link, $this->auth_handler->format_post_args(
+								$link,
+								$this->auth_handler->format_post_args(
 									array(
 										'timeout' => self::$timeout,
 										'body'    => array( 'test' => 1 ),

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -320,10 +320,13 @@ class NetworkSiteConnection extends Connection {
 					restore_current_blog();
 
 					return apply_filters(
-						'dt_remote_get', [
+						'dt_remote_get',
+						[
 							'items'       => array(),
 							'total_items' => 0,
-						], $args, $this
+						],
+						$args,
+						$this
 					);
 				}
 
@@ -363,10 +366,13 @@ class NetworkSiteConnection extends Connection {
 			restore_current_blog();
 
 			return apply_filters(
-				'dt_remote_get', [
+				'dt_remote_get',
+				[
 					'items'       => $formatted_posts,
 					'total_items' => $posts_query->found_posts,
-				], $args, $this
+				],
+				$args,
+				$this
 			);
 
 		} else {
@@ -618,7 +624,8 @@ class NetworkSiteConnection extends Connection {
 			}
 
 			$response = wp_remote_post(
-				untrailingslashit( $base_url ) . '/wp-admin/admin-ajax.php', array(
+				untrailingslashit( $base_url ) . '/wp-admin/admin-ajax.php',
+				array(
 					'body'    => array(
 						'nonce'    => wp_create_nonce( 'dt-auth-check' ),
 						'username' => $current_user->user_login,

--- a/includes/distributed-post-ui.php
+++ b/includes/distributed-post-ui.php
@@ -14,7 +14,8 @@ namespace Distributor\DistributedPostUI;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_post_scripts_styles' );
 			add_action( 'post_submitbox_misc_actions', __NAMESPACE__ . '\distributed_to' );
 			add_action( 'in_admin_header', __NAMESPACE__ . '\add_help_tab' );

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -14,7 +14,8 @@ namespace Distributor\ExternalConnectionCPT;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'init', __NAMESPACE__ . '\setup_cpt' );
 			add_filter( 'enter_title_here', __NAMESPACE__ . '\filter_enter_title_here', 10, 2 );
 			add_filter( 'post_updated_messages', __NAMESPACE__ . '\filter_post_updated_messages' );
@@ -268,7 +269,9 @@ function admin_enqueue_scripts( $hook ) {
 		wp_enqueue_script( 'dt-admin-external-connection', plugins_url( '/dist/js/admin-external-connection.min.js', __DIR__ ), array( 'jquery', 'underscore' ), DT_VERSION, true );
 
 		wp_localize_script(
-			'dt-admin-external-connection', 'dt', array(
+			'dt-admin-external-connection',
+			'dt',
+			array(
 				'nonce'                     => wp_create_nonce( 'dt-verify-ext-conn' ),
 				'bad_connection'            => esc_html__( 'No connection found.', 'distributor' ),
 				'good_connection'           => esc_html__( 'Connection established.', 'distributor' ),

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -14,7 +14,8 @@ namespace Distributor\PullUI;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'admin_menu', __NAMESPACE__ . '\action_admin_menu' );
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\admin_enqueue_scripts' );
 			add_action( 'load-distributor_page_pull', __NAMESPACE__ . '\setup_list_table' );
@@ -205,7 +206,8 @@ function process_actions() {
 			$posts = array_map(
 				function( $remote_post_id ) {
 						return [ 'remote_post_id' => $remote_post_id ];
-				}, $posts
+				},
+				$posts
 			);
 
 			if ( 'external' === $_GET['connection_type'] ) {

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -14,7 +14,8 @@ namespace Distributor\PushUI;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_action( 'wp_ajax_dt_push', __NAMESPACE__ . '\ajax_push' );
@@ -226,7 +227,9 @@ function enqueue_scripts( $hook ) {
 	wp_enqueue_style( 'dt-push', plugins_url( '/dist/css/push.min.css', __DIR__ ), array(), DT_VERSION );
 	wp_enqueue_script( 'dt-push', plugins_url( '/dist/js/push.min.js', __DIR__ ), array( 'jquery', 'underscore', 'hoverIntent' ), DT_VERSION, true );
 	wp_localize_script(
-		'dt-push', 'dt', array(
+		'dt-push',
+		'dt',
+		array(
 			'nonce'   => wp_create_nonce( 'dt-push' ),
 			'postId'  => (int) get_the_ID(),
 			'ajaxurl' => esc_url( admin_url( 'admin-ajax.php' ) ),

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -14,7 +14,8 @@ namespace Distributor\RestApi;
  */
 function setup() {
 	add_action(
-		'init', function() {
+		'init',
+		function() {
 			add_action( 'rest_api_init', __NAMESPACE__ . '\register_endpoints' );
 
 			$post_types = get_post_types(
@@ -27,7 +28,8 @@ function setup() {
 				add_action( "rest_insert_{$post_type}", __NAMESPACE__ . '\process_distributor_attributes', 10, 3 );
 				add_filter( "rest_pre_insert_{$post_type}", __NAMESPACE__ . '\filter_distributor_content', 1, 2 );
 			}
-		}, 100
+		},
+		100
 	);
 }
 
@@ -136,7 +138,9 @@ function register_endpoints() {
 	);
 
 	register_rest_field(
-		$post_types, 'distributor_meta', array(
+		$post_types,
+		'distributor_meta',
+		array(
 			'get_callback'    => function( $post_array ) {
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
@@ -153,7 +157,9 @@ function register_endpoints() {
 	);
 
 	register_rest_field(
-		$post_types, 'distributor_terms', array(
+		$post_types,
+		'distributor_terms',
+		array(
 			'get_callback'    => function( $post_array ) {
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
@@ -170,7 +176,9 @@ function register_endpoints() {
 	);
 
 	register_rest_field(
-		$post_types, 'distributor_media', array(
+		$post_types,
+		'distributor_media',
+		array(
 			'get_callback'    => function( $post_array ) {
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
@@ -187,7 +195,9 @@ function register_endpoints() {
 	);
 
 	register_rest_field(
-		$post_types, 'distributor_original_site_name', array(
+		$post_types,
+		'distributor_original_site_name',
+		array(
 			'get_callback'    => function( $post_array ) {
 				return get_bloginfo( 'name' );
 			},
@@ -200,7 +210,9 @@ function register_endpoints() {
 	);
 
 	register_rest_field(
-		$post_types, 'distributor_original_site_url', array(
+		$post_types,
+		'distributor_original_site_url',
+		array(
 			'get_callback'    => function( $post_array ) {
 				return home_url();
 			},

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -16,7 +16,8 @@ use Distributor\Utils;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu', 20 );
 
 			if ( DT_IS_NETWORK ) {

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -16,7 +16,8 @@ use Distributor\ExternalConnection as ExternalConnection;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'init', __NAMESPACE__ . '\register_cpt' );
 			add_action( 'save_post', __NAMESPACE__ . '\send_notifications' );
 			add_action( 'before_delete_post', __NAMESPACE__ . '\delete_subscriptions' );
@@ -210,7 +211,8 @@ function delete_subscriptions( $post_id ) {
 
 			// We need to ensure any remote post is unlinked to this post
 			wp_remote_post(
-				untrailingslashit( $target_url ) . '/wp/v2/dt_subscription/receive', [
+				untrailingslashit( $target_url ) . '/wp/v2/dt_subscription/receive',
+				[
 					'timeout'  => 5,
 					'blocking' => \Distributor\Utils\is_dt_debug(),
 					'body'     => [
@@ -275,7 +277,8 @@ function send_notifications( $post_id ) {
 		}
 
 		$request = wp_remote_post(
-			untrailingslashit( $target_url ) . '/wp/v2/dt_subscription/receive', [
+			untrailingslashit( $target_url ) . '/wp/v2/dt_subscription/receive',
+			[
 				'timeout' => 5,
 				/**
 				 * Filter the arguments sent to the remote server during a subscription update.

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -14,7 +14,8 @@ namespace Distributor\SyndicatedPostUI;
  */
 function setup() {
 	add_action(
-		'plugins_loaded', function() {
+		'plugins_loaded',
+		function() {
 			add_action( 'edit_form_top', __NAMESPACE__ . '\syndicated_message', 9, 1 );
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_post_scripts' );
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_edit_scripts' );
@@ -528,7 +529,9 @@ function enqueue_gutenberg_edit_scripts() {
 	wp_enqueue_script( 'dt-gutenberg-syndicated-post', plugins_url( '/dist/js/gutenberg-syndicated-post.min.js', __DIR__ ), [ 'wp-blocks' ], DT_VERSION, true );
 	wp_enqueue_script( 'dt-gutenberg-syndicated-status-plugin', plugins_url( '/dist/js/gutenberg-status-plugin.min.js', __DIR__ ), [ 'wp-blocks', 'wp-edit-post' ], DT_VERSION, true );
 	wp_localize_script(
-		'dt-gutenberg-syndicated-post', 'dtGutenberg', [
+		'dt-gutenberg-syndicated-post',
+		'dtGutenberg',
+		[
 			'i18n'                 => gutenberg_get_jed_locale_data( 'distributor' ),
 			'originalBlogId'       => (int) $original_blog_id,
 			'originalPostId'       => (int) $original_post_id,

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -77,7 +77,8 @@ function get_network_settings() {
 function check_license_key( $email, $license_key ) {
 
 	$request = wp_remote_post(
-		'https://distributorplugin.com/wp-json/distributor-theme/v1/validate-license', [
+		'https://distributorplugin.com/wp-json/distributor-theme/v1/validate-license',
+		[
 			'timeout' => 10,
 			'body'    => [
 				'license_key' => $license_key,
@@ -357,7 +358,9 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 
 				if ( ! empty( $term_array['parent'] ) ) {
 					wp_update_term(
-						$term_id_mapping[ $term_array['term_id'] ], $taxonomy, [
+						$term_id_mapping[ $term_array['term_id'] ],
+						$taxonomy,
+						[
 							'parent' => $term_id_mapping[ $term_array['parent'] ],
 						]
 					);


### PR DESCRIPTION
Seems the most recent update to the WordPress Coding Standards caused a bunch of PHPCS errors to pop up. Most of these are spacing issues but there was one case of `Overriding WordPress globals is prohibited. Found assignment to $plugins`, which I fixed.