### PR TITLE
Apply filter to modify connection cpt arguments

### DIFF
--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -646,6 +646,13 @@ function setup_cpt() {
 		'register_meta_box_cb' => __NAMESPACE__ . '\add_meta_boxes',
 	);
 
+	/**
+	 * Filter to alter `dt_ext_connection` post type arguments
+	 *
+	 * @param array $args
+	 */
+	$args = apply_filters( 'dt_before_setup_cpt', $args );
+
 	register_post_type( 'dt_ext_connection', $args );
 }
 


### PR DESCRIPTION
Added `dt_before_setup_cpt` filter to make possible to modify `dt_ext_connection` custom post type arguments (closes #394).