### PR TITLE
add canonical URL distributing caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ __Distributing Authors__ - By default, distributed stories reference the origina
 
 __Distributing Post Date__ - By default, the "post date" on distributed stories is the date its published on the remote site, not the date published on the origin site.  This can be overridden by extending Distributor with custom code to make it preserve the post date.
 
+__Distributing Canonical URL__ - By default, canonical URL of distributed post will point to original content, which corresponds to SEO best practices. This can be overridden by extending Distributor with custom code and removing Distributor's default front end canonical URL filtering (look for `'get_canonical_url'` and `'wpseo_canonical'`).
+
 __Drafts as preferred Status__ - By default, drafts are the preferred status and can't be changed at the source site.
 
 ## Changelog


### PR DESCRIPTION
Related to https://github.com/10up/distributor/issues/321

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Distributor plugin is modifying canonical URL of distributed post and pointing to original website. In some situations, for example when original post is in password-protected area, this behavior is unexpected. 

### Alternate Designs

I suggested to add an option in admin or hook, but @adamsilverstein suggests just remove applied filters and add a section in docs.

### Benefits

Better documentation? 

### Possible Drawbacks

I don't see any

### Verification Process

Ask colleagues to read the change. It's easy to understand.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
None
