### PR TITLE
Bypass check_admin_referrer() call in the use_block_editor_for_post()

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -56,8 +56,8 @@ function is_using_gutenberg( $post ) {
 	}
 
 	/**
-	 * WordPress 5.1 will do a check_admin_referrer() inside the use_block_editor_for_posts(),
-	 * and this call would fail and returns a 404 if there's custom meta box.
+	 * WordPress 5.0 will do a check_admin_referrer() inside the use_block_editor_for_posts(),
+	 * and this call would fail, returns a 404 if there's custom meta box, and kills the request.
 	 *
 	 * Unsetting the 'meta-box-loader' in the global request would bypass that check.
 	 */
@@ -76,7 +76,7 @@ function is_using_gutenberg( $post ) {
 		$_GET['meta-box-loader'] = $meta_box_loader;
 	}
 
-	return use_block_editor_for_post( $post );
+	return $use_block_editor;
 }
 
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -55,6 +55,27 @@ function is_using_gutenberg( $post ) {
 		return false;
 	}
 
+	/**
+	 * WordPress 5.1 will do a check_admin_referrer() inside the use_block_editor_for_posts(),
+	 * and this call would fail and returns a 404 if there's custom meta box.
+	 *
+	 * Unsetting the 'meta-box-loader' in the global request would bypass that check.
+	 */
+	if ( isset( $_GET['meta-box-loader'] ) ) {
+		$meta_box_loader = $_GET['meta-box-loader'];
+		unset( $_GET['meta-box-loader'] );
+	}
+
+	$use_block_editor = use_block_editor_for_post( $post );
+
+	/**
+	 * Set the $meta_box_loader back to the request, if it exists
+	 * so other areas that rely on it would still work.
+	 */
+	if ( isset( $meta_box_loader ) ) {
+		$_GET['meta-box-loader'] = $meta_box_loader;
+	}
+
 	return use_block_editor_for_post( $post );
 }
 


### PR DESCRIPTION
Since WordPress 5.0 will do a [check_admin_referrer() inside the use_block_editor_for_posts()](https://github.com/WordPress/WordPress/commit/a119d4561e10ad6c5fdd27cb3ca8c7313705b6e4), this call [would fail and kill the request](https://github.com/WordPress/WordPress/blob/5.0/wp-includes/pluggable.php#L1104) if there's any custom meta boxes in the edit screen.

Unsetting the 'meta-box-loader' in the global request would bypass that check. Then, we will restore the value once we secured the date from the use_block_editor_for_posts() API.

This fixes the [infinite saving / previewing](https://github.com/10up/distributor/issues/346) on WordPress 5.0.