### PR TITLE
Make pull list table views include/exclude more performant

### DIFF
--- a/assets/css/admin-pull-table.css
+++ b/assets/css/admin-pull-table.css
@@ -11,6 +11,10 @@
 	}
 }
 
+.wp-list-table .disabled {
+	opacity: 0.7;
+}
+
 .status-sync .check-column {
 	display: none;
 }

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -404,6 +404,8 @@ class PullListTable extends \WP_List_Table {
 			rsort( $skipped, SORT_NUMERIC );
 			rsort( $syndicated, SORT_NUMERIC );
 
+			// This is somewhat arbitrarily set to 200 and should probably be made filterable eventually.
+			// IDs can get rather large and 400 easily exceeds typical header size limits.
 			$post_ids = array_slice( array_merge( $skipped, $syndicated ), 0, 200, true );
 
 			$remote_get_args['post__not_in'] = $post_ids;

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -412,7 +412,7 @@ class PullListTable extends \WP_List_Table {
 		}
 
 		if ( empty( $_GET['status'] ) || 'new' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
-			$remote_get_args['post__not_in'] = array_merge( $skipped, $syndicated );
+			$remote_get_args['post__not_in'] = array_slice( array_merge( $skipped, $syndicated ), 0, 200, true );
 
 			$remote_get_args['meta_query'] = [
 				[
@@ -421,9 +421,9 @@ class PullListTable extends \WP_List_Table {
 				],
 			];
 		} elseif ( 'skipped' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
-			$remote_get_args['post__in'] = $skipped;
+			$remote_get_args['post__in'] = array_slice( $skipped, 0, 200, true );
 		} else {
-			$remote_get_args['post__in'] = $syndicated;
+			$remote_get_args['post__in'] = array_slice( $syndicated, 0, 200, true );
 		}
 
 		$remote_get = $connection_now->remote_get( $remote_get_args );

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -68,21 +68,6 @@ class PullListTable extends \WP_List_Table {
 	}
 
 	/**
-	 * Get sortable table columns
-	 *
-	 * @since  0.8
-	 * @return array
-	 */
-	public function get_sortable_columns() {
-		$sortable_columns = array(
-			'name' => 'name',
-			'date' => array( 'date', true ),
-		);
-
-		return $sortable_columns;
-	}
-
-	/**
 	 * Get table views
 	 *
 	 * @since  0.8
@@ -361,7 +346,7 @@ class PullListTable extends \WP_List_Table {
 
 		$columns  = $this->get_columns();
 		$hidden   = get_hidden_columns( $this->screen );
-		$sortable = $this->get_sortable_columns();
+		$sortable = [];
 
 		$data = $this->table_data();
 
@@ -378,6 +363,8 @@ class PullListTable extends \WP_List_Table {
 			'posts_per_page' => $per_page,
 			'paged'          => $current_page,
 			'post_type'      => $connection_now->pull_post_type ?: 'post',
+			'orderby'       => 'ID', // this is because of include/exclude truncation
+			'order'          => 'DESC', // default but specifying to be safe
 		];
 
 		if ( ! empty( $_GET['s'] ) ) { // @codingStandardsIgnoreLine Nonce isn't required.

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -60,7 +60,7 @@ class PullListTable extends \WP_List_Table {
 		];
 
 		// Remove checkbox column on the Pulled view
-		if ( isset( $_GET['status'] ) && 'pulled' === $_GET['status'] ) {
+		if ( isset( $_GET['status'] ) && 'pulled' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not needed.
 			unset( $columns['cb'] );
 		}
 
@@ -389,7 +389,7 @@ class PullListTable extends \WP_List_Table {
 			'posts_per_page' => $per_page,
 			'paged'          => $current_page,
 			'post_type'      => $connection_now->pull_post_type ?: 'post',
-			'orderby'       => 'ID', // this is because of include/exclude truncation
+			'orderby'        => 'ID', // this is because of include/exclude truncation
 			'order'          => 'DESC', // default but specifying to be safe
 		];
 
@@ -444,24 +444,24 @@ class PullListTable extends \WP_List_Table {
 			];
 		} elseif ( 'skipped' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
 			// Put most recently skipped items first.
-			$skipped = array_reverse( $skipped );
+			$skipped     = array_reverse( $skipped );
 			$total_items = count( $skipped );
-			$offset = $per_page * ( $current_page - 1 );
-			$post_ids = array_slice( $skipped, $offset, $per_page, true );
+			$offset      = $per_page * ( $current_page - 1 );
+			$post_ids    = array_slice( $skipped, $offset, $per_page, true );
 
 			$remote_get_args['post__in'] = $post_ids;
 			$remote_get_args['orderby']  = 'post__in';
-			$remote_get_args['paged']  = 1;
+			$remote_get_args['paged']    = 1;
 		} else {
 			// Put most recently pulled items first.
-			$syndicated = array_reverse( $syndicated );
+			$syndicated  = array_reverse( $syndicated );
 			$total_items = count( $syndicated );
-			$offset = $per_page * ( $current_page - 1 );
-			$post_ids = array_slice( $syndicated, $offset, $per_page, true );
+			$offset      = $per_page * ( $current_page - 1 );
+			$post_ids    = array_slice( $syndicated, $offset, $per_page, true );
 
 			$remote_get_args['post__in'] = $post_ids;
 			$remote_get_args['orderby']  = 'post__in';
-			$remote_get_args['paged']  = 1;
+			$remote_get_args['paged']    = 1;
 		}
 
 		$remote_get = $connection_now->remote_get( $remote_get_args );


### PR DESCRIPTION
### Description of the Change

As reported in #418, getting content from external connections for the pull list table when there are a lot of pulled/skipped posts ends up failing due to header size. This PR truncates the list of posts found in the sync log to include/exclude so as to avoid that failure and adjusts the UI to accommodate the change.

### Alternate Designs

Initial suggestion was to strip the referer, which might help if you're right above the limit as it would let a few more characters through, but would eventually stop working. In the future, not as an alternate, we should explore generating/storing the sync log for authenticated connections on the remote side so a full include/exclude list doesn't have to be passed.

### Benefits

Besides that you will no longer get a failed authentication message, this makes the pulled and skipped lists more performant, and IMO all the lists are more sensibly ordered. For pulled and skipped, **only** the necessary IDs for the current page are passed and in reverse order of when things were pulled/skipped (e.g. latest acted upon show up first, regardless of date), negating the need to run extra queries to sort by date on the remote site and, again IMO, match user expectations/needs for referring to those screens better. For new content, it is now sorted by ID descending instead of date to match the sync log truncation method, which means newly _created_ content shows up at the top, as opposed to just by date.

### Possible Drawbacks

Posts that were pulled/skipped a while back will start showing up in the new list again, although they are marked/styled appropriately and cannot be pulled. For sites that pull some but not all/most content, these should not show up until later pages. For sites that pull most or all content from a connection, these items will show up sooner and could lead to some weirdness where you're just getting pages and pages of already-processed content. Not great, but better than not being able to connect at all.

We can discuss changing skipped to be able to be pulled, but for the moment, it looks like this:

![Screen Shot 2019-07-17 at 8 56 31 AM](https://user-images.githubusercontent.com/906334/61394347-2154da00-a880-11e9-945a-7bbe1f17bf4d.png)

### Verification Process

For pulled/skipped, I set the posts per page in screen options to 1, pulled/skipped posts in mixed chronology, and made sure that pagination and ordering worked as expected.

For new, I commented out the `post__not_in` argument to see pulled/skipped posts in place. I also reproduced the originally reported failure by inserting `$this->sync_log = array_combine ( range( 1, 500 ), range( 1, 500 ) )`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #418 
