### PR TITLE
Fix: subscription authentication

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -141,7 +141,7 @@ class SubscriptionsController extends \WP_REST_Controller {
 		}
 
 		$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], '/' . $this->rest_base . '/receive' );
-		$request->set_body_params( wp_unslash( $_POST ) );
+		$request->set_body_params( wp_unslash( $_POST ) ); // phpcs:ignore
 
 		// If this is not a subscription request, return the original value.
 		if ( '/dt_subscription/receive' !== $request->get_route() && '/dt_subscription/delete' !== $request->get_route() ) {


### PR DESCRIPTION
* Improve auth check in subscription callback.
* Return passed value if current request isn't subscription related.
* Throw an error is the signature is unset or empty.
* Returned the passed value by default.