### PR TITLE
Fix and simplify `is_using_gutenberg()`

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -34,6 +34,9 @@ function is_vip_com() {
  * @return boolean
  */
 function is_using_gutenberg( $post ) {
+	if ( empty ( $post->post_content ) ) {
+		return false;
+	}
 
 	global $wp_version;
 	$gutenberg_available = function_exists( 'the_gutenberg_project' );
@@ -44,45 +47,14 @@ function is_using_gutenberg( $post ) {
 	}
 
 	// WordPress 5.0 introduces the has_blocks function.
+	// We pass `post_content` directly because `has_blocks()`
+	// tries to retrieve a local post object, but this may be a remote post.
 	if ( function_exists( 'has_blocks' ) ) {
-		return has_blocks( $post );
+		return has_blocks( $post->post_content );
+	} else {
+		// This duplicates the check from `has_blocks()` as of WP 5.2.
+		return false !== strpos( (string) $post->post_content, '<!-- wp:' );
 	}
-
-	// We have to use the function here instead of the filter due to differences in the way certain plugins implement this.
-	if ( ! function_exists( 'use_block_editor_for_post' ) ) {
-		include_once ABSPATH . 'wp-admin/includes/post.php';
-	}
-
-	// Previous to Gutenberg 5.0, `use_block_editor_for_post` was named `gutenberg_can_edit_post`.
-	if ( ! function_exists( 'use_block_editor_for_post' ) ) {
-		if ( function_exists( 'gutenberg_can_edit_post' ) ) {
-			return gutenberg_can_edit_post( $post );
-		}
-		return false;
-	}
-
-	/**
-	 * WordPress 5.0 will do a check_admin_referrer() inside the use_block_editor_for_posts(),
-	 * and this call would fail, returns a 404 if there's custom meta box, and kills the request.
-	 *
-	 * Unsetting the 'meta-box-loader' in the global request would bypass that check.
-	 */
-	if ( isset( $_GET['meta-box-loader'] ) ) {
-		$meta_box_loader = $_GET['meta-box-loader'];
-		unset( $_GET['meta-box-loader'] );
-	}
-
-	$use_block_editor = use_block_editor_for_post( $post );
-
-	/**
-	 * Set the $meta_box_loader back to the request, if it exists
-	 * so other areas that rely on it would still work.
-	 */
-	if ( isset( $meta_box_loader ) ) {
-		$_GET['meta-box-loader'] = $meta_box_loader;
-	}
-
-	return $use_block_editor;
 }
 
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -34,7 +34,7 @@ function is_vip_com() {
  * @return boolean
  */
 function is_using_gutenberg( $post ) {
-	if ( empty ( $post->post_content ) ) {
+	if ( empty( $post->post_content ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
### Description of the Change

`has_blocks()` does a `get_post()` if you don't pass a string, which doesn't work for external posts (which presumably is what you're pulling). Better to pass a string.

Also simplifies the rest of the function down to just reproducing the check from `has_blocks()` if you're not in WP 5.0+.

### Alternate Designs

Considered leaving the rest of the function alone but thought it best to just do it all at once.

### Benefits

Far simplified codebase, no more fatal error, no more false positives.

### Possible Drawbacks

Not seeing any.

### Verification Process

Testing pulling and pushing posts written using block editor, both in network and external connections.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Don't have a companion issue open but you can see here http://s.hyhs.me/7bfef432f30c
