### PR TITLE
Style and tweak hookdoc output

### DIFF
--- a/.github/hookdoc-tmpl/README.md
+++ b/.github/hookdoc-tmpl/README.md
@@ -1,0 +1,7 @@
+## Welcome to the Distributor Plugin Hook Documentation
+
+This resource is generated documentation on actions and filters found in the Distributor plugin. Use the sidebar to browse and navigate.
+
+For more information about using Distributor with WordPress, please see the [Distributor website](https://distributorplugin.com/).
+
+To report an issue with Distributor or contribute back to the project, please visit the [GitHub repository](https://github.com/10up/distributor/).

--- a/.github/hookdoc-tmpl/README.md
+++ b/.github/hookdoc-tmpl/README.md
@@ -1,7 +1,9 @@
-## Welcome to the Distributor Plugin Hook Documentation
+# Welcome to the Distributor Plugin Hook Documentation
 
 This resource is generated documentation on actions and filters found in the Distributor plugin. Use the sidebar to browse and navigate.
 
 For more information about using Distributor with WordPress, please see the [Distributor website](https://distributorplugin.com/).
 
 To report an issue with Distributor or contribute back to the project, please visit the [GitHub repository](https://github.com/10up/distributor/).
+
+<a href="http://10up.com/contact/" class="banner"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>

--- a/.github/hookdoc-tmpl/layout.tmpl
+++ b/.github/hookdoc-tmpl/layout.tmpl
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title><?js= title ?> - 10up Distributor Dev Docs</title>
+
+    <script src="scripts/prettify/prettify.js"> </script>
+    <script src="scripts/prettify/lang-css.js"> </script>
+	<script type='text/javascript' src='//use.typekit.net/dtp2teh.js?ver=4.0'></script>
+    <!--[if lt IE 9]>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+    <link type="text/css" rel="stylesheet" href="styles-10up.css">
+</head>
+
+<body>
+
+<div id="main">
+
+    <h1 class="page-title"><?js= title ?></h1>
+
+    <?js= content ?>
+
+	<p><a href="http://10up.com/contact/"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a></p>
+</div>
+
+<nav>
+    <?js= this.nav ?>
+</nav>
+
+<br class="clear">
+
+<script> prettyPrint(); </script>
+<script src="scripts/linenumber.js"> </script>
+</body>
+</html>

--- a/.github/hookdoc-tmpl/layout.tmpl
+++ b/.github/hookdoc-tmpl/layout.tmpl
@@ -2,28 +2,37 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title><?js= title ?> - 10up Distributor Dev Docs</title>
+    <title><?js= title ?> - 10up Distributor Hook Docs</title>
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>
-	<script type='text/javascript' src='//use.typekit.net/dtp2teh.js?ver=4.0'></script>
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+
+	<link rel="stylesheet" href="https://use.typekit.net/tha4jvf.css">
     <link type="text/css" rel="stylesheet" href="styles-10up.css">
 </head>
 
-<body>
+<body<?js if (title === 'Home') { ?> class="home"<?js } ?>>
 
 <div id="main">
 
+	<?js if (title !== 'Home') { ?>
     <h1 class="page-title"><?js= title ?></h1>
+	<?js } ?>
 
     <?js= content ?>
 
-	<p><a href="http://10up.com/contact/"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a></p>
+    <footer>
+		<a href="https://distributorplugin.com/">Distributor Plugin</a> &bull;
+		<a href="https://github.com/10up/distributor/">Distributor on GitHub</a> &bull;
+		<a href="https://10up.com/careers">Careers at 10up</a>
+	</footer>
+
+	
 </div>
 
 <nav>

--- a/.github/hookdoc-tmpl/static/styles-10up.css
+++ b/.github/hookdoc-tmpl/static/styles-10up.css
@@ -1,0 +1,8 @@
+body {
+	font-family: 'proxima-nova', sans-serif;
+	font-size: 1.2rem;
+}
+
+h1, h2, h3 {
+	font-family: 'freight-text-pro', serif;
+}

--- a/.github/hookdoc-tmpl/static/styles-10up.css
+++ b/.github/hookdoc-tmpl/static/styles-10up.css
@@ -1,8 +1,73 @@
 body {
+	background: #fefefe;
+	color: #232323;
 	font-family: 'proxima-nova', sans-serif;
-	font-size: 1.2rem;
+	font-size: 1.3rem;
+	font-weight: 300;
 }
 
 h1, h2, h3 {
-	font-family: 'freight-text-pro', serif;
+	line-height: 1.2;
+	font-family: 'proxima-nova', sans-serif;
+	font-weight: 800;
+	letter-spacing: -.02em;
+}
+
+h1.page-title {
+	margin-top: .5em;
+}
+
+nav ul {
+	font-size: 1.1rem;
+}
+
+article h1 {
+	margin: 12px 0 32px;
+}
+
+a {
+	background-image: linear-gradient(transparent calc(100% - 7px), #f2dede 0),
+		linear-gradient(transparent calc(100% - 7px), #cef8f7 0);
+	background-position: 0 0;
+	background-repeat: no-repeat;
+	background-size: 0 100%, 100% 100%;
+	color: #232323;
+	text-decoration: none;
+	transition: all .1s;
+}
+
+a:visited,
+a:active {
+	color: #232323;
+}
+
+a:focus,
+a:hover {
+	background-size: 100% 100%, 100% 100%;
+	color: #232323;
+	text-decoration: none;
+}
+
+nav li a {
+	background-image: none;
+}
+
+a.banner {
+	background-image: none;
+	margin-left: -10px;
+}
+
+a.banner img {
+	width: 100%;
+	max-width: 888px;
+}
+
+footer {
+	text-align: center;
+	font-size: .8em;
+	font-style: normal;
+}
+
+.home #main > section:first-of-type {
+	display: none;
 }

--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -2,12 +2,23 @@
   "opts": {
       "destination": "docs",
       "template": "node_modules/wp-hookdoc/template",
-      "recurse": true
+      "recurse": true,
+      "readme": "./.github/hookdoc-tmpl/README.md"
   },
   "source": {
       "includePattern": ".+\\.(php|inc)?$"
   },
   "plugins": [
     "node_modules/wp-hookdoc/plugin"
-  ]
+  ],
+  "templates":  {
+    "default": {
+      "layoutFile": ".github/hookdoc-tmpl/layout.tmpl",
+      "staticFiles": {
+        "include": [
+          "./.github/hookdoc-tmpl/static"
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Description of the Change

Leverages JSdoc config to do the following:

* Uses a layout.tmpl override
* Uses a specific README file for home content
* Includes a 10up-specific stylesheet (actual styling in progress)

### Alternate Designs

See #481, #480 

### Benefits

Can explain what this site is for, point to other resources, and make it look nice and 10uppy.

### Possible Drawbacks

More maintenance?

### Verification Process

`npm run build:docs` locally

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

See #387. Also noticed in working on this that the docblocks still need some more work, in particular naming params and adding `@returns` to filters so they are separated from actions.
