### PR TITLE
WIP: Update Notices to latest Gutenberg Package

### DIFF
--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -14,7 +14,7 @@ if ( '0' !== dtGutenberg.originalSourceId || '0' !== dtGutenberg.originalBlogId 
 		message = wp.i18n.sprintf( wp.i18n.__( 'Distributed from %s. The original will update this unless you', 'distributor' ), dtGutenberg.originalLocationName );
 
 		actions.push( {
-			label: wp.i18n. __( 'unlink from original. ', 'distributor' ),
+			label: wp.i18n. __( 'unlink from original.', 'distributor' ),
 			url: dtGutenberg.unlinkNonceUrl
 		} );
 
@@ -30,6 +30,11 @@ if ( '0' !== dtGutenberg.originalSourceId || '0' !== dtGutenberg.originalBlogId 
 		actions.push( {
 			label: wp.i18n. __( 'restore it.', 'distributor' ),
 			url: dtGutenberg.linkNonceUrl
+		} );
+
+		actions.push( {
+			label: wp.i18n. __( 'View Original', 'distributor' ),
+			url: dtGutenberg.postUrl
 		} );
 	}
 

--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -5,70 +5,36 @@ wp.i18n.setLocaleData( dtGutenberg.i18n, 'distributor' );
 
 if ( '0' !== dtGutenberg.originalSourceId || '0' !== dtGutenberg.originalBlogId ) {
 
-	const messages = [];
+	let message = '';
+	const actions = [];
 
-	if ( parseInt( dtGutenberg.originalDeleted ) ) {
-		messages.push( wp.i18n.sprintf( wp.i18n.__( 'This %s was distributed from ' ), dtGutenberg.postTypeSingular ) );
-		messages.push( wp.element.createElement( 'a', {
-			href: dtGutenberg.postUrl,
-			key: 'original-location-link'
-		}, [
-			dtGutenberg.originalLocationName
-		] ) );
-		messages.push( wp.i18n.__( '. However, the original has been deleted.' ) );
+	if ( parseInt( dtGutenberg.originalDelete ) ) {
+		message = wp.i18n.sprintf( wp.i18n.__( 'This %1$s was distributed from %2$s. However, the original has been deleted.' ), dtGutenberg.postTypeSingular, dtGutenberg.originalLocationName );
 	} else if ( ! parseInt( dtGutenberg.unlinked ) ) {
-		messages.push( wp.i18n.__( 'Distributed from ', 'distributor' ) );
+		message = wp.i18n.sprintf( wp.i18n.__( 'Distributed from %s. The original will update this unless you', 'distributor' ), dtGutenberg.originalLocationName );
 
-		messages.push( wp.element.createElement( 'a', {
-			href: dtGutenberg.postUrl,
-			key: 'original-location-link'
-		}, [
-			dtGutenberg.originalLocationName
-		] ) );
+		actions.push( {
+			label: wp.i18n. __( 'unlink from original. ', 'distributor' ),
+			url: dtGutenberg.unlinkNonceUrl
+		} );
 
-		messages.push( '.' );
+		actions.push( {
+			label: wp.i18n.__( 'View Original', 'distributor' ),
+			url: dtGutenberg.postUrl,
+		} );
 
-		messages.push( wp.element.createElement( 'span', {
-			key: 'message-span'
-		}, [
-			wp.i18n.sprintf( wp.i18n.__( ' The original %1$s will update this version unless you ', 'distributor' ), dtGutenberg.postTypeSingular.toLowerCase() ),
-			wp.element.createElement( 'a', {
-				href: dtGutenberg.unlinkNonceUrl,
-				key: 'original-unlink'
-			}, [
-				wp.i18n.__( 'unlink from the original.', 'distributor' )
-			] )
-		] ) );
+
 	} else {
-		messages.push( wp.i18n.__( 'Originally distributed from ', 'distributor' ) );
+		message = wp.i18n.sprintf( wp.i18n.__( 'Originally distributed from %1$s. This %2$s has been unlinked from the original. However, you can always', 'distributor' ), dtGutenberg.originalLocationName, dtGutenberg.postTypeSingular );
 
-		messages.push( wp.element.createElement( 'a', {
-			href: dtGutenberg.postUrl,
-			key: 'original-location-link'
-		}, [
-			dtGutenberg.originalLocationName
-		] ) );
-
-		messages.push( '.' );
-
-		messages.push( wp.element.createElement( 'span', {
-			key: 'message-span'
-		}, [
-			wp.i18n.sprintf( wp.i18n.__( ' This %1$s has been unlinked from the original. However, you can always ', 'distributor' ), dtGutenberg.postTypeSingular.toLowerCase() ),
-			wp.element.createElement( 'a', {
-				href: dtGutenberg.linkNonceUrl,
-				key: 'original-restore-link'
-			}, [
-				wp.i18n.__( 'restore it.', 'distributor' )
-			] )
-		] ) );
+		actions.push( {
+			label: wp.i18n. __( 'restore it.', 'distributor' ),
+			url: dtGutenberg.linkNonceUrl
+		} );
 	}
 
-	const messageElement = wp.element.createElement( 'p', {
-		className: 'dt-message-wrapper'
-	}, messages );
-
-	wp.data.dispatch( 'core/editor' ).createWarningNotice( messageElement, {
-		isDismissible: false
+	wp.data.dispatch( 'core/notices' ).createWarningNotice( message, {
+		id: 'distributor-notice',
+		actions,
 	} );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,6 +1539,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "binaryextensions": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
+      "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -2598,6 +2603,11 @@
       "requires": {
         "readable-stream": "~1.1.9"
       }
+    },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -4416,6 +4426,45 @@
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
     },
+    "gulp-replace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.0.0.tgz",
+      "integrity": "sha512-lgdmrFSI1SdhNMXZQbrC75MOl1UjYWlOWNbNRnz+F/KHmgxt3l6XstBoAYIdadwETFyG/6i+vWUSCawdC3pqOw==",
+      "requires": {
+        "istextorbinary": "2.2.1",
+        "readable-stream": "^2.0.1",
+        "replacestream": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "gulp-sourcemaps": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
@@ -5040,6 +5089,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "istextorbinary": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+      "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+      "requires": {
+        "binaryextensions": "2",
+        "editions": "^1.3.3",
+        "textextensions": "2"
+      }
     },
     "js-base64": {
       "version": "2.4.3",
@@ -8480,6 +8539,50 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "requires": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "require-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.0.0.tgz",
@@ -9304,6 +9407,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "textextensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
+      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
     },
     "through": {
       "version": "2.3.8",


### PR DESCRIPTION
Brought up in #252 

This changes the way notices are generated, passing plain text strings and a series of actions, instead of creating a dynamic element and passing it to `createWarningNotice`. Most of the text remains the same in the notices, but some of  the nomenclature has to be shifted.

Here are the three states:
![screen shot 2018-11-16 at 8 27 31 am](https://user-images.githubusercontent.com/1718298/48624468-7996ad80-e97a-11e8-8bcb-8b9a40841a2f.png)

![screen shot 2018-11-16 at 8 28 03 am](https://user-images.githubusercontent.com/1718298/48624484-81eee880-e97a-11e8-9e14-2a7e0fd6416d.png)

![screen shot 2018-11-16 at 8 36 21 am](https://user-images.githubusercontent.com/1718298/48624565-b9f62b80-e97a-11e8-8f95-ce6b84368faf.png)



