### PR TITLE
Define $local_post_types before the conditional to prevent PHP notice

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -235,6 +235,7 @@ function set_meta( $post_id, $meta ) {
  */
 function available_pull_post_types( $connection, $type ) {
 	$post_types        = array();
+	$local_post_types  = array();
 	$remote_post_types = $connection->get_post_types();
 
 	if ( ! empty( $remote_post_types ) && ! is_wp_error( $remote_post_types ) ) {


### PR DESCRIPTION
### Description of the Change
Define $local_post_types before the conditional to prevent PHP notice

### Benefits
No PHP notice if `$remote_post_types` is empty or return a WP Error.

### Possible Drawbacks
None

### Verification Process
Tested it locally by accessing the Pull Content page and not seeing any PHP notice.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
https://github.com/10up/distributor/issues/400
<!-- Enter any applicable Issues here -->
