### PR TITLE
Don't push updates to sites that no longer exist

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -573,7 +573,21 @@ class NetworkSiteConnection extends Connection {
 		}
 
 		foreach ( $connection_map['internal'] as $blog_id => $syndicated_post ) {
-			$connection = new self( get_site( $blog_id ) );
+			// Make sure this site is still available
+			$site = get_site( (int) $blog_id );
+			if ( null === $site ) {
+
+				// If the site isn't available anymore, remove this item from the connection map
+				if ( ! empty( $connection_map['internal'][ (int) $blog_id ] ) ) {
+					unset( $connection_map['internal'][ (int) $blog_id ] );
+
+					update_post_meta( $post_id, 'dt_connection_map', $connection_map );
+				}
+
+				continue;
+			}
+
+			$connection = new self( $site );
 
 			switch_to_blog( $blog_id );
 


### PR DESCRIPTION
When a post that has been distributed is updated, we try and push those updates upstream. For internal connections, this means we switch over to the blog that we pushed to and update the post there.

In the case where a site gets deleted after items have been distributed to it, this would result in an error when the original post was updated, as we were trying to push updates to a non-existent site. This fix checks that a site actually exists before we try and do anything with it.

In addition, if the site doesn't exist anymore, we remove that particular connection from our connection mapping, so the mapping we output is updated.

Fixes #208 