### PR TITLE
Remove the checkbox column if on the previously pulled item screen.

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -59,6 +59,11 @@ class PullListTable extends \WP_List_Table {
 			'date' => esc_html__( 'Date', 'distributor' ),
 		];
 
+		// Remove checkbox column on the Pulled view
+		if ( isset( $_GET['status'] ) && 'pulled' === $_GET['status'] ) {
+			unset( $columns['cb'] );
+		}
+
 		return $columns;
 	}
 


### PR DESCRIPTION
This will remove the checkbox from the list screen that shows previously pulled items. Don't think this is a big deal but does fix the issue found in #204.