### PR TITLE
Added urldecode() to fix searching multiple words during a multisite pull

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -401,7 +401,7 @@ class NetworkSiteConnection extends Connection {
 			}
 
 			if ( isset( $args['s'] ) ) {
-				$query_args['s'] = $args['s'];
+				$query_args['s'] = urldecode( $args['s'] );
 			}
 
 			if ( ! empty( $args['orderby'] ) ) {

--- a/tests/wpacceptance/InternalPullTest.php
+++ b/tests/wpacceptance/InternalPullTest.php
@@ -90,4 +90,27 @@ class InternalPullTest extends \TestCase {
 
 		$I->seeText( 'Test Post', '.wp-list-table .page-title' );
 	}
+
+	/**
+	 * Test searching mutilple words.
+	 * 
+	 * @link https://github.com/10up/distributor/pull/533
+	 */
+	public function testSearchMultipleWordsDuringPull() {
+		$I = $this->openBrowserPage();
+
+		$I->loginAs( 'wpsnapshots' );
+
+		$I->moveTo( 'two/wp-admin/admin.php?page=pull' );
+
+		$I->waitUntilElementVisible( '.wp-list-table' );
+
+		$I->typeInField( '#post-search-input', 'test post' );
+
+		$I->click( '#search-submit' );
+
+		$I->waitUntilElementVisible( '.wp-list-table' );
+
+		$I->dontSeeText( 'No items found.', 'table.distributor_page_pull' );
+	}
 }


### PR DESCRIPTION
### Description of the Change

Fixes a bug when searching for posts using multiple words during a multisite pull.

### Verification Process

Verified searching by single and multiple words in a multisite pull works.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Applicable Issues

#522 

### Changelog Entry

* Fixed a bug when searching for posts using multiple words during a multisite pull.