### PR TITLE
Provide taxonomy to dt_update_term_hierarchy filter

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -381,9 +381,10 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param bool true Controls whether term hierarchy should be updated. Default 'true'.
+		 * @param bool   true      Controls whether term hierarchy should be updated. Default 'true'.
+		 * @param string $taxonomy The taxonomy slug for the current term.
 		 */
-		$update_term_hierachy = apply_filters( 'dt_update_term_hierarchy', true );
+		$update_term_hierachy = apply_filters( 'dt_update_term_hierarchy', true, $taxonomy );
 
 		if ( ! empty( $update_term_hierachy ) ) {
 			foreach ( $terms as $term_array ) {


### PR DESCRIPTION
This data allows a developer to selectively enable/disable term hierarchy distribution based on the specific taxonomy rather than as a blanket decision for all terms.

See #219 for some more reasoning.