### PR TITLE
Fix pull post error

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -462,7 +462,7 @@ class PullListTable extends \WP_List_Table {
 
 			<div class="alignleft actions">
 				<label for="pull_post_type" class="screen-reader-text">Content to Pull</label>
-				<select id="pull_post_type" name="post_type">
+				<select id="pull_post_type" name="pull_post_type">
 					<?php foreach ( $connection_now->pull_post_types as $post_type ) : ?>
 						<option <?php selected( $connection_now->pull_post_type, $post_type['slug'] ); ?> value="<?php echo esc_attr( $post_type['slug'] ); ?>">
 							<?php echo esc_html( $post_type['name'] ); ?>


### PR DESCRIPTION
Change the name of our pull post type input from `post_type` to `pull_post_type`, so we don't cause errors when pulling a post.