### PR TITLE
Pass Media Meta Through `prepare_meta`

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -574,7 +574,7 @@ function format_media_post( $media_post ) {
 	$media_item['media_details'] = apply_filters( 'dt_get_media_details', wp_get_attachment_metadata( $media_post->ID ), $media_post->ID );
 	$media_item['post']          = $media_post->post_parent;
 	$media_item['source_url']    = wp_get_attachment_url( $media_post->ID );
-	$media_item['meta']          = \Distributor\Utils\prepare_meta( $post_id );
+	$media_item['meta']          = \Distributor\Utils\prepare_meta( $media_post->ID );
 
 	return apply_filters( 'dt_media_item_formatted', $media_item, $media_post->ID );
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -574,7 +574,7 @@ function format_media_post( $media_post ) {
 	$media_item['media_details'] = apply_filters( 'dt_get_media_details', wp_get_attachment_metadata( $media_post->ID ), $media_post->ID );
 	$media_item['post']          = $media_post->post_parent;
 	$media_item['source_url']    = wp_get_attachment_url( $media_post->ID );
-	$media_item['meta']          = get_post_meta( $media_post->ID );
+	$media_item['meta']          = \Distributor\Utils\prepare_meta( $post_id );
 
 	return apply_filters( 'dt_media_item_formatted', $media_item, $media_post->ID );
 }

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -421,8 +421,8 @@ class UtilsTest extends \TestCase {
 				'times'  => 1,
 				'args'   => [ $media_post->ID ],
 				'return' => [
-					'meta1' => true,
-					'meta2' => false,
+					'meta1' => [ true ],
+					'meta2' => [ false ],
 				],
 			]
 		);


### PR DESCRIPTION
When an image is created on a site, then distributed to another site, the original `_wp_attachment_metadata` is sent with the image thumbnail sizes. If the receiving site does not have the same size rules, the `srcset` attribute can cause 404ed images based on browser size.

It appears this was already [addressed here](https://github.com/10up/distributor/issues/237), however the media meta is not actually compared against the blacklist.

For anyone reading this who needs a patch now, you can add the following to your functions.php file:

```/**
 * If the _wp_attachment_metadata is set on an image, remove it. Let the receving site build its own data.
 *
 * @param array $media_item An array of media values.
 * @param int   $media_id The media ID on the originating site.
 * @return array
 */
function remove_attachment_metadata( $media_item, $media_id ) {

	if ( isset( $media_item['meta']['_wp_attachment_metadata'] ) ) {
		unset( $media_item['meta']['_wp_attachment_metadata'] );
	}
	return $media_item;
}
add_filter( 'dt_media_item_formatted', 'remove_attachment_metadata', 20, 2 );```