### PR TITLE
Add missing changelog links and dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,11 +151,11 @@ This adds a post type selector when viewing the Pull Content list for both exter
 ### Added
 - Gutenberg support, public release.
 
-## [1.1.0] - 2018-05-07
+## [1.1.0] - 2018-01-19
 ### Added
 - WordPress.com Oauth2 authentication.
 
-## [1.0.0]
+## [1.0.0] - 2016-09-26
 - Initial closed release.
 
 [1.5.0]: https://github.com/10up/distributor/compare/1.4.1...1.5.0
@@ -172,5 +172,9 @@ This adds a post type selector when viewing the Pull Content list for both exter
 [1.3.1]: https://github.com/10up/distributor/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/10up/distributor/compare/1.2.3...1.3.0
 [1.2.3]: https://github.com/10up/distributor/compare/1.2.2...1.2.3
-[1.2.2]: https://github.com/10up/distributor/releases/tag/1.2.2
-[1.1.0]: https://github.com/10up/distributor/releases/tag/archive%2Ffeature%2Fenable-oath2
+[1.2.2]: https://github.com/10up/distributor/compare/7f245b5...1.2.2
+[1.2.1]: https://github.com/10up/distributor/compare/457b14...7f245b5
+[1.2.0]: https://github.com/10up/distributor/compare/archive%2Ffeature%2Fenable-oath2...457b14
+[1.1.0]: https://github.com/10up/distributor/compare/5f68677...archive%2Ffeature%2Fenable-oath2
+[1.0.0]: https://github.com/10up/distributor/commit/5f68677da972336b6a8161c143faa456bfdbe4ef
+


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The CHANGELOG.md was missing a date and several links for the first couple releases.  This PR adds the missing date, updates a date, and adds missing release links.  Unfortunately there aren't tagged releases for some of the original releases, so I had to do some commit spelunking to try and find the correct place in time based on the changelog notes for each release.

### Alternate Designs

none.

### Benefits

For folks looking to compare the codebase of past releases, we now have a valid changelog per the keepachangelog.com standard.

### Possible Drawbacks

none identified.

### Verification Process

Manually verified via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a
