### PR TITLE
Avoid null post excerpts causing pulls to fail

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -880,8 +880,10 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		if ( isset( $post['excerpt']['raw'] ) ) {
 			$obj->post_excerpt = $post['excerpt']['raw'];
-		} else {
+		} elseif ( isset( $post['excerpt']['rendered'] ) ) {
 			$obj->post_excerpt = $post['excerpt']['rendered'];
+		} else {
+			$obj->post_excerpt = '';
 		}
 
 		$obj->post_status       = 'draft';


### PR DESCRIPTION
Avoid a null post excerpt when syndicating a post from an external WordPress connection when the source post type doesn't support excerpts. A null post excerpt will prevent WordPress from being able
to insert the post and it fails silently.