### PR TITLE
Blacklist `_wp_attachment_metadata` from `set_meta()`

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -224,7 +224,25 @@ function blacklisted_meta() {
 	 *
 	 * @param array Blacklisted meta keys. Default 'dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _edit_lock, _edit_last, _wp_old_slug, _wp_old_date.
 	 */
-	return apply_filters( 'dt_blacklisted_meta', [ 'dt_unlinked', 'dt_connection_map', 'dt_subscription_update', 'dt_subscriptions', 'dt_subscription_signature', 'dt_original_post_id', 'dt_original_post_url', 'dt_original_blog_id', 'dt_syndicate_time', '_wp_attached_file', '_edit_lock', '_edit_last', '_wp_old_slug', '_wp_old_date' ] );
+	return apply_filters(
+		'dt_blacklisted_meta',
+		[
+			'dt_unlinked',
+			'dt_connection_map',
+			'dt_subscription_update',
+			'dt_subscriptions',
+			'dt_subscription_signature',
+			'dt_original_post_id',
+			'dt_original_post_url',
+			'dt_original_blog_id',
+			'dt_syndicate_time',
+			'_wp_attached_file',
+			'_edit_lock',
+			'_edit_last',
+			'_wp_old_slug',
+			'_wp_old_date',
+		]
+	);
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -222,7 +222,7 @@ function blacklisted_meta() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array Blacklisted meta keys. Default 'dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _edit_lock, _edit_last, _wp_old_slug, _wp_old_date.
+	 * @param array Blacklisted meta keys. Default 'dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _wp_attachment_metadata, _edit_lock, _edit_last, _wp_old_slug, _wp_old_date.
 	 */
 	return apply_filters(
 		'dt_blacklisted_meta',
@@ -237,6 +237,7 @@ function blacklisted_meta() {
 			'dt_original_blog_id',
 			'dt_syndicate_time',
 			'_wp_attached_file',
+			'_wp_attachment_metadata',
 			'_edit_lock',
 			'_edit_last',
 			'_wp_old_slug',


### PR DESCRIPTION
Fixes #237 