### PR TITLE
Lazy load available push connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - WP_VERSION=4.7
 before_script:
   - composer install
+  - npm install
 script:
   - if [ -n "$AWS_ACCESS_KEY" ]; then ./vendor/bin/wpsnapshots configure 10up --aws_key=$AWS_ACCESS_KEY --aws_secret=$SECRET_ACCESS_KEY --user_name=Travis --user_email=travis@10up.com; fi
   - if [ -n "$AWS_ACCESS_KEY" ]; then bash run-wpacceptance.sh; fi

--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -270,7 +270,8 @@
     box-sizing: border-box;
 }
 
-#wpadminbar #distributor-push-wrapper .action-wrapper.loading .syndicate-button:after {
+#wpadminbar #distributor-push-wrapper .action-wrapper.loading .syndicate-button:after,
+#distributor-push-wrapper .loading:after {
 	content: ' ';
 	vertical-align: middle;
 	border-radius: 50%;

--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -323,7 +323,18 @@
 	-ms-flex-wrap: wrap;
 	flex-wrap: wrap;
 	overflow: hidden;
-	border-radius: 2px;
+}
+
+#distributor-push-wrapper.message-error .loader-item {
+	display: none;
+}
+
+#wpadminbar #distributor-push-wrapper .loader-messages {
+	@media (--small-screen) {
+		width: 100%;
+		float: none;
+		padding-left: 0;
+	}
 }
 
 #distributor-push-wrapper .loader-item,
@@ -342,7 +353,7 @@
 	bottom: 0;
 	left: 50%;
 	z-index: 1;
-	width: 500%;
+	width: 349%;
 	margin-left: -250%;
 	-webkit-animation: loaderAnimation 0.8s linear infinite;
 	animation: loaderAnimation 0.8s linear infinite;
@@ -369,7 +380,6 @@
 	display: flex;
 	-ms-flex-wrap: wrap;
 	flex-wrap: wrap;
-	margin-bottom: 7.5px;
 }
 
 #distributor-push-wrapper .loader-row.border {
@@ -395,8 +405,8 @@
 
 #distributor-push-wrapper .loader-col-4 {
 	-webkit-box-flex: 0;
-	-ms-flex: 0 0 40%;
-	flex: 0 0 40%;
+	-ms-flex: 0 0 30%;
+	flex: 0 0 30%;
 	padding-left: 3em;
 }
 

--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -270,8 +270,7 @@
     box-sizing: border-box;
 }
 
-#wpadminbar #distributor-push-wrapper .action-wrapper.loading .syndicate-button:after,
-#distributor-push-wrapper .loading:after {
+#wpadminbar #distributor-push-wrapper .action-wrapper.loading .syndicate-button:after {
 	content: ' ';
 	vertical-align: middle;
 	border-radius: 50%;
@@ -316,6 +315,103 @@
 	display: block;
 }
 
+#distributor-push-wrapper .loader-item {
+	position: relative;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	overflow: hidden;
+	border-radius: 2px;
+}
+
+#distributor-push-wrapper .loader-item,
+#distributor-push-wrapper .loader-item *,
+#distributor-push-wrapper .loader-item ::after,
+#distributor-push-wrapper .loader-item ::before {
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+#distributor-push-wrapper .loader-item::before {
+	content: " ";
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 50%;
+	z-index: 1;
+	width: 500%;
+	margin-left: -250%;
+	-webkit-animation: loaderAnimation 0.8s linear infinite;
+	animation: loaderAnimation 0.8s linear infinite;
+	background: -webkit-gradient(linear, left top, right top, color-stop(46%, rgba(255, 255, 255, 0)), color-stop(50%, rgba(255, 255, 255, 0.35)), color-stop(54%, rgba(255, 255, 255, 0))) 50% 50%;
+	background: linear-gradient(to right, rgba(255, 255, 255, 0) 46%, rgba(255, 255, 255, 0.35) 50%, rgba(255, 255, 255, 0) 54%) 50% 50%;
+}
+
+#distributor-push-wrapper .loader-item > * {
+	-webkit-box-flex: 1;
+	-ms-flex: 1 1 auto;
+	flex: 1 1 auto;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-flow: column;
+	flex-flow: column;
+}
+
+#distributor-push-wrapper .loader-row {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	margin-bottom: 7.5px;
+}
+
+#distributor-push-wrapper .loader-row.border {
+	border: 1px solid #555;
+}
+
+#distributor-push-wrapper .loader-row div {
+	height: 15px;
+}
+
+#distributor-push-wrapper .loader-row .big,
+#distributor-push-wrapper .loader-row.big div {
+	height: 30px;
+}
+
+#distributor-push-wrapper .loader-row .odd {
+	background-color: #23282d;
+}
+
+#distributor-push-wrapper .loader-row .bottom {
+	margin-bottom: 15px;
+}
+
+#distributor-push-wrapper .loader-col-4 {
+	-webkit-box-flex: 0;
+	-ms-flex: 0 0 40%;
+	flex: 0 0 40%;
+	padding-left: 3em;
+}
+
+#distributor-push-wrapper .loader-col-8 {
+	-webkit-box-flex: 0;
+	-ms-flex: 0 0 60%;
+	flex: 0 0 60%;
+}
+
+#distributor-push-wrapper .loader-col-12 {
+	-webkit-box-flex: 0;
+	-ms-flex: 0 0 100%;
+	flex: 0 0 100%;
+}
+
 @-webkit-keyframes load8 {
 	0% {
 		-webkit-transform: rotate(0deg);
@@ -338,3 +434,24 @@
 	}
 }
 
+@-webkit-keyframes loaderAnimation {
+	0% {
+		-webkit-transform: translate3d(-30%, 0, 0);
+		transform: translate3d(-30%, 0, 0);
+	}
+	100% {
+		-webkit-transform: translate3d(30%, 0, 0);
+		transform: translate3d(30%, 0, 0);
+	}
+}
+
+@keyframes loaderAnimation {
+	0% {
+		-webkit-transform: translate3d(-30%, 0, 0);
+		transform: translate3d(-30%, 0, 0);
+	}
+	100% {
+		-webkit-transform: translate3d(30%, 0, 0);
+		transform: translate3d(30%, 0, 0);
+	}
+}

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -53,6 +53,19 @@ jQuery( window ).on( 'load', () => {
 		actionWrapper           = distributorPushWrapper.querySelector( '.action-wrapper' );
 		postStatusInput         = document.getElementById( 'dt-post-status' );
 		asDraftInput            = document.getElementById( 'dt-as-draft' );
+
+		/**
+		 * Listen for connection filtering
+		 */
+		jQuery( connectionsSearchInput ).on( 'keyup change', _.debounce( ( event ) => {
+			if ( '' === event.currentTarget.value ) {
+				showConnections( dtConnections );
+			}
+
+			searchString = event.currentTarget.value.replace( /https?:\/\//i, '' ).replace( /www/i, '' ).replace( /[^0-9a-zA-Z ]+/, '' );
+
+			showConnections();
+		}, 300 ) );
 	}
 
 	/**
@@ -305,17 +318,4 @@ jQuery( window ).on( 'load', () => {
 
 		showConnections();
 	} );
-
-	/**
-	 * List for connection filtering
-	 */
-	jQuery( connectionsSearchInput ).on( 'keyup change', _.debounce( ( event ) => {
-		if ( '' === event.currentTarget.value ) {
-			showConnections( dtConnections );
-		}
-
-		searchString = event.currentTarget.value.replace( /https?:\/\//i, '' ).replace( /www/i, '' ).replace( /[^0-9a-zA-Z ]+/, '' );
-
-		showConnections();
-	}, 300 ) );
 } );

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -153,6 +153,7 @@ jQuery( window ).on( 'load', () => {
 			return;
 		}
 
+		distributorPushWrapper.classList.remove( 'message-error' );
 		distributorPushWrapper.classList.add( 'loaded' );
 
 		const data = {
@@ -170,7 +171,8 @@ jQuery( window ).on( 'load', () => {
 			data: data
 		} ).done( ( response ) => {
 			if ( ! response.success || ! response.data ) {
-				doError();
+				distributorPushWrapper.classList.remove( 'loaded' );
+				distributorPushWrapper.classList.add( 'message-error' );
 				return;
 			}
 
@@ -183,7 +185,7 @@ jQuery( window ).on( 'load', () => {
 			setVariables();
 		} ).error( () => {
 			distributorPushWrapper.classList.remove( 'loaded' );
-			doError();
+			distributorPushWrapper.classList.add( 'message-error' );
 		} );
 	}
 

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -34,7 +34,6 @@ jQuery( window ).on( 'load', () => {
 	let connectionsSelectedList = '';
 	let connectionsNewList      = '';
 	let connectionsSearchInput  = '';
-	let syndicateButton         = '';
 	let actionWrapper           = '';
 	let postStatusInput         = '';
 	let asDraftInput            = '';
@@ -49,7 +48,6 @@ jQuery( window ).on( 'load', () => {
 		connectionsSelectedList = distributorPushWrapper.querySelector( '.selected-connections-list' );
 		connectionsNewList      = distributorPushWrapper.querySelector( '.new-connections-list' );
 		connectionsSearchInput  = document.getElementById( 'dt-connection-search' );
-		syndicateButton         = distributorPushWrapper.querySelector( '.syndicate-button' );
 		actionWrapper           = distributorPushWrapper.querySelector( '.action-wrapper' );
 		postStatusInput         = document.getElementById( 'dt-post-status' );
 		asDraftInput            = document.getElementById( 'dt-as-draft' );
@@ -205,7 +203,7 @@ jQuery( window ).on( 'load', () => {
 	/**
 	 * Do syndication ajax
 	 */
-	jQuery( syndicateButton ).on( 'click', () => {
+	jQuery( distributorPushWrapper ).on( 'click', '.syndicate-button', () => {
 		if ( actionWrapper.classList.contains( 'loading' ) ) {
 			return;
 		}

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -169,24 +169,21 @@ jQuery( window ).on( 'load', () => {
 			method: 'post',
 			data: data
 		} ).done( ( response ) => {
-			setTimeout( () => {
-				if ( ! response.success || ! response.data ) {
-					doError();
-					return;
-				}
-
-				dtConnections = response.data;
-
-				distributorPushWrapper.innerHTML = processTemplate( 'dt-show-connections' )( {
-					connections: dtConnections,
-				} );
-
-				setVariables();
-			}, 500 );
-		} ).error( () => {
-			setTimeout( () => {
+			if ( ! response.success || ! response.data ) {
 				doError();
-			}, 500 );
+				return;
+			}
+
+			dtConnections = response.data;
+
+			distributorPushWrapper.innerHTML = processTemplate( 'dt-show-connections' )( {
+				connections: dtConnections,
+			} );
+
+			setVariables();
+		} ).error( () => {
+			distributorPushWrapper.classList.remove( 'loaded' );
+			doError();
 		} );
 	}
 

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -178,6 +178,7 @@ jQuery( window ).on( 'load', () => {
 
 			dtConnections = response.data;
 
+			// Allowing innerHTML because processTemplate escapes values
 			distributorPushWrapper.innerHTML = processTemplate( 'dt-show-connections' )( {
 				connections: dtConnections,
 			} );

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -453,15 +453,11 @@ function menu_content() {
 						<div class="new-connections-list">
 							<# for ( var key in connections ) { #>
 								<# if ( 'external' === connections[ key ]['type'] ) { #>
-									<div class="add-connection
-										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
-syndicated<# } #>" data-connection-type="external" data-connection-id="{{ connections[ key ]['id'] }}>">
-										<span>{{ connections[ key ]['title'] }}</span>
+									<div class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>" data-connection-type="external" data-connection-id="{{ connections[ key ]['id'] }}>">
+										<span>{{ connections[ key ]['name'] }}</span>
 									</div>
 								<# } else { #>
-									<div class="add-connection
-										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
-syndicated<# } #>" data-connection-type="internal" data-connection-id="{{ connections[ key ]['id'] }}">
+									<div class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>" data-connection-type="internal" data-connection-id="{{ connections[ key ]['id'] }}">
 										<span>{{ connections[ key ]['url'] }}</span>
 										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
 											<a href="{{ connections[ key ]['syndicated'] }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -453,7 +453,7 @@ function menu_content() {
 						<div class="new-connections-list">
 							<# for ( var key in connections ) { #>
 								<# if ( 'external' === connections[ key ]['type'] ) { #>
-									<div class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>" data-connection-type="external" data-connection-id="{{ connections[ key ]['id'] }}>">
+									<div class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>" data-connection-type="external" data-connection-id="{{ connections[ key ]['id'] }}">
 										<span>{{ connections[ key ]['name'] }}</span>
 									</div>
 								<# } else { #>

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -493,7 +493,7 @@ syndicated<# } #>" data-connection-type="internal" data-connection-id="{{ connec
 						 * @param object  $connection The connection being used to push.
 						 * @param WP_Post $post       The post being pushed.
 						 */
-						$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection, $post );
+						$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection = null, $post );
 						?>
 						<button class="syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
 					</div>

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -18,6 +18,7 @@ function setup() {
 		function() {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+			add_action( 'wp_ajax_dt_load_connections', __NAMESPACE__ . '\get_connections' );
 			add_action( 'wp_ajax_dt_push', __NAMESPACE__ . '\ajax_push' );
 			add_action( 'admin_bar_menu', __NAMESPACE__ . '\menu_button', 999 );
 			add_action( 'wp_footer', __NAMESPACE__ . '\menu_content', 10, 1 );
@@ -65,6 +66,126 @@ function syndicatable() {
 	}
 
 	return true;
+}
+
+/**
+ * Get available connections for use in the Push UI.
+ *
+ * @return void
+ */
+function get_connections() {
+	if ( ! check_ajax_referer( 'dt-load-connections', 'loadConnectionsNonce', false ) ) {
+		wp_send_json_error();
+		exit;
+	}
+
+	if ( empty( $_POST['postId'] ) ) {
+		wp_send_json_error();
+		exit;
+	}
+
+	$post            = get_post( intval( $_POST['postId'] ) );
+	$connection_map  = (array) get_post_meta( $post->ID, 'dt_connection_map', true );
+	$dom_connections = [];
+
+	if ( empty( $connection_map['external'] ) ) {
+		$connection_map['external'] = [];
+	}
+
+	if ( empty( $connection_map['internal'] ) ) {
+		$connection_map['internal'] = [];
+	}
+
+	if ( ! empty( \Distributor\Connections::factory()->get_registered()['networkblog'] ) ) {
+		$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites( 'push' );
+
+		foreach ( $sites as $site_array ) {
+			if ( in_array( $post->post_type, $site_array['post_types'], true ) ) {
+				$connection = new \Distributor\InternalConnections\NetworkSiteConnection( $site_array['site'] );
+
+				$syndicated = false;
+				if ( ! empty( $connection_map['internal'][ (int) $connection->site->blog_id ] ) ) {
+					switch_to_blog( $connection->site->blog_id );
+					$syndicated = get_permalink( $connection_map['internal'][ (int) $connection->site->blog_id ]['post_id'] );
+					restore_current_blog();
+
+					if ( empty( $syndicated ) ) {
+						$syndicated = true; // In case it was deleted
+					}
+				}
+
+				$dom_connections[ 'internal' . $connection->site->blog_id ] = [
+					'type'       => 'internal',
+					'id'         => $connection->site->blog_id,
+					'url'        => untrailingslashit( preg_replace( '#(https?:\/\/|www\.)#i', '', get_site_url( $connection->site->blog_id ) ) ),
+					'name'       => $connection->site->blogname,
+					'syndicated' => $syndicated,
+				];
+			}
+		}
+	}
+
+	$external_connections_query = new \WP_Query(
+		array(
+			'post_type'      => 'dt_ext_connection',
+			'posts_per_page' => 200, // @codingStandardsIgnoreLine This high pagination limit is purposeful
+			'no_found_rows'  => true,
+			'post_status'    => 'publish',
+		)
+	);
+
+	$current_post_type = get_post_type( $post );
+
+	foreach ( $external_connections_query->posts as $external_connection ) {
+		$external_connection_type = get_post_meta( $external_connection->ID, 'dt_external_connection_type', true );
+
+		if ( empty( \Distributor\Connections::factory()->get_registered()[ $external_connection_type ] ) ) {
+			continue;
+		}
+
+		$external_connection_status = get_post_meta( $external_connection->ID, 'dt_external_connections', true );
+		$allowed_roles              = get_post_meta( $external_connection->ID, 'dt_external_connection_allowed_roles', true );
+		if ( empty( $allowed_roles ) ) {
+			$allowed_roles = array( 'administrator', 'editor' );
+		}
+
+		if ( empty( $external_connection_status ) ) {
+			continue;
+		}
+
+		if ( ! empty( $external_connection_status['errors'] ) && ! empty( $external_connection_status['errors']['no_distributor'] ) ) {
+			continue;
+		}
+
+		if ( ! in_array( $current_post_type, $external_connection_status['can_post'], true ) ) {
+			continue;
+		}
+
+		// If not admin lets make sure the current user can push to this connection
+		if ( ! current_user_can( apply_filters( 'dt_push_capabilities', 'manage_options' ) ) ) {
+			$current_user_roles = (array) wp_get_current_user()->roles;
+
+			if ( count( array_intersect( $current_user_roles, $allowed_roles ) ) < 1 ) {
+				continue;
+			}
+		}
+
+		$connection = \Distributor\ExternalConnection::instantiate( $external_connection->ID );
+
+		if ( ! is_wp_error( $connection ) ) {
+			$dom_connections[ 'external' . $connection->id ] = [
+				'type'       => 'external',
+				'id'         => $connection->id,
+				'url'        => $connection->base_url,
+				'name'       => $connection->name,
+				'syndicated' => ( ! empty( $connection_map['external'][ (int) $external_connection->ID ] ) ) ? true : false,
+			];
+		}
+	}
+
+	wp_send_json_success( $dom_connections );
+
+	exit;
 }
 
 /**
@@ -234,9 +355,10 @@ function enqueue_scripts( $hook ) {
 		'dt-push',
 		'dt',
 		array(
-			'nonce'   => wp_create_nonce( 'dt-push' ),
-			'postId'  => (int) get_the_ID(),
-			'ajaxurl' => esc_url( admin_url( 'admin-ajax.php' ) ),
+			'nonce'                => wp_create_nonce( 'dt-push' ),
+			'loadConnectionsNonce' => wp_create_nonce( 'dt-load-connections' ),
+			'postId'               => (int) get_the_ID(),
+			'ajaxurl'              => esc_url( admin_url( 'admin-ajax.php' ) ),
 
 			/**
 			 * Filter whether front end ajax requests should use xhrFields credentials:true.
@@ -249,7 +371,7 @@ function enqueue_scripts( $hook ) {
 			 *
 			 * @param bool false Whether front end ajax requests should use xhrFields credentials:true.
 			 */
-			'usexhr'  => apply_filters( 'dt_ajax_requires_with_credentials', false ),
+			'usexhr'               => apply_filters( 'dt_ajax_requires_with_credentials', false ),
 		)
 	);
 }
@@ -314,116 +436,84 @@ function menu_content() {
 		</div>
 		<?php
 	} else {
-		$connection_map = (array) get_post_meta( $post->ID, 'dt_connection_map', true );
-
-		$dom_connections = [];
-
-		if ( empty( $connection_map['external'] ) ) {
-			$connection_map['external'] = [];
-		}
-
-		if ( empty( $connection_map['internal'] ) ) {
-			$connection_map['internal'] = [];
-		}
-
-		if ( ! empty( \Distributor\Connections::factory()->get_registered()['networkblog'] ) ) {
-			$sites = \Distributor\InternalConnections\NetworkSiteConnection::get_available_authorized_sites( 'push' );
-
-			foreach ( $sites as $site_array ) {
-				if ( in_array( $post->post_type, $site_array['post_types'], true ) ) {
-					$connection = new \Distributor\InternalConnections\NetworkSiteConnection( $site_array['site'] );
-
-					$syndicated = false;
-					if ( ! empty( $connection_map['internal'][ (int) $connection->site->blog_id ] ) ) {
-						switch_to_blog( $connection->site->blog_id );
-						$syndicated = get_permalink( $connection_map['internal'][ (int) $connection->site->blog_id ]['post_id'] );
-						restore_current_blog();
-
-						if ( empty( $syndicated ) ) {
-							$syndicated = true; // In case it was deleted
-						}
-					}
-
-					$dom_connections[ 'internal' . $connection->site->blog_id ] = [
-						'type'       => 'internal',
-						'id'         => $connection->site->blog_id,
-						'url'        => untrailingslashit( preg_replace( '#(https?:\/\/|www\.)#i', '', get_site_url( $connection->site->blog_id ) ) ),
-						'name'       => $connection->site->blogname,
-						'syndicated' => $syndicated,
-					];
-				}
-			}
-		}
-
-		$external_connections_query = new \WP_Query(
-			array(
-				'post_type'      => 'dt_ext_connection',
-				'posts_per_page' => 200, // @codingStandardsIgnoreLine This high pagination limit is purposeful
-				'no_found_rows'  => true,
-				'post_status'    => 'publish',
-			)
-		);
-
-		$current_post_type = get_post_type();
-
-		if ( ! empty( $_GET['post_type'] ) ) { // @codingStandardsIgnoreLine nonce not required
-			$current_post_type = sanitize_key( $_GET['post_type'] );
-		}
-
-		if ( empty( $current_post_type ) ) {
-			// Serious problem
-			return;
-		}
-
-		foreach ( $external_connections_query->posts as $external_connection ) {
-			$external_connection_type = get_post_meta( $external_connection->ID, 'dt_external_connection_type', true );
-
-			if ( empty( \Distributor\Connections::factory()->get_registered()[ $external_connection_type ] ) ) {
-				continue;
-			}
-
-			$external_connection_status = get_post_meta( $external_connection->ID, 'dt_external_connections', true );
-			$allowed_roles              = get_post_meta( $external_connection->ID, 'dt_external_connection_allowed_roles', true );
-			if ( empty( $allowed_roles ) ) {
-				$allowed_roles = array( 'administrator', 'editor' );
-			}
-
-			if ( empty( $external_connection_status ) ) {
-				continue;
-			}
-
-			if ( ! empty( $external_connection_status['errors'] ) && ! empty( $external_connection_status['errors']['no_distributor'] ) ) {
-				continue;
-			}
-
-			if ( ! in_array( $current_post_type, $external_connection_status['can_post'], true ) ) {
-				continue;
-			}
-
-			// If not admin lets make sure the current user can push to this connection
-			if ( ! current_user_can( apply_filters( 'dt_push_capabilities', 'manage_options' ) ) ) {
-				$current_user_roles = (array) wp_get_current_user()->roles;
-
-				if ( count( array_intersect( $current_user_roles, $allowed_roles ) ) < 1 ) {
-					continue;
-				}
-			}
-
-			$connection = \Distributor\ExternalConnection::instantiate( $external_connection->ID );
-
-			if ( ! is_wp_error( $connection ) ) {
-				$dom_connections[ 'external' . $connection->id ] = [
-					'type'       => 'external',
-					'id'         => $connection->id,
-					'url'        => $connection->base_url,
-					'name'       => $connection->name,
-					'syndicated' => ( ! empty( $connection_map['external'][ (int) $external_connection->ID ] ) ) ? true : false,
-				];
-			}
-		}
 		?>
-		<script type="text/javascript">
-		var dtConnections = <?php echo wp_json_encode( $dom_connections ); ?>;
+
+		<script id="dt-show-connections" type="text/html">
+			<div class="inner">
+			<# if ( ! _.isEmpty( connections ) ) { #>
+				<?php /* translators: %s the post title */ ?>
+				<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), esc_html( get_the_title( $post->ID ) ) ); ?></p>
+
+				<div class="connections-selector">
+					<div>
+						<# if ( 5 < _.keys( connections ).length ) { #>
+							<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
+						<# } #>
+
+						<div class="new-connections-list">
+							<# for ( var key in connections ) { #>
+								<# if ( 'external' === connections[ key ]['type'] ) { #>
+									<div class="add-connection
+										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
+syndicated<# } #>" data-connection-type="external" data-connection-id="{{ connections[ key ]['id'] }}>">
+										<span>{{ connections[ key ]['title'] }}</span>
+									</div>
+								<# } else { #>
+									<div class="add-connection
+										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
+syndicated<# } #>" data-connection-type="internal" data-connection-id="{{ connections[ key ]['id'] }}">
+										<span>{{ connections[ key ]['url'] }}</span>
+										<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #>
+											<a href="{{ connections[ key ]['syndicated'] }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+										<# } #>
+									</div>
+								<# } #>
+							<# } #>
+						</div>
+					</div>
+				</div>
+				<div class="connections-selected empty">
+					<header class="with-selected">
+						<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
+					</header>
+					<header class="no-selected">
+						<?php esc_html_e( 'No connections selected', 'distributor' ); ?>
+					</header>
+
+					<div class="selected-connections-list"></div>
+
+					<div class="action-wrapper">
+						<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
+						<?php
+						$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
+						/**
+						 * Filter whether the 'As Draft' option appears in the push ui.
+						 *
+						 * @param bool    $as_draft   Whether the 'As Draft' option should appear.
+						 * @param object  $connection The connection being used to push.
+						 * @param WP_Post $post       The post being pushed.
+						 */
+						$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection, $post );
+						?>
+						<button class="syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
+					</div>
+				</div>
+
+				<div class="messages">
+					<div class="dt-success">
+						<?php esc_html_e( 'Post successfully distributed.', 'distributor' ); ?>
+					</div>
+					<div class="dt-error">
+						<?php esc_html_e( 'There was an issue distributing the post.', 'distributor' ); ?>
+					</div>
+				</div>
+
+			<# } else { #>
+				<p class="no-connections-notice">
+					<?php esc_html_e( 'No connections available for distribution.', 'distributor' ); ?>
+				</p>
+			<# } #>
+			</div>
 		</script>
 
 		<script id="dt-add-connection" type="text/html">
@@ -441,83 +531,9 @@ function menu_content() {
 		</script>
 
 		<div id="distributor-push-wrapper">
-			<div class="inner">
-
-				<?php if ( ! empty( $dom_connections ) ) : ?>
-					<?php /* translators: %s the post title */ ?>
-					<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), esc_html( get_the_title( $post->ID ) ) ); ?></p>
-
-					<div class="connections-selector">
-						<div>
-							<?php if ( 5 < count( $dom_connections ) ) : ?>
-								<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
-							<?php endif; ?>
-
-							<div class="new-connections-list">
-								<?php foreach ( $dom_connections as $connection ) : ?>
-									<?php if ( 'external' === $connection['type'] ) : ?>
-										<div class="add-connection
-										<?php
-										if ( ! empty( $connection['syndicated'] ) ) :
-											?>
-syndicated<?php endif; ?>" data-connection-type="external" data-connection-id="<?php echo (int) $connection['id']; ?>">
-											<span><?php echo wp_kses_post( get_the_title( $connection['id'] ) ); ?></span>
-										</div>
-									<?php else : ?>
-										<div class="add-connection
-										<?php
-										if ( ! empty( $connection['syndicated'] ) ) :
-											?>
-syndicated<?php endif; ?>" data-connection-type="internal" data-connection-id="<?php echo (int) $connection['id']; ?>">
-											<span><?php echo esc_html( $connection['url'] ); ?></span>
-											<?php if ( ! empty( $connection['syndicated'] ) ) : ?>
-												<a href="<?php echo esc_url( $connection['syndicated'] ); ?>"><?php esc_html_e( 'View', 'distributor' ); ?></a>
-											<?php endif; ?>
-										</div>
-									<?php endif; ?>
-								<?php endforeach; ?>
-							</div>
-						</div>
-					</div>
-					<div class="connections-selected empty">
-						<header class="with-selected"><?php esc_html_e( 'Selected connections', 'distributor' ); ?></header>
-						<header class="no-selected"><?php esc_html_e( 'No connections selected', 'distributor' ); ?></header>
-
-						<div class="selected-connections-list"></div>
-
-						<div class="action-wrapper">
-							<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
-							<?php
-								$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
-								/**
-								 * Filter whether the 'As Draft' option appears in the push ui.
-								 *
-								 * @param bool    $as_draft   Whether the 'As Draft' option should appear.
-								 * @param object  $connection The connection being used to push.
-								 * @param WP_Post $post       The post being pushed.
-								 */
-								$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection, $post );
-							?>
-							<button class="syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
-						</div>
-					</div>
-
-					<div class="messages">
-						<div class="dt-success">
-							<?php esc_html_e( 'Post successfully distributed.', 'distributor' ); ?>
-						</div>
-						<div class="dt-error">
-							<?php esc_html_e( 'There was an issue distributing the post.', 'distributor' ); ?>
-						</div>
-					</div>
-
-				<?php else : ?>
-					<p class="no-connections-notice">
-						<?php esc_html_e( 'No connections available for distribution.', 'distributor' ); ?>
-					</p>
-				<?php endif; ?>
-			</div>
+			<span class="loading"></span>
 		</div>
+
 		<?php
 	}
 }

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -522,8 +522,23 @@ function menu_content() {
 			</div>
 		</script>
 
-		<div id="distributor-push-wrapper">
-			<span class="loading"></span>
+		<div id="distributor-push-wrapper" class="loaded">
+			<div class="inner">
+				<div class="loader-item">
+					<div class="loader-col-8">
+						<div class="loader-row border">
+							<div class="loader-col-12 big odd"></div>
+							<div class="loader-col-12 big"></div>
+						</div>
+					</div>
+					<div class="loader-col-4">
+						<div class="loader-row">
+							<div class="loader-col-12 odd bottom"></div>
+							<div class="loader-col-12 big odd"></div>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<?php

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -76,12 +76,10 @@ function syndicatable() {
 function get_connections() {
 	if ( ! check_ajax_referer( 'dt-load-connections', 'loadConnectionsNonce', false ) ) {
 		wp_send_json_error();
-		exit;
 	}
 
 	if ( empty( $_POST['postId'] ) ) {
 		wp_send_json_error();
-		exit;
 	}
 
 	$post            = get_post( intval( $_POST['postId'] ) );
@@ -184,8 +182,6 @@ function get_connections() {
 	}
 
 	wp_send_json_success( $dom_connections );
-
-	exit;
 }
 
 /**

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -522,7 +522,7 @@ function menu_content() {
 			</div>
 		</script>
 
-		<div id="distributor-push-wrapper" class="loaded">
+		<div id="distributor-push-wrapper">
 			<div class="inner">
 				<div class="loader-item">
 					<div class="loader-col-8">
@@ -536,6 +536,11 @@ function menu_content() {
 							<div class="loader-col-12 odd bottom"></div>
 							<div class="loader-col-12 big odd"></div>
 						</div>
+					</div>
+				</div>
+				<div class="loader-messages messages">
+					<div class="dt-error">
+						<?php esc_html_e( 'There was an issue loading connections.', 'distributor' ); ?>
 					</div>
 				</div>
 			</div>

--- a/tests/wpacceptance/PushMenuTest.php
+++ b/tests/wpacceptance/PushMenuTest.php
@@ -25,7 +25,9 @@ class PushMenuTest extends \TestCase {
 
 		$I->click( '#wp-admin-bar-distributor a' );
 
-		$I->seeElement( '#distributor-push-wrapper .new-connections-list' );
+		$I->waitUntilElementVisible( '#distributor-push-wrapper .new-connections-list' );
+
+		$I->seeElement( '#distributor-push-wrapper .add-connection' );
 	}
 
 	/**


### PR DESCRIPTION
When on a screen that allows you to push content (currently when editing a supported post type or viewing that post on the front-end and being logged in) when the page loads, we grab all available connections to build out our Push UI.

If you're not going to actually push content, this ends up slowing down the page load unnecessarily. This PR attempts to fix this by not loading any of this connection information on page load but loading it only when a user goes to push (i.e. hovers over the Distributor button in the admin bar). This action triggers an ajax request that hits a new endpoint that builds this connection information. This builds out connection information the same way it does now, just happens on an ajax request and not on initial page load.

We then take the same HTML output we use currently and put that into a javascript template. Once our ajax request finishes, we take that template, combine it with the data we received and output that in our Distributor dropdown.

This is the second part of the performance fixes mentioned in #326. The changes here should also be combined with the changes in #355, as that PR provides the best performance improvement (and without those changes, for sites with lots of internal connections, the ajax request will probably fail due to timeouts).

I'm open to suggestions here as far as the interface we show when the data is being loaded. Currently I'm using the same spinner we show when items are being distributed, but it is kind of small and might need to at least be bigger, if not something different all together.