### PR TITLE
Add context to get_available_authorized_sites

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -656,9 +656,12 @@ class NetworkSiteConnection extends Connection {
 	 * Find out which sites user can create post type on
 	 *
 	 * @since  0.8
+	 *
+	 * @param string $context The context of the authorization.
+	 *
 	 * @return array
 	 */
-	public static function get_available_authorized_sites() {
+	public static function get_available_authorized_sites( $context = null ) {
 		if ( ! is_multisite() ) {
 			return array();
 		}
@@ -673,8 +676,9 @@ class NetworkSiteConnection extends Connection {
 		 *         'site'       => $site,  // WP_Site object.
 		 *         'post_types' => $array, // List of post type objects the user can edit.
 		 * }
+		 * @param string $context The context of the authorization.
 		 */
-		$authorized_sites = apply_filters( 'dt_pre_get_authorized_sites', array() );
+		$authorized_sites = apply_filters( 'dt_pre_get_authorized_sites', array(), $context );
 		if ( ! empty( $authorized_sites ) ) {
 			return $authorized_sites;
 		}
@@ -739,8 +743,9 @@ class NetworkSiteConnection extends Connection {
 		 *         'site'       => $site,  // WP_Site object.
 		 *         'post_types' => $array, // List of post type objects the user can edit.
 		 * }
+		 * @param string $context The context of the authorization.
 		 */
-		return apply_filters( 'dt_authorized_sites', $authorized_sites );
+		return apply_filters( 'dt_authorized_sites', $authorized_sites, $context );
 	}
 
 	/**

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -671,6 +671,7 @@ class NetworkSiteConnection extends Connection {
 		 * Allow plugins to override the default {@see \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites()} function.
 		 *
 		 * @since 1.2
+		 * @since 1.3.7 Added the `$context` parameter.
 		 *
 		 * @param array  $authorized_sites {
 		 *     @type array {
@@ -738,6 +739,7 @@ class NetworkSiteConnection extends Connection {
 		 * Allow plugins to modify the array of authorized sites.
 		 *
 		 * @since 1.2
+		 * @since 1.3.7 Added the `$context` parameter.
 		 *
 		 * @param array  $authorized_sites {
 		 *     @type array {

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -656,6 +656,7 @@ class NetworkSiteConnection extends Connection {
 	 * Find out which sites user can create post type on
 	 *
 	 * @since  0.8
+	 * @since  1.3.7 Added the `$context` parameter.
 	 *
 	 * @param string $context The context of the authorization.
 	 *

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -60,7 +60,7 @@ function setup_list_table() {
 	$connection_list_table = new \Distributor\PullListTable();
 
 	if ( ! empty( \Distributor\Connections::factory()->get_registered()['networkblog'] ) ) {
-		$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites();
+		$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites( 'pull' );
 
 		foreach ( $sites as $site_array ) {
 			$internal_connection                         = new \Distributor\InternalConnections\NetworkSiteConnection( $site_array['site'] );

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -326,7 +326,7 @@ function menu_content() {
 		}
 
 		if ( ! empty( \Distributor\Connections::factory()->get_registered()['networkblog'] ) ) {
-			$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites();
+			$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites( 'push' );
 
 			foreach ( $sites as $site_array ) {
 				if ( in_array( $post->post_type, $site_array['post_types'], true ) ) {


### PR DESCRIPTION
This PR extends the fetching of available authorized sites within a multisite network to include the context of the authorization; push or pull.

Currently, this method does not distinguish between push or pull contexts.
The proposed changes updates the method signature to accept the context as a parameter and passes it to its filters to allow for more granular control.

A simple use-case for this might be that you might want to prevent sub-sites from pushing content to the main site, but you still want to allow those sites to pull from the main site.

The added parameter is nullable for backwards compatibility. 
