### PR TITLE
Fix pagination and search on pull screens

### DIFF
--- a/assets/js/admin-pull.js
+++ b/assets/js/admin-pull.js
@@ -3,6 +3,8 @@ import jQuery from 'jquery';
 const chooseConnection = document.getElementById( 'pull_connections' );
 const choosePostType = document.getElementById( 'pull_post_type' );
 const choosePostTypeBtn = document.getElementById( 'pull_post_type_submit' );
+const searchField = document.getElementById( 'post-search-input' );
+const searchBtn = document.getElementById( 'search-submit' );
 const form = document.getElementById( 'posts-filter' );
 
 jQuery( chooseConnection ).on( 'change', ( event ) => {
@@ -12,23 +14,47 @@ jQuery( chooseConnection ).on( 'change', ( event ) => {
 	document.body.className += ' ' + 'dt-loading';
 } );
 
-if ( chooseConnection && choosePostType && choosePostTypeBtn && form ) {
-	jQuery( choosePostTypeBtn ).on( 'click', ( event ) => {
+if ( chooseConnection && choosePostType && form ) {
 
-		event.preventDefault();
+	if ( choosePostTypeBtn ) {
+		jQuery( choosePostTypeBtn ).on( 'click', ( event ) => {
 
-		const postType = choosePostType.options[ choosePostType.selectedIndex ].value;
-		const url = chooseConnection.options[ chooseConnection.selectedIndex ].getAttribute( 'data-pull-url' );
-		let status = 'new';
+			event.preventDefault();
 
-		if ( -1 < ( ' ' + form.className + ' ' ).indexOf( ' status-skipped ' ) ) {
-			status = 'skipped';
-		} else if ( -1 < ( ' ' + form.className + ' ' ).indexOf( ' status-pulled ' ) ) {
-			status = 'pulled';
-		}
+			document.location = getURL();
 
-		document.location = url + '&pull_post_type=' + postType + '&status=' + status;
+			document.body.className += ' ' + 'dt-loading';
+		} );
+	}
 
-		document.body.className += ' ' + 'dt-loading';
-	} );
+	if ( searchField && searchBtn ) {
+		jQuery( searchBtn ).on( 'click', ( event ) => {
+			event.preventDefault();
+
+			const search = searchField.value;
+
+			document.location = getURL() + '&s=' + search;
+
+			document.body.className += ' ' + 'dt-loading';
+		} );
+	}
 }
+
+/**
+ * Build our Distribution URL.
+ *
+ * @return {string}
+ */
+const getURL = () => {
+	const postType = choosePostType.options[ choosePostType.selectedIndex ].value;
+	const baseURL = chooseConnection.options[ chooseConnection.selectedIndex ].getAttribute( 'data-pull-url' );
+	let status = 'new';
+
+	if ( -1 < ( ' ' + form.className + ' ' ).indexOf( ' status-skipped ' ) ) {
+		status = 'skipped';
+	} else if ( -1 < ( ' ' + form.className + ' ' ).indexOf( ' status-pulled ' ) ) {
+		status = 'pulled';
+	}
+
+	return baseURL + '&pull_post_type=' + postType + '&status=' + status;
+};

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -89,10 +89,36 @@ class PullListTable extends \WP_List_Table {
 
 		$request_uri = $_SERVER['REQUEST_URI'];
 
+		$url         = add_query_arg(
+			array(
+				'paged' => false,
+				's'     => false,
+			),
+			$request_uri
+		);
+		$new_url     = add_query_arg(
+			array(
+				'status' => 'new',
+			),
+			$url
+		);
+		$pulled_url  = add_query_arg(
+			array(
+				'status' => 'pulled',
+			),
+			$url
+		);
+		$skipped_url = add_query_arg(
+			array(
+				'status' => 'skipped',
+			),
+			$url
+		);
+
 		$status_links = [
-			'new'     => '<a href="' . esc_url( add_query_arg( array( 'status' => 'new', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'new' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'New', 'distributor' ) . '</a>',
-			'pulled'  => '<a href="' . esc_url( add_query_arg( array( 'status' => 'pulled', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'pulled' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Pulled', 'distributor' ) . '</a>',
-			'skipped' => '<a href="' . esc_url( add_query_arg( array( 'status' => 'skipped', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'skipped' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Skipped', 'distributor' ) . '</a>',
+			'new'     => '<a href="' . esc_url( $new_url ) . '" class="' . ( ( 'new' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'New', 'distributor' ) . '</a>',
+			'pulled'  => '<a href="' . esc_url( $pulled_url ) . '" class="' . ( ( 'pulled' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Pulled', 'distributor' ) . '</a>',
+			'skipped' => '<a href="' . esc_url( $skipped_url ) . '" class="' . ( ( 'skipped' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Skipped', 'distributor' ) . '</a>',
 		];
 
 		return $status_links;

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -90,9 +90,9 @@ class PullListTable extends \WP_List_Table {
 		$request_uri = $_SERVER['REQUEST_URI'];
 
 		$status_links = [
-			'new'     => '<a href="' . esc_url( $request_uri . '&status=new' ) . '" class="' . ( ( 'new' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'New', 'distributor' ) . '</a>',
-			'pulled'  => '<a href="' . esc_url( $request_uri . '&status=pulled' ) . '" class="' . ( ( 'pulled' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Pulled', 'distributor' ) . '</a>',
-			'skipped' => '<a href="' . esc_url( $request_uri . '&status=skipped' ) . '" class="' . ( ( 'skipped' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Skipped', 'distributor' ) . '</a>',
+			'new'     => '<a href="' . esc_url( add_query_arg( array( 'status' => 'new', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'new' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'New', 'distributor' ) . '</a>',
+			'pulled'  => '<a href="' . esc_url( add_query_arg( array( 'status' => 'pulled', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'pulled' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Pulled', 'distributor' ) . '</a>',
+			'skipped' => '<a href="' . esc_url( add_query_arg( array( 'status' => 'skipped', 'paged' => false, 's' => false ), $request_uri ) ) . '" class="' . ( ( 'skipped' === $current_status ) ? 'current' : '' ) . '">' . esc_html__( 'Skipped', 'distributor' ) . '</a>',
 		];
 
 		return $status_links;


### PR DESCRIPTION
On the Pull screen, if you paginate through results and then switch to a different view (New, Pulled or Skipped), the pagination number is brought over which is unexpected and can break things. This fixes that by removing unnecessary query args from the URLs we use for those views.

Also, searching on these views doesn't work as expected. If you are on the Pulled screen and you search for something, it will send you to the New screen. This fixes that with some javascript to change the destination URL when you search, so we keep the proper query args.

Fixes #273.