### PR TITLE
Add dt_process_subscription_attributes hook to receive_item method

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -282,6 +282,16 @@ class SubscriptionsController extends \WP_REST_Controller {
 				\Distributor\Utils\set_media( $request['post_id'], $request['post_data']['distributor_media'] );
 			}
 
+			/**
+			 * Action fired after receiving a subscription update from Distributor
+			 *
+			 * @since 1.3.8
+			 *
+			 * @param WP_Post         $post    Updated post object.
+			 * @param WP_REST_Request $request Request object.
+			 */
+			do_action( 'dt_process_subscription_attributes', $post, $request );
+
 			$response = new \WP_REST_Response();
 			$response->set_data( array( 'updated' => true ) );
 


### PR DESCRIPTION
There's an existing hook called `dt_process_distributor_attributes` that you can use to handle the arguments passed to the `dt_push_post_args` filter.

There's a similar filter called `dt_subscription_post_args` for passing custom arguments when a distributed post is updated, but no hook to handle those arguments. This pull request adds a hook called `dt_process_subscription_attributes` for that purpose. 