### PR TITLE
get post from original id

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -786,3 +786,14 @@ function get_processed_content( $post_content ) {
 
 	return $post_content;
 }
+
+/**
+ * Get post in destination using original post id
+ *
+ * @param int $original_id Original post id.
+ * @return null|int
+ */
+function get_post_from_original_id( $original_id ) {
+	global $wpdb;
+	return $wpdb->get_var( "SELECT post_id from $wpdb->postmeta WHERE meta_key = 'dt_original_post_id' AND meta_value = '$original_id'" ); //phpcs:ignore
+}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -795,5 +795,5 @@ function get_processed_content( $post_content ) {
  */
 function get_post_from_original_id( $original_id ) {
 	global $wpdb;
-	return $wpdb->get_var( "SELECT post_id from $wpdb->postmeta WHERE meta_key = 'dt_original_post_id' AND meta_value = '$original_id'" ); //phpcs:ignore
+	return $wpdb->get_var( $wpdb->prepare( "SELECT post_id from $wpdb->postmeta WHERE meta_key = 'dt_original_post_id' AND meta_value = %s", $original_id ) );
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -793,7 +793,7 @@ function get_processed_content( $post_content ) {
  * @param int $original_id Original post id.
  * @return null|int
  */
-function get_post_from_original_id( $original_id ) {
+function get_post_id_from_original_id( $original_id ) {
 	global $wpdb;
 	return $wpdb->get_var( $wpdb->prepare( "SELECT post_id from $wpdb->postmeta WHERE meta_key = 'dt_original_post_id' AND meta_value = %s", $original_id ) );
 }


### PR DESCRIPTION
Added function to get posts using original post id stored in `postmeta` table. closes #410.