### PR TITLE
10up develop

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -647,11 +647,15 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$body_array = json_decode( $body, true );
 
-		try {
-			$remote_id = $body_array['id'];
-		} catch ( \Exception $e ) {
+		if( isset( $body_array['data']['status'] ) && $body_array['data']['status'] == 400 ){
+			return new \WP_Error( 'bad-request', esc_html__( 'Status code is 400', 'distributor' ) );
+		}
+
+		if( !isset( $body_array['id'] ) ){
 			return new \WP_Error( 'no-push-post-remote-id', esc_html__( 'Could not determine remote post id.', 'distributor' ) );
 		}
+
+		$remote_id = $body_array['id'];
 
 		$response_headers = wp_remote_retrieve_headers( $response );
 


### PR DESCRIPTION
### Description of the Change
Related to #488 
Removed try/catch case and added new conditions to check is it `bad request` response or  we don't receive `remote_id`
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
n/a

### Benefits
We can handle the case, were not distributed the post ( really not distributed but shown like distributed in the hub ) with `post_id = 0` can't distribute because spoke is down or we don't receive some remote post id or we have a bad request.

### Possible Drawbacks
We don't have drawbacks, because we fix a bug.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
I have created envirment for test, downed spoke site and hub for distribution, My code tested up and work clean.This case i show in my live sites where my spoke go down some time.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
