### PR TITLE
Make menu content extendable

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -510,6 +510,15 @@ syndicated<?php endif; ?>" data-connection-type="internal" data-connection-id="<
 							<?php esc_html_e( 'There was an issue distributing the post.', 'distributor' ); ?>
 						</div>
 					</div>
+					<?php
+					/**
+					 * Add neccessary markup/actions in menu content
+					 *
+					 * @param int $post->ID Post ID.
+					 * @param array Connection map.
+					 */
+					do_action( 'dt_add_to_menu_content', $post->ID, $connection_map );
+					?>
 
 				<?php else : ?>
 					<p class="no-connections-notice">


### PR DESCRIPTION
Add `do_action( 'dt_add_to_menu_content', $post->ID, $connection_map )` hook to the `menu_content()` function (closes #385 ).