### PR TITLE
Add snapshot for WordPress 4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
       name: "Unit Tests and Liniting"
       script: ./vendor/bin/phpunit
       script: composer run-script lint
+    - script: travis_retry bash run-wpacceptance.sh 8ca702c1814182b90179cd390bbf3b8e
+      name: "wp-acceptance: WordPress 4.7"
     - script: travis_retry bash run-wpacceptance.sh 3593222a181f0f91824947dbd06985d5
       name: "wp-acceptance: WordPress 4.9"
     - script: travis_retry bash run-wpacceptance.sh 9ea863cebfcbb416c6334a6bef6552f0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
       script: ./vendor/bin/phpunit
       script: composer run-script lint
     - script: travis_retry bash run-wpacceptance.sh d1d46ee7e55bb0a75524ec6af40dfadd
+      php: 5.6
       name: "wp-acceptance: WordPress 4.7"
     - script: travis_retry bash run-wpacceptance.sh 3593222a181f0f91824947dbd06985d5
       name: "wp-acceptance: WordPress 4.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       name: "Unit Tests and Liniting"
       script: ./vendor/bin/phpunit
       script: composer run-script lint
-    - script: travis_retry bash run-wpacceptance.sh 8ca702c1814182b90179cd390bbf3b8e
+    - script: travis_retry bash run-wpacceptance.sh d1d46ee7e55bb0a75524ec6af40dfadd
       name: "wp-acceptance: WordPress 4.7"
     - script: travis_retry bash run-wpacceptance.sh 3593222a181f0f91824947dbd06985d5
       name: "wp-acceptance: WordPress 4.9"


### PR DESCRIPTION
* Add a snapshot for WordPress 4.7
* depends on https://github.com/10up/distributor/pull/439