### PR TITLE
Change setting page title from h2 to h1.

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -317,7 +317,7 @@ function network_settings_screen() {
 	?>
 
 	<div class="wrap">
-		<h2><?php esc_html_e( 'Distributor Network Settings', 'distributor' ); ?></h2>
+		<h1><?php esc_html_e( 'Distributor Network Settings', 'distributor' ); ?></h1>
 
 		<form action="" method="post">
 		<?php settings_fields( 'dt-settings' ); ?>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -290,7 +290,7 @@ function network_admin_menu() {
 function settings_screen() {
 	?>
 	<div class="wrap">
-		<h2><?php esc_html_e( 'Distributor Settings', 'distributor' ); ?></h2>
+		<h1><?php esc_html_e( 'Distributor Settings', 'distributor' ); ?></h1>
 
 		<form action="options.php" method="post">
 


### PR DESCRIPTION
Fixes #555.

## Description of the Change
Every page should have main title as `<h1>`. 

## Benefits
Screen reader users navigating using headings.

## Possible Drawbacks

None.

## Verification Process

Go to the setting page `admin.php?page=distributor-settings` and verify that Distributor Settings title is now `<h1>`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
