### PR TITLE
Typo in variable name

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -123,7 +123,7 @@ class NetworkSiteConnection extends Connection {
 			update_post_meta( $new_post_id, 'dt_original_post_url', esc_url_raw( $original_post_url ) );
 
 			if ( ! empty( $post->post_parent ) ) {
-				update_post_meta( $new_post, 'dt_original_post_parent', (int) $post->post_parent );
+				update_post_meta( $new_post_id, 'dt_original_post_parent', (int) $post->post_parent );
 			}
 
 			\Distributor\Utils\set_meta( $new_post_id, $meta );
@@ -222,7 +222,7 @@ class NetworkSiteConnection extends Connection {
 				update_post_meta( $new_post_id, 'dt_original_post_url', esc_url_raw( $post->link ) );
 
 				if ( ! empty( $post->post_parent ) ) {
-					update_post_meta( $new_post, 'dt_original_post_parent', (int) $post->post_parent );
+					update_post_meta( $new_post_id, 'dt_original_post_parent', (int) $post->post_parent );
 				}
 
 				\Distributor\Utils\set_meta( $new_post_id, $post->meta );


### PR DESCRIPTION
Undefined variable "new_post" should be "new_post_id".

### Description of the Change

Variable throws a PHP notice as undefined. This change just renames it as needed.