### PR TITLE
Fix: Block content pulled through external connections get converted to classic

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -912,7 +912,7 @@ class WordPressExternalConnection extends ExternalConnection {
 		$obj->ping_status       = $post['ping_status'];
 
 		// Use raw content if both remote and local are using Gutenberg.
-		$obj->post_content = Utils\is_gutenberg_active() && isset( $post['is_using_gutenberg'] ) ?
+		$obj->post_content = Utils\is_using_gutenberg( new \WP_Post( $obj ) ) && isset( $post['is_using_gutenberg'] ) ?
 			$post['content']['raw'] :
 			Utils\get_processed_content( $post['content']['raw'] );
 

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -912,7 +912,7 @@ class WordPressExternalConnection extends ExternalConnection {
 		$obj->ping_status       = $post['ping_status'];
 
 		// Use raw content if both remote and local are using Gutenberg.
-		$obj->post_content = \Distributor\Utils\is_using_gutenberg( new \WP_Post( $obj ) ) && isset( $post['is_using_gutenberg'] ) ?
+		$obj->post_content = Utils\is_gutenberg_active() && isset( $post['is_using_gutenberg'] ) ?
 			$post['content']['raw'] :
 			Utils\get_processed_content( $post['content']['raw'] );
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,8 +54,8 @@ function is_using_gutenberg( $post ) {
 
 	$use_block_editor = true;
 
-	if ( ! function_exists( 'is_plugin_active' ) ){
-		require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
 	}
 
 	if ( is_plugin_active( 'classic-editor/classic-editor.php' ) ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,6 +54,10 @@ function is_using_gutenberg( $post ) {
 
 	$use_block_editor = true;
 
+	if ( ! function_exists( 'is_plugin_active' ) ){
+		require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+	}
+
 	if ( is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
 		$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,6 +54,40 @@ function is_using_gutenberg( $post ) {
 	}
 }
 
+	/**
+	 * Check if Gutenberg is active.
+	 *
+	 * @since 2.0.0
+	 * 
+	 * @return bool
+	 */
+	function is_gutenberg_active() {
+		$gutenberg    = false;
+		$block_editor = false;
+
+		if ( has_filter( 'replace_editor', 'gutenberg_init' ) ) {
+			// Gutenberg is installed and activated.
+			$gutenberg = true;
+		}
+
+		if ( version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' ) ) {
+			// Block editor.
+			$block_editor = true;
+		}
+
+		if ( ! $gutenberg && ! $block_editor ) {
+			return false;
+		}
+
+		if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
+			return true;
+		}
+
+		$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+
+		return $use_block_editor;
+	}
+
 /**
  * Get Distributor settings with defaults
  *

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -58,35 +58,35 @@ function is_using_gutenberg( $post ) {
 	 * Check if Gutenberg is active.
 	 *
 	 * @since 2.0.0
-	 * 
+	 *
 	 * @return bool
 	 */
-	function is_gutenberg_active() {
-		$gutenberg    = false;
-		$block_editor = false;
+function is_gutenberg_active() {
+	$gutenberg    = false;
+	$block_editor = false;
 
-		if ( has_filter( 'replace_editor', 'gutenberg_init' ) ) {
-			// Gutenberg is installed and activated.
-			$gutenberg = true;
-		}
-
-		if ( version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' ) ) {
-			// Block editor.
-			$block_editor = true;
-		}
-
-		if ( ! $gutenberg && ! $block_editor ) {
-			return false;
-		}
-
-		if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
-			return true;
-		}
-
-		$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
-
-		return $use_block_editor;
+	if ( has_filter( 'replace_editor', 'gutenberg_init' ) ) {
+		// Gutenberg is installed and activated.
+		$gutenberg = true;
 	}
+
+	if ( version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' ) ) {
+		// Block editor.
+		$block_editor = true;
+	}
+
+	if ( ! $gutenberg && ! $block_editor ) {
+		return false;
+	}
+
+	if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
+		return true;
+	}
+
+	$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+
+	return $use_block_editor;
+}
 
 /**
  * Get Distributor settings with defaults

--- a/tests/wpacceptance/SettingsTest.php
+++ b/tests/wpacceptance/SettingsTest.php
@@ -90,6 +90,6 @@ class SettingsTest extends \TestCase {
 		// Verify byline is normal
 		$I->moveTo( $post_info['distributed_front_url'] );
 
-		$I->seeText( 'wpsnapshots', '.byline .author' );
+		$I->seeText( 'admin', '.byline .author' );
 	}
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
- Add: A new helper function to detect if the current site is using Gutenberg or not.
- Fix: get correct content when pulling block-based posts through external connections. 

See: https://github.com/10up/distributor/issues/516#issuecomment-593244566

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
n/a
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
Better support for block editor.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
n/a
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
0. Activate block editor/Gutenber on both sites.
1. Go to Distributor > Pull Content.
2. Choose the target external connection.
3. Pull a post that has blocks.
4. See the pulled post has identical content with block display correctly.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Close #516 
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
