### PR TITLE
Fix password field label for attribute

### DIFF
--- a/includes/classes/Authentications/WordPressBasicAuth.php
+++ b/includes/classes/Authentications/WordPressBasicAuth.php
@@ -70,7 +70,7 @@ class WordPressBasicAuth extends Authentication {
 		</p>
 
 		<p>
-			<label for="dt_username"><?php esc_html_e( 'Password', 'distributor' ); ?> <?php
+			<label for="dt_password"><?php esc_html_e( 'Password', 'distributor' ); ?> <?php
 			if ( ! empty( $args['base64_encoded'] ) ) :
 				?>
 <a class="change-password" href="#"><?php esc_html_e( '(Change)', 'distributor' ); ?></a><?php endif; ?></label><br>


### PR DESCRIPTION
Fixes #551.

## Description of the Change

Change Password field `for` attribute to `dt_password` to match password field ID..

## Benefits

- Users can click password label to focus correct password field.
- Screen reader users get correct info about the field.

## Possible Drawbacks

None.

## Verification Process

1. Edit connection.
1. Click password field.
1. Check that correct password field is focused.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#551.