### PR TITLE
Ensure connection check does not create empty posts

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -855,7 +855,7 @@ class WordPressExternalConnection extends ExternalConnection {
 										// this runs.
 										'body'    => array(
 											'test' => 1,
-											'id' => -1
+											'id'   => -1
 										),
 									)
 								)

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -855,7 +855,7 @@ class WordPressExternalConnection extends ExternalConnection {
 										// this runs.
 										'body'    => array(
 											'test' => 1,
-											'id'   => -1
+											'id'   => -1,
 										),
 									)
 								)

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -853,7 +853,10 @@ class WordPressExternalConnection extends ExternalConnection {
 										// types whose POST REST endpoints have no required fields, such as page and
 										// block_type. Otherwise, an empty page/block_type will be created each time
 										// this runs.
-										'body'    => array( 'test' => 1, 'id' => -1 ),
+										'body'    => array(
+											'test' => 1,
+											'id' => -1
+										),
 									)
 								)
 							);

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -849,7 +849,11 @@ class WordPressExternalConnection extends ExternalConnection {
 								$this->auth_handler->format_post_args(
 									array(
 										'timeout' => self::$timeout,
-										'body'    => array( 'test' => 1 ),
+										// Set id to -1 to ensure the request can authenticate but is invalid for post
+										// types whose POST REST endpoints have no required fields, such as page and
+										// block_type. Otherwise, an empty page/block_type will be created each time
+										// this runs.
+										'body'    => array( 'test' => 1, 'id' => -1 ),
 									)
 								)
 							);

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -351,6 +351,7 @@ function prepare_meta( $post_id ) {
 				$meta_value = maybe_unserialize( $meta_value );
 				/**
 				 * Filter whether to sync meta.
+				 *
 				 * @hook dt_sync_meta
 				 *
 				 * @param {bool}   $sync_meta  Whether to sync meta. Default `true`.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This would resolve the issues recently noted on #255, particularly: 

> On wp-admin/admin.php?page=distributor, clicking the (Verify) link for an External Connection will generate a single (no title) — Draft Page on that external site.
On wp-admin/post.php?post=###&action=edit (where ### is a number for a valid External Connection), clicking the Update Connection button will generate two (no title) — Draft Pages on that external site.

(In the first case, the empty page was actually being created each time the single External Connection post was loaded, not just when accessed via the (Verify) link.)

I'm not sure whether this fix would resolve the older comments in #255, though. We don't have enough details for those.

At [this point](https://github.com/10up/distributor/blob/2e8e0779a4dd83739c78317d7faa5f331f7c36d7/includes/classes/ExternalConnections/WordPressExternalConnection.php#L846-L855) in the `check_connections` method that runs on `save_post` and in an AJAX request in the External Connection post type editor, the plugin iterates through post types and makes a REST POST request for each one. If the POST request authenticates, that post type is marked as one that can receive post requests.

The problem with this is that the `page` and `wp_block` post types have no required fields, so their REST POST endpoints create an empty post even when no data is set. 

To fix this, I added `id => -1` to the request body sent to the POST endpoint, because this will cause the request to be invalid. It still authenticates, though, which is all we need to know.

**Note:** Before debugging this, I tested on the `feature/auth-flow` branch (#368) and confirmed that that update did not fix the issue.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

Other ways of invalidating the POST request body while still authenticating could be explored, although in my experience there's no circumstance in which passing `id => -1` will result in a valid request.

### Benefits

<!-- What benefits will be realized by the code change? -->

Empty pages and wp_blocks (and maybe custom post types) will no longer be created when the External Connection post type editor is visited or updated.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

#### Before

Replicate the test scenarios quoted above **using separate WordPress instances**.  When visiting the External Connection editor page, or when updating it, if you have a valid external connection, you will see empty pages created on the remote site. Empty `wp_block` posts will also appear in the database. 

#### After

Visiting the External Connection editor page for an external connection with a valid connection will not result in empty pages anymore.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Maybe resolves #255 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Resolve issue where empty pages and `wp_block` posts were created on remote sites while verifying external connections