### PR TITLE
Resolve risky tests.

### DIFF
--- a/tests/php/ConnectionsTest.php
+++ b/tests/php/ConnectionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Distributor;
 
-class ConnectionsTest extends \TestCase {
+use WP_Mock\Tools\TestCase;
+
+class ConnectionsTest extends TestCase {
 	/**
 	 * Test connection registration
 	 *

--- a/tests/php/ExternalConnectionTest.php
+++ b/tests/php/ExternalConnectionTest.php
@@ -2,7 +2,9 @@
 
 namespace Distributor;
 
-class ExternalConnectionTest extends \TestCase {
+use WP_Mock\Tools\TestCase;
+
+class ExternalConnectionTest extends TestCase {
 
 	/**
 	 * Text External Connection instantiation failure on no type

--- a/tests/php/NetworkSiteConnectionsTest.php
+++ b/tests/php/NetworkSiteConnectionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Distributor\InternalConnections;
 
-class NetworkSiteConnectionsTest extends \TestCase {
+use WP_Mock\Tools\TestCase;
+
+class NetworkSiteConnectionsTest extends TestCase {
 
 	public function setUp() {
 		$this->site_obj = \Mockery::mock(

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -109,6 +109,7 @@ class SubscriptionsTest extends TestCase {
 
 		Subscriptions\delete_subscriptions( 1 );
 
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -165,6 +166,7 @@ class SubscriptionsTest extends TestCase {
 		// External connection comes back WP_Error and delete_subscription isn't actually called on connection
 		Subscriptions\delete_subscriptions( 1 );
 
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -196,6 +198,8 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\send_notifications( 1 );
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -361,6 +365,8 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\send_notifications( $post_id );
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -522,6 +528,8 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\send_notifications( $post_id );
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -599,6 +607,8 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\create_subscription( $post_id, $remote_post_id, $target_url, $signature );
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -681,6 +691,8 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\create_remote_subscription( $connection, $remote_post_id, $post_id );
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -718,5 +730,7 @@ class SubscriptionsTest extends TestCase {
 		);
 
 		Subscriptions\delete_subscription( $post_id, $signature );
+
+		$this->assertConditionsMet();
 	}
 }

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Distributor;
 
-class SubscriptionsTest extends \TestCase {
+use WP_Mock\Tools\TestCase;
+
+class SubscriptionsTest extends TestCase {
 
 	/**
 	 * Test delete subscribed to post

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -61,6 +61,8 @@ class UtilsTest extends TestCase {
 				'key' => [ [ 'value' ] ],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -143,6 +145,8 @@ class UtilsTest extends TestCase {
 				'key2' => [ 'value3' ],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -183,6 +187,8 @@ class UtilsTest extends TestCase {
 				'key2' => [ 'a:1:{i:0;s:4:"test";}' ],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -252,6 +258,8 @@ class UtilsTest extends TestCase {
 				],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -318,6 +326,8 @@ class UtilsTest extends TestCase {
 				],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**
@@ -360,6 +370,8 @@ class UtilsTest extends TestCase {
 				],
 			]
 		);
+
+		$this->assertConditionsMet();
 	}
 
 	/**

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -2,7 +2,9 @@
 
 namespace Distributor;
 
-class UtilsTest extends \TestCase {
+use WP_Mock\Tools\TestCase;
+
+class UtilsTest extends TestCase {
 
 	/**
 	 * Test set meta with string value and array value

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -2,8 +2,9 @@
 namespace Distributor\ExternalConnections;
 
 use \Distributor\Authentications\WordPressBasicAuth as WordPressBasicAuth;
+use WP_Mock\Tools\TestCase;
 
-class WordPressExternalConnectionTest extends \TestCase {
+class WordPressExternalConnectionTest extends TestCase {
 
 	public function setUp() {
 


### PR DESCRIPTION
This updates the unit tests to do the following:
* Extends `WP_Mock\Tools\TestCase` and not `\TestCase` to add functionality.
* Drops in the `$this->assertConditionsMet()` to the risky tests to force all Mockery conditions to be met if no assertions are present.