### PR TITLE
Respect comment and pingback status on pull

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -863,7 +863,7 @@ class WordPressExternalConnection extends ExternalConnection {
 
 	/**
 	 * Convert array to WP_Post object suitable for insert/update.
-	 * 
+	 *
 	 * Some field names in the REST API response object do not match DB field names.
 	 *
 	 * @see    \WP_REST_Posts_Controller::prepare_item_for_database()

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -869,7 +869,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	 * @return \WP_Post
 	 */
 	private function to_wp_post( $post ) {
-		$obj = new \stdClass();
+		$obj = (object) $post;
 
 		$obj->ID           = $post['id'];
 		$obj->post_title   = $post['title']['rendered'];
@@ -888,7 +888,6 @@ class WordPressExternalConnection extends ExternalConnection {
 		$obj->post_modified     = $post['modified'];
 		$obj->post_modified_gmt = $post['modified_gmt'];
 		$obj->post_type         = $post['type'];
-		$obj->link              = $post['link'];
 		$obj->post_author       = get_current_user_id();
 
 		/**

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -872,7 +872,7 @@ class WordPressExternalConnection extends ExternalConnection {
 	 * @return \WP_Post
 	 */
 	private function to_wp_post( $post ) {
-		$obj = (object) $post;
+		$obj = new \stdClass();
 
 		$obj->ID           = $post['id'];
 		$obj->post_title   = $post['title']['rendered'];
@@ -885,14 +885,20 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 
 		$obj->post_status       = 'draft';
-		$obj->post_password     = $post['password'];
 		$obj->post_date         = $post['date'];
 		$obj->post_date_gmt     = $post['date_gmt'];
 		$obj->guid              = $post['guid']['rendered'];
 		$obj->post_modified     = $post['modified'];
 		$obj->post_modified_gmt = $post['modified_gmt'];
 		$obj->post_type         = $post['type'];
+		$obj->link              = $post['link'];
+		$obj->comment_status    = $post['comment_status'];
+		$obj->ping_status       = $post['ping_status'];
 		$obj->post_author       = get_current_user_id();
+
+		if ( ! empty( $post['password'] ) ) {
+			$obj->post_password = $post['password'];
+		}
 
 		/**
 		 * These will only be set if Distributor is active on the other side

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -885,6 +885,9 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 
 		$obj->post_status       = 'draft';
+		$obj->post_author       = get_current_user_id();
+
+		$obj->post_password     = $post['password'];
 		$obj->post_date         = $post['date'];
 		$obj->post_date_gmt     = $post['date_gmt'];
 		$obj->guid              = $post['guid']['rendered'];
@@ -894,11 +897,6 @@ class WordPressExternalConnection extends ExternalConnection {
 		$obj->link              = $post['link'];
 		$obj->comment_status    = $post['comment_status'];
 		$obj->ping_status       = $post['ping_status'];
-		$obj->post_author       = get_current_user_id();
-
-		if ( ! empty( $post['password'] ) ) {
-			$obj->post_password = $post['password'];
-		}
 
 		/**
 		 * These will only be set if Distributor is active on the other side

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -862,8 +862,11 @@ class WordPressExternalConnection extends ExternalConnection {
 	}
 
 	/**
-	 * Convert array to WP_Post
+	 * Convert array to WP_Post object suitable for insert/update.
+	 * 
+	 * Some field names in the REST API response object do not match DB field names.
 	 *
+	 * @see    \WP_REST_Posts_Controller::prepare_item_for_database()
 	 * @param  array $post Post as array.
 	 * @since  0.8
 	 * @return \WP_Post
@@ -882,6 +885,7 @@ class WordPressExternalConnection extends ExternalConnection {
 		}
 
 		$obj->post_status       = 'draft';
+		$obj->post_password     = $post['password'];
 		$obj->post_date         = $post['date'];
 		$obj->post_date_gmt     = $post['date_gmt'];
 		$obj->guid              = $post['guid']['rendered'];

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -252,6 +252,7 @@ class WordPressExternalConnectionTest extends \TestCase {
 				[
 					'id'        => 111,
 					'post_type' => 'post',
+					'password'  => '',
 				]
 			)
 		);

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -252,7 +252,6 @@ class WordPressExternalConnectionTest extends \TestCase {
 				[
 					'id'        => 111,
 					'post_type' => 'post',
-					'password'  => '',
 				]
 			)
 		);

--- a/tests/php/includes/common.php
+++ b/tests/php/includes/common.php
@@ -195,6 +195,9 @@ function remote_get_setup() {
 					'distributor_terms' => [],
 					'distributor_media' => [],
 					$post_type          => $links,
+					'comment_status'    => 'open',
+					'ping_status'       => 'open',
+					'password'          => '',
 				]
 			),
 		]


### PR DESCRIPTION
This likely pre-emptively fixes other members of the post object that are inadvertently being dropped. Post password comes to mind.

Fixes #249 