### PR TITLE
Improve Gutenberg detection pre GB 5.0

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -46,6 +46,15 @@ function is_using_gutenberg( $post ) {
 	if ( ! function_exists( 'use_block_editor_for_post' ) ) {
 		include_once ABSPATH . 'wp-admin/includes/post.php';
 	}
+
+	// Previous to Gutenberg 5.0, `use_block_editor_for_post` was named `gutenberg_can_edit_post`.
+	if ( ! function_exists( 'use_block_editor_for_post' ) ) {
+		if ( function_exists( 'gutenberg_can_edit_post' ) ) {
+			return gutenberg_can_edit_post( $post );
+		}
+		return false;
+	}
+
 	return use_block_editor_for_post( $post );
 }
 


### PR DESCRIPTION
Fix an issue where if you are using Gutenberg 4.9.0 and WordPress 4.9.9 you get a fatal error when going to the edit attachment screen.

* Previous to Gutenberg 5.0, `use_block_editor_for_post` was named `gutenberg_can_edit_post`

Originally reported by @ivanlopez.