### PR TITLE
Place pulled list action links in standard order

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -326,8 +326,8 @@ class PullListTable extends \WP_List_Table {
 
 			if ( ! empty( $new_post ) ) {
 				$actions = [
-					'view' => '<a href="' . esc_url( get_permalink( $new_post_id ) ) . '">' . esc_html__( 'View', 'distributor' ) . '</a>',
 					'edit' => '<a href="' . esc_url( get_edit_post_link( $new_post_id ) ) . '">' . esc_html__( 'Edit', 'distributor' ) . '</a>',
+					'view' => '<a href="' . esc_url( get_permalink( $new_post_id ) ) . '">' . esc_html__( 'View', 'distributor' ) . '</a>',
 				];
 			}
 		}


### PR DESCRIPTION
### Description of the Change

This PR addresses issue [505](https://github.com/10up/distributor/issues/505).

### Benefits

Changes action link order to align with other Post listing pages.

### Verification Process

1. On your install, Pull a post from another site via `wp-admin/admin.php?page=pull&status=new`
2. Visit the Pulled listing page: `wp-admin/admin.php?page=pull&status=pulled` and see that the links are in the following order when hovering over a Post: [Edit | View](url).

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

[505](https://github.com/10up/distributor/issues/505)
