### PR TITLE
Tweak allowed to push markup

### DIFF
--- a/assets/css/admin-external-connection.css
+++ b/assets/css/admin-external-connection.css
@@ -13,8 +13,15 @@
 	box-shadow: none;
 }
 
+.dt-roles-allowed legend {
+	font-size: 14px;
+	font-weight: 700;
+	margin-bottom: 4px;
+}
+
 #dt_external_connection_details .dt-roles-allowed label {
-	font-weight: normal;
+	font-weight: 400;
+	vertical-align: top;
 }
 
 #dt_external_connection_details .dt-roles-allowed label:first-child {
@@ -48,6 +55,7 @@
 }
 
 #dt_external_connection_details p,
+#dt_external_connection_details .dt-roles-allowed,
 #dt_external_connection_details .connection-field-wrap {
 	margin-bottom: 2em;
 }

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -479,8 +479,8 @@ function meta_box_external_connection_details( $post ) {
 		<ul class="endpoint-errors"></ul>
 	</div>
 
-	<p class="dt-roles-allowed hide-until-authed">
-		<label><?php esc_html_e( 'Roles Allowed to Push', 'distributor' ); ?></label><br>
+	<fieldset class="dt-roles-allowed hide-until-authed">
+		<legend><?php esc_html_e( 'Roles Allowed to Push', 'distributor' ); ?></legend>
 
 		<?php
 		$editable_roles = get_editable_roles();
@@ -488,13 +488,13 @@ function meta_box_external_connection_details( $post ) {
 			$name = translate_user_role( $details['name'] );
 			?>
 
-			<label for="dt-role-<?php echo esc_attr( $role ); ?>"><input class="dt-role-checkbox" name="dt_external_connection_allowed_roles[]" id="dt-role-<?php echo esc_attr( $role ); ?>" type="checkbox" <?php checked( true, in_array( $role, $allowed_roles, true ) ); ?> value="<?php echo esc_attr( $role ); ?>"> <?php echo esc_html( $name ); ?></label><br>
+			<input class="dt-role-checkbox" name="dt_external_connection_allowed_roles[]" id="dt-role-<?php echo esc_attr( $role ); ?>" type="checkbox" <?php checked( true, in_array( $role, $allowed_roles, true ) ); ?> value="<?php echo esc_attr( $role ); ?>"> <label for="dt-role-<?php echo esc_attr( $role ); ?>"><?php echo esc_html( $name ); ?></label><br>
 
 			<?php
 		}
 		?>
-		<span class="description"><?php esc_html_e( 'Select the roles of users on this site that will be allowed to push content to this connection. Keep in mind that pushing will use the permissions of the user credentials provided for this connection.', 'distributor' ); ?></p>
-	</p>
+		<span class="description"><?php esc_html_e( 'Select the roles of users on this site that will be allowed to push content to this connection. Keep in mind that pushing will use the permissions of the user credentials provided for this connection.', 'distributor' ); ?></span>
+	</fieldset>
 
 	<p class="dt-submit-connection hide-until-authed">
 		<input type="hidden" name="post_status" value="publish">


### PR DESCRIPTION
Fixes #552. 

## Description of the Change

Change the markup used in "Roles Allowed to Push" checkboxes. This is part of External connection view.

## Benefits

Screen reader will announce legend "Roles Allowed to Push" when selecting checkboxes.

## Possible Drawbacks

Is there any JS behind the scenes when checking checkboxes that could break with markup change.

## Verification Process

Tested with Voiceover by selecting checkboxes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#552 