### PR TITLE
Check if `gutenberg_get_jed_locale_data()` exists before use

### DIFF
--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -526,13 +526,25 @@ function enqueue_gutenberg_edit_scripts() {
 
 	$post_type_singular = $post_type_object->labels->singular_name;
 
+	if ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+		$i18n_locale = gutenberg_get_jed_locale_data( 'distributor' );
+	} else {
+		$i18n_locale = [
+			'' => [
+				'domain' => 'distributor',
+				'lang'   => get_user_locale(),
+			],
+		]; // this is a temp hacky substitute for gutenberg_get_jed_locale_data()
+	}
+
 	wp_enqueue_script( 'dt-gutenberg-syndicated-post', plugins_url( '/dist/js/gutenberg-syndicated-post.min.js', __DIR__ ), [ 'wp-blocks' ], DT_VERSION, true );
 	wp_enqueue_script( 'dt-gutenberg-syndicated-status-plugin', plugins_url( '/dist/js/gutenberg-status-plugin.min.js', __DIR__ ), [ 'wp-blocks', 'wp-edit-post' ], DT_VERSION, true );
+
 	wp_localize_script(
 		'dt-gutenberg-syndicated-post',
 		'dtGutenberg',
 		[
-			'i18n'                 => gutenberg_get_jed_locale_data( 'distributor' ),
+			'i18n'                 => $i18n_locale,
 			'originalBlogId'       => (int) $original_blog_id,
 			'originalPostId'       => (int) $original_post_id,
 			'originalSourceId'     => (int) $original_source_id,


### PR DESCRIPTION
Temporary manual alternative included. More to come later. Fixes #266 