### PR TITLE
Don't cast wp_error object to int on failure

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -248,7 +248,8 @@ function ajax_push() {
 					$push_args['post_status'] = $_POST['postStatus'];
 				}
 
-				$remote_id = $external_connection->push( intval( $_POST['postId'] ), $push_args );
+				$post_id   = intval( $_POST['postId'] );
+				$remote_id = $external_connection->push( $post_id, $push_args );
 
 				/**
 				 * Record the external connection id's remote post id for this local post
@@ -269,7 +270,7 @@ function ajax_push() {
 					$external_connection->log_sync( array( $remote_id => $_POST['postId'] ) );
 				} else {
 					$external_push_results[ (int) $connection['id'] ] = array(
-						'post_id' => (int) $remote_id,
+						'post_id' => $post_id,
 						'date'    => date( 'F j, Y g:i a' ),
 						'status'  => 'fail',
 					);
@@ -550,3 +551,5 @@ function menu_content() {
 	}
 }
 
+$post_id   = intval( $_POST['postId'] );
+$remote_id = $external_connection->push( $post_id, $push_args );


### PR DESCRIPTION
### Description of the Change

Avoid casting an error into an int (`1`) and labeling it as a post_id.

## Alternate Designs

n/a

### Benefits

Clear information about the failure rather than an arbitrary value coercion.

### Possible Drawbacks

None come to mind.

### Verification Process

Test failing push.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my change.
- [ x ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
