### PR TITLE
Add label to Email and Registration Key fields.

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -221,7 +221,11 @@ function license_key_callback() {
 	$email       = ( ! empty( $settings['email'] ) ) ? $settings['email'] : '';
 	?>
 	<div class="license-wrap <?php if ( true === $settings['valid_license'] ) : ?>valid<?php elseif ( false === $settings['valid_license'] ) : ?>invalid<?php endif; ?>">
-		<input name="dt_settings[email]" type="email" placeholder="<?php esc_html_e( 'Email', 'distributor' ); ?>" value="<?php echo esc_attr( $email ); ?>"> <input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>">
+		<label class="screen-reader-text" for="dt_settings_email"><?php esc_html_e( 'Email', 'distributor' ); ?></label>
+		<input name="dt_settings[email]" type="email" placeholder="<?php esc_html_e( 'Email', 'distributor' ); ?>" value="<?php echo esc_attr( $email ); ?>" id="dt_settings_email">
+
+		<label class="screen-reader-text" for="dt_settings_license_key"><?php esc_html_e( 'Registration Key', 'distributor' ); ?></label>
+		<input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>" id="dt_settings_license_key">
 	</div>
 
 	<p class="description">


### PR DESCRIPTION
Fixes #556 

## Description of the Change

Add labels to Email and Registration Key fields in settings page.

## Benefits

Make sure different combinations announce field name using label.

## Possible Drawbacks

None.

## Verification Process

- Open screen reader like Voiceover and navigate to the setting page.
- Navigate to the Email and Registration Key fields.
- Check correct announcement.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#556 