### PR TITLE
Fix duplication of terms

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -404,8 +404,8 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 							$term_array['name'], 
 							$taxonomy,
 							[
-							'slug'        => $term_array['slug'],
-							'description' => $term_array['description']
+								'slug'        => $term_array['slug'],
+								'description' => $term_array['description'],
 							]
 						);
 
@@ -437,7 +437,7 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 				}
 
 				if ( empty ( $term_array['parent'] ) ) {
-					$r = wp_update_term(
+					wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,
 						[

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -400,14 +400,14 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 					continue;
 				}
 
-				$term = wp_insert_term( 
-							$term_array['name'], 
-							$taxonomy,
-							[
-								'slug'        => $term_array['slug'],
-								'description' => $term_array['description'],
-							]
-						);
+				$term = wp_insert_term(
+					$term_array['name'],
+					$taxonomy,
+					[
+						'slug'        => $term_array['slug'],
+						'description' => $term_array['description'],
+					]
+				);
 
 				if ( ! is_wp_error( $term ) ) {
 					$term_id_mapping[ $term_array['term_id'] ] = $term['term_id'];
@@ -436,7 +436,7 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 					$term_array = (array) $term_array;
 				}
 
-				if ( empty ( $term_array['parent'] ) ) {
+				if ( empty( $term_array['parent'] ) ) {
 					$term = wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,
@@ -444,7 +444,7 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 							'parent' => '',
 						]
 					);
-				} elseif ( isset ( $term_id_mapping[ $term_array['parent'] ] ) ) {
+				} elseif ( isset( $term_id_mapping[ $term_array['parent'] ] ) ) {
 					$term = wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -436,7 +436,15 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 					$term_array = (array) $term_array;
 				}
 
-				if ( ! empty( $term_array['parent'] ) ) {
+				if ( empty ( $term_array['parent'] ) ) {
+					$r = wp_update_term(
+						$term_id_mapping[ $term_array['term_id'] ],
+						$taxonomy,
+						[
+							'parent' => '',
+						]
+					);
+				} elseif ( isset ( $term_id_mapping[ $term_array['parent'] ] ) ) {
 					wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -437,7 +437,7 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 				}
 
 				if ( empty ( $term_array['parent'] ) ) {
-					wp_update_term(
+					$term = wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,
 						[
@@ -445,7 +445,7 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 						]
 					);
 				} elseif ( isset ( $term_id_mapping[ $term_array['parent'] ] ) ) {
-					wp_update_term(
+					$term = wp_update_term(
 						$term_id_mapping[ $term_array['term_id'] ],
 						$taxonomy,
 						[

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -400,7 +400,14 @@ function set_taxonomy_terms( $post_id, $taxonomy_terms ) {
 					continue;
 				}
 
-				$term = wp_insert_term( $term_array['name'], $taxonomy );
+				$term = wp_insert_term( 
+							$term_array['name'], 
+							$taxonomy,
+							[
+							'slug'        => $term_array['slug'],
+							'description' => $term_array['description']
+							]
+						);
 
 				if ( ! is_wp_error( $term ) ) {
 					$term_id_mapping[ $term_array['term_id'] ] = $term['term_id'];

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -223,6 +223,20 @@ class UtilsTest extends \TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'wp_update_term', [
+				'times'  => 1,
+				'args'   => [
+					$term_id,
+					$taxonomy,
+					[
+						'parent' => 0,
+					]
+				],
+				'return' => [ 'term_id' => $term_id ],
+			]
+		);
+
 		\WP_Mock::onFilter( 'dt_update_term_hierarchy' )
 			->with( true )
 			->reply( true );
@@ -256,11 +270,12 @@ class UtilsTest extends \TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_set_taxonomy_terms_create_term() {
-		$post_id  = 1;
-		$term_id  = 1;
-		$taxonomy = 'taxonomy';
-		$slug     = 'slug';
-		$name     = 'name';
+		$post_id     = 1;
+		$term_id     = 1;
+		$taxonomy    = 'taxonomy';
+		$slug        = 'slug';
+		$name        = 'name';
+		$description = 'description';
 
 		\WP_Mock::userFunction(
 			'taxonomy_exists', [
@@ -284,7 +299,28 @@ class UtilsTest extends \TestCase {
 		\WP_Mock::userFunction(
 			'wp_insert_term', [
 				'times'  => 1,
-				'args'   => [ $name, $taxonomy ],
+				'args'   => [
+					$name,
+					$taxonomy,
+					[
+						'slug' => $slug,
+						'description' => $description
+					]
+				],
+				'return' => [ 'term_id' => $term_id ],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_update_term', [
+				'times'  => 1,
+				'args'   => [
+					$term_id,
+					$taxonomy,
+					[
+						'parent' => 0,
+					]
+				],
 				'return' => [ 'term_id' => $term_id ],
 			]
 		);
@@ -304,10 +340,11 @@ class UtilsTest extends \TestCase {
 			$post_id, [
 				$taxonomy => [
 					[
-						'slug'    => $slug,
-						'name'    => $name,
-						'term_id' => $term_id,
-						'parent'  => 0,
+						'slug'        => $slug,
+						'name'        => $name,
+						'term_id'     => $term_id,
+						'parent'      => 0,
+						'description' => $description,
 					],
 				],
 			]


### PR DESCRIPTION
Fix duplication of terms with every update, in case if term slug is custom set in source website and term creation is not disabled/skipped with hooks in destination. #261 