### PR TITLE
Add `gh-pages` static root file, build hooks docs in subfolder

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build and deploy:
     runs-on: ubuntu-latest
-    node-version: [12.x]
+    node-version: '12.x'
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -25,4 +25,4 @@ jobs:
       uses: maxheld83/ghpages@v0.2.1
       env:
         BUILD_DIR = "docs/"
-        secrets = ["GH_PAT"]
+      secrets: ${{ secrets.GH_PAT }}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,6 @@
+<html>
+	<body>
+		<h1>Welcome to Distributor Docs</h1>
+		<a href="hooks/index.html">Visit the Hook Docs</a>
+	</body>
+</html>

--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -1,6 +1,6 @@
 {
   "opts": {
-      "destination": "docs",
+      "destination": "docs/hooks",
       "template": "node_modules/wp-hookdoc/template",
       "recurse": true
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "gulp",
     "makepot": "wpi18n makepot && echo '.pot file updated'",
     "release": "rm -rf release/ && git worktree prune && npm run build && git worktree add -B stable release origin/stable && gulp copy",
-    "build:docs": "rm -rf hook_docs && jsdoc -c hookdoc-conf.json distributor.php includes"
+    "build:docs": "jsdoc -c hookdoc-conf.json distributor.php includes"
   },
   "dependencies": {
     "@10up/eslint-config": "^1.0.6",


### PR DESCRIPTION
 
### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

* Add a simple static `index.html` template file - this will be the `gh-pages` landing page.
* Change the build command in `hooks-doc.conf` to build into a `hooks` subfolder.
* Clean up the `build:docs` command.