### PR TITLE
Make sure meta that is stored as an associative array is processed correctly

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -127,9 +127,9 @@ function set_meta( $post_id, $meta ) {
 		} else {
 			$meta_array  = (array) $meta_value;
 			$meta_values = array();
-			foreach ( $meta_array as $meta_item_value ) {
+			foreach ( $meta_array as $meta_item_key => $meta_item_value ) {
 				if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
-					$meta_values[] = maybe_unserialize( $meta_item_value );
+					$meta_values[ $meta_item_key ] = maybe_unserialize( $meta_item_value );
 				}
 			}
 			update_post_meta( $post_id, $meta_key, $meta_values );


### PR DESCRIPTION
We recently made processing of array meta data a little smarter but there was still an issue if that array was associative, as we didn't take into account the array key when processing, so we would end up setting all meta arrays as index arrays. This fix will use the keys from the array we are processing in the array we build up and save.

Fixes #197.