### PR TITLE
Block Editor Fixes for 5 0

### DIFF
--- a/assets/css/gutenberg-syndicated-post.css
+++ b/assets/css/gutenberg-syndicated-post.css
@@ -35,6 +35,7 @@ body.dt-linked-post {
 	& .components-panel__body-toggle,
 	& .edit-post-post-visibility__toggle,
 	& .editor-post-trash,
+	& .editor-post-publish-button,
 	& .edit-post-post-schedule__toggle,
 	& .components-menu-item__button  {
 		opacity: 1;

--- a/distributor.php
+++ b/distributor.php
@@ -16,9 +16,10 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
+global $wp_version;
 define( 'DT_VERSION', '1.3.4-dev' );
 define( 'DT_PLUGIN_FILE', preg_replace( '#^.*plugins/(.*)$#i', '$1', __FILE__ ) );
+define( 'DT_WP_5_PLUS',  version_compare( $wp_version, '5', '>=' ) );
 
 // Define a constant if we're network activated to allow plugin to respond accordingly.
 $active_plugins = get_site_option( 'active_sitewide_plugins' );

--- a/distributor.php
+++ b/distributor.php
@@ -16,10 +16,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-global $wp_version;
+
 define( 'DT_VERSION', '1.3.5-dev' );
 define( 'DT_PLUGIN_FILE', preg_replace( '#^.*plugins/(.*)$#i', '$1', __FILE__ ) );
-define( 'DT_WP_5_PLUS',  version_compare( $wp_version, '5', '>=' ) );
 
 // Define a constant if we're network activated to allow plugin to respond accordingly.
 $active_plugins = get_site_option( 'active_sitewide_plugins' );

--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -223,7 +223,7 @@ class SubscriptionsController extends \WP_REST_Controller {
 			// When both sides of a subscription connection support Gutenberg, update with the raw content.
 			$content = $request['post_data']['content'];
 			if ( \Distributor\Utils\is_using_gutenberg() && $request['post_data']['distributor_raw_content'] ) {
-				if ( gutenberg_can_edit_post_type( $request['post_data']['post_type'] ) ) {
+				if ( \Distributor\Utils\dt_use_block_editor_for_post_type( $post->post_type ) ) {
 					$content = $request['post_data']['distributor_raw_content'];
 
 					// Remove filters that may alter content updates.

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -548,7 +548,7 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		// Gutenberg posts also distribute raw content.
 		if ( \Distributor\Utils\is_using_gutenberg() ) {
-			if ( gutenberg_can_edit_post_type( $post->post_type ) ) {
+			if ( \Distributor\Utils\dt_use_block_editor_for_post_type( $post->post_type ) ) {
 				$post_body['distributor_raw_content'] = $post->post_content;
 			}
 		}

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -457,7 +457,7 @@ class PullListTable extends \WP_List_Table {
 	public function extra_tablenav( $which ) {
 		global $connection_now;
 
-		if ( $connection_now->pull_post_types && $connection_now->pull_post_type ) :
+		if ( $connection_now && $connection_now->pull_post_types && $connection_now->pull_post_type ) :
 			?>
 
 			<div class="alignleft actions">

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -47,7 +47,7 @@ function setup() {
 function filter_distributor_content( $prepared_post, $request ) {
 
 	if ( \Distributor\Utils\is_using_gutenberg() && isset( $request['distributor_raw_content'] ) ) {
-		if ( gutenberg_can_edit_post_type( $prepared_post->post_type ) ) {
+		if ( \Distributor\Utils\dt_use_block_editor_for_post_type( $prepared_post->post_type ) ) {
 			$prepared_post->post_content = $request['distributor_raw_content'];
 		}
 	}

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -271,7 +271,7 @@ function send_notifications( $post_id ) {
 			],
 		];
 		if ( \Distributor\Utils\is_using_gutenberg() ) {
-			if ( gutenberg_can_edit_post_type( $post->post_type ) ) {
+			if ( \Distributor\Utils\dt_use_block_editor_for_post_type( $post->post_type ) ) {
 				$post_body['post_data']['distributor_raw_content'] = $post->post_content;
 			}
 		}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -25,7 +25,7 @@ function is_vip_com() {
  */
 function is_using_gutenberg() {
 	global $wp_version;
-	return ( function_exists( 'the_gutenberg_project' ) || DT_WP_5_PLUS );
+	return ( function_exists( 'the_gutenberg_project' ) || version_compare( $wp_version, '5', '>=' ) );
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -623,3 +623,39 @@ function process_media( $url, $post_id ) {
 	}
 	return (int) $result;
 }
+
+/**
+ * Return whether a post type is compatible with the block editor.
+ *
+ * The block editor depends on the REST API, and if the post type is not shown in the
+ * REST API, then it won't work with the block editor.
+ *
+ * @source WordPress 5.0.0
+ *
+ * @param string $post_type The post type.
+ * @return bool Whether the post type can be edited with the block editor.
+ */
+function dt_use_block_editor_for_post_type( $post_type ) {
+	if ( ! post_type_exists( $post_type ) ) {
+		return false;
+	}
+
+	if ( ! post_type_supports( $post_type, 'editor' ) ) {
+		return false;
+	}
+
+	$post_type_object = get_post_type_object( $post_type );
+	if ( $post_type_object && ! $post_type_object->show_in_rest ) {
+		return false;
+	}
+
+	/**
+	 * Filter whether a post is able to be edited in the block editor.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param bool   $use_block_editor  Whether the post type can be edited or not. Default true.
+	 * @param string $post_type         The post type being checked.
+	 */
+	return apply_filters( 'use_block_editor_for_post_type', true, $post_type );
+}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -25,7 +25,7 @@ function is_vip_com() {
  */
 function is_using_gutenberg() {
 	global $wp_version;
-	return ( function_exists( 'the_gutenberg_project' ) || version_compare( $wp_version, '5', '>=' )  );
+	return ( function_exists( 'the_gutenberg_project' ) || DT_WP_5_PLUS );
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -24,7 +24,8 @@ function is_vip_com() {
  * @return boolean
  */
 function is_using_gutenberg() {
-	return ( function_exists( 'the_gutenberg_project' ) );
+	global $wp_version;
+	return ( function_exists( 'the_gutenberg_project' ) || version_compare( $wp_version, '5', '>=' )  );
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/10up/distributor/issues/272

* address gutenberg checks for 5.0 + ensuring posts correctly recognized as using the block editor in 5.0 or the plugin pre 5.0
* new helper function `dt_use_block_editor_for_post_type` we can use before or after 5.0
* fix styling for the post publish button (enabling it for distributed posts)