### PR TITLE
WP 5.2 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distributor [![Build Status](https://travis-ci.org/10up/distributor.svg?branch=master)](https://travis-ci.org/10up/distributor)
+# Distributor [![Build Status](https://travis-ci.org/10up/distributor.svg?branch=master)](https://travis-ci.org/10up/distributor) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.2%20tested-success.svg)
 ### [Download Latest Stable Version](https://github.com/10up/distributor/archive/stable.zip)
 <img alt="distributor icon" src="https://github.com/10up/distributor/blob/master/assets/img/icon.svg" height="45" width="45" align="left"> Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web.
 


### PR DESCRIPTION
@adamsilverstein tested and confirmed Distributor with 5.2 RC and everything worked as expected, so adding a badge to note the WP version we're tested up to.