### PR TITLE
Replace has_blocks with use_block_editor_for_post in is_using_gutenberg

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -46,17 +46,13 @@ function is_using_gutenberg( $post ) {
 		return false;
 	}
 
-	// WordPress 5.0 introduces the has_blocks function.
-	// We pass `post_content` directly because `has_blocks()`
-	// tries to retrieve a local post object, but this may be a remote post.
-	if ( function_exists( 'has_blocks' ) ) {
-		return has_blocks( $post->post_content );
+	if ( function_exists( 'use_block_editor_for_post' ) ) {
+		return use_block_editor_for_post( $post );
 	} else {
-		// This duplicates the check from `has_blocks()` as of WP 5.2.
+		// This duplicates the check from `use_block_editor_for_post()` as of WP 5.2.
 		return false !== strpos( (string) $post->post_content, '<!-- wp:' );
 	}
 }
-
 
 /**
  * Get Distributor settings with defaults

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -347,6 +347,7 @@ function prepare_meta( $post_id ) {
 				$meta_value = maybe_unserialize( $meta_value );
 				/**
 				 * Filter whether to sync meta.
+				 *
 				 * @hook dt_sync_meta
 				 *
 				 * @param {bool}   $sync_meta  Whether to sync meta. Default `true`.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -49,7 +49,7 @@ function is_using_gutenberg( $post ) {
 	if ( function_exists( 'use_block_editor_for_post' ) ) {
 		return use_block_editor_for_post( $post );
 	} else {
-		// This duplicates the check from `use_block_editor_for_post()` as of WP 5.2.
+		// This duplicates the check from `has_blocks()` as of WP 5.2.
 		return false !== strpos( (string) $post->post_content, '<!-- wp:' );
 	}
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This would fix the issue described in #512 by providing a more reliable check for whether the Gutenberg editor is enabled for a post. 

The issue @dkotter found comes from a specific scenario where a post may be distributed to a Gutenberg-enabled site without having `<!-- wp:` in the post content. In this case, the core function `has_blocks` returns false because checking for `<!-- wp:` [is exactly what `has_blocks` does](https://github.com/WordPress/WordPress/blob/317465e2feb965ea7d86529e54908b3fbea539a8/wp-includes/blocks.php#L56-L65).

This replaces `has_blocks` with `use_block_editor_for_post`, which checks whether the current post's post type has the editor enabled and shows in REST. This works with the Classic Editor plugin because that plugin [uses the `use_block_editor_for_post_type` filter to have this function always return false](https://github.com/WordPress/classic-editor/blob/2099a42394710fdd717589da789a3404aa6e6eb6/classic-editor.php#L104)

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

I can't think of any good alternatives to this small change.

### Benefits

<!-- What benefits will be realized by the code change? -->

After being distributed in draft status, posts with no blocks can be published.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

#### Before

Adapting Darin's steps to reproduce from #512:

1. Activate the Classic Editor plugin
2. Write a new post using the Classic Editor
3. Disable the Classic Editor plugin
4. Distribute the post to another site, keeping the post in draft status on the destination site
5. Notice on the destination site the Publish button is disabled

#### After

Following the above steps, the Publish button will now be enabled on the destination site

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

**Note**: There were multiple issues with tests. I was unable to run `composer install` because of missing PHP extensions on my system (can share more details if helpful). I see tests are failing on all the PRs, so I'm going to assume that's not just me.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

#512 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Replace `has_blocks` with `use_block_editor_for_post` in is_using_gutenberg check
