### PR TITLE
Pass CPT to WordPress External Connection

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -356,10 +356,12 @@ class WordPressExternalConnection extends ExternalConnection {
 		$created_posts = array();
 
 		foreach ( $items as $item_array ) {
-			$post = $this->remote_get( [
-				'id'        => $item_array['remote_post_id'],
-				'post_type' => $item_array['post_type'],
-			] );
+			$post = $this->remote_get(
+				[
+					'id'        => $item_array['remote_post_id'],
+					'post_type' => $item_array['post_type'],
+				]
+			);
 
 			if ( is_wp_error( $post ) ) {
 				$created_posts[] = $post;

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -356,7 +356,10 @@ class WordPressExternalConnection extends ExternalConnection {
 		$created_posts = array();
 
 		foreach ( $items as $item_array ) {
-			$post = $this->remote_get( [ 'id' => $item_array['remote_post_id'] ] );
+			$post = $this->remote_get( [
+				'id'        => $item_array['remote_post_id'],
+				'post_type' => $item_array['post_type'],
+			] );
 
 			if ( is_wp_error( $post ) ) {
 				$created_posts[] = $post;

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -201,11 +201,15 @@ function process_actions() {
 				break;
 			}
 
-			$posts = (array) $_GET['post'];
+			$posts     = (array) $_GET['post'];
+			$post_type = sanitize_text_field( $_GET['pull_post_type'] );
 
 			$posts = array_map(
-				function( $remote_post_id ) {
-						return [ 'remote_post_id' => $remote_post_id ];
+				function( $remote_post_id ) use ( $post_type ) {
+						return [
+							'remote_post_id' => $remote_post_id,
+							'post_type'      => $post_type,
+						];
 				},
 				$posts
 			);
@@ -215,6 +219,9 @@ function process_actions() {
 				$new_posts  = $connection->pull( $posts );
 
 				foreach ( $posts as $key => $post_array ) {
+					if ( is_wp_error( $new_posts[ $key ] ) ) {
+						continue;
+					}
 					\Distributor\Subscriptions\create_remote_subscription( $connection, $post_array['remote_post_id'], $new_posts[ $key ] );
 				}
 			} else {
@@ -226,6 +233,9 @@ function process_actions() {
 			$post_id_mappings = array();
 
 			foreach ( $posts as $key => $post_array ) {
+				if ( is_wp_error( $new_posts[ $key ] ) ) {
+					continue;
+				}
 				$post_id_mappings[ $post_array['remote_post_id'] ] = $new_posts[ $key ];
 			}
 

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -207,7 +207,10 @@ class WordPressExternalConnectionTest extends \TestCase {
 			is_array(
 				$this->connection->pull(
 					[
-						[ 'remote_post_id' => $post_id ],
+						[
+							'remote_post_id' => $post_id,
+							'post_type'      => 'post',
+						],
 					]
 				)
 			)


### PR DESCRIPTION
This PR resolves an issue where the post type was never getting passed to the WordPress external connection, so it tries to resolve all posts with the `/posts/[id]` endpoint regardless of type.

Additionally, the pull UI logic did not account for WP_Error objects being part of the returned `$new_posts` array.

Happy to open an issue if needed!