### PR TITLE
Fix rest invalid signature

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -140,7 +140,13 @@ class SubscriptionsController extends \WP_REST_Controller {
 			return $status;
 		}
 
-		$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], '/' . $this->rest_base . '/receive' );
+		if ( ! empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			$path = $GLOBALS['wp']->query_vars['rest_route'];
+		} else {
+			$path = $_SERVER['REQUEST_URI'];
+		}
+
+		$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], $path );
 		$request->set_body_params( wp_unslash( $_POST ) ); // phpcs:ignore
 
 		// If this is not a subscription request, return the original value.


### PR DESCRIPTION
`$request` is always being set to `/dt_subscription/receive` for all the endpoints and failing the exclude check at LN147 and returning the `rest_post_invalid_signature` error. 