### PR TITLE
Leverage is_dt_debug() for logging image sideload issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The plugin contains a standard test suite compatible with PHPUnit. If you want t
 
 You can define a constant `DISTRIBUTOR_DEBUG` to `true` to increase the ease of debugging in Distributor. This will make all remote requests blocking and expose the subscription post type.
 
-Enabling this will also provide needed debug information in your error log for Image side loading issues.
+Enabling this will also provide more debugging information in your error log for image side loading issues. The specific logging method may change in the future.
 
 ### Work with us
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The plugin contains a standard test suite compatible with PHPUnit. If you want t
 
 You can define a constant `DISTRIBUTOR_DEBUG` to `true` to increase the ease of debugging in Distributor. This will make all remote requests blocking and expose the subscription post type.
 
+Enabling this will also provide needed debug information in your error log for Image side loading issues.
+
 ### Work with us
 
 <a href="http://10up.com/contact/"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -651,7 +651,7 @@ function process_media( $url, $post_id ) {
 
 		// Distributor is in debug mode, display the issue, could be storage related.
 		if ( is_dt_debug() ) {
-			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) );
+			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) ); // @codingStandardsIgnoreLine
 		}
 
 		return false;
@@ -663,7 +663,7 @@ function process_media( $url, $post_id ) {
 
 		// Distributor is in debug mode, display the issue, could be storage related.
 		if ( is_dt_debug() ) {
-			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) );
+			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) ); // @codingStandardsIgnoreLine
 		}
 
 		return false;

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -651,7 +651,7 @@ function process_media( $url, $post_id ) {
 
 		// Distributor is in debug mode, display the issue, could be storage related.
 		if ( is_dt_debug() ) {
-			error_log( sprintf( "Distributor: %s", $file_array['tmp_name']->get_error_message() ) );
+			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) );
 		}
 
 		return false;
@@ -663,7 +663,7 @@ function process_media( $url, $post_id ) {
 
 		// Distributor is in debug mode, display the issue, could be storage related.
 		if ( is_dt_debug() ) {
-			error_log( sprintf( "Distributor: %s", $file_array['tmp_name']->get_error_message() ) );
+			error_log( sprintf( 'Distributor: %s', $file_array['tmp_name']->get_error_message() ) );
 		}
 
 		return false;

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -648,12 +648,24 @@ function process_media( $url, $post_id ) {
 
 	// If error storing temporarily, return the error.
 	if ( is_wp_error( $file_array['tmp_name'] ) ) {
+
+		// Distributor is in debug mode, display the issue, could be storage related.
+		if ( is_dt_debug() ) {
+			error_log( sprintf( "Distributor: %s", $file_array['tmp_name']->get_error_message() ) );
+		}
+
 		return false;
 	}
 
 	// Do the validation and storage stuff.
 	$result = media_handle_sideload( $file_array, $post_id );
 	if ( is_wp_error( $result ) ) {
+
+		// Distributor is in debug mode, display the issue, could be storage related.
+		if ( is_dt_debug() ) {
+			error_log( sprintf( "Distributor: %s", $file_array['tmp_name']->get_error_message() ) );
+		}
+
 		return false;
 	}
 	return (int) $result;


### PR DESCRIPTION
In short, the image handler doesn't bubble up to the top and say "I couldn't get this image" so posts will be processed normally, but in some edge cases, the image simply isn't processed when using an external connection.

Some scenarios include CDN issues, Firewall blocks, etc... 

This PR is really to open a conversation about this issue, in an ideal world we would give feedback to the client when distributing to an external connection, but this will at least allow developers to review their logs to see what happened.