### PR TITLE
Use button in external connection URL.

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -74,8 +74,10 @@ function checkConnections() {
 				if ( response.data.endpoint_suggestion ) {
 					endpointResult.innerText = `${ dt.endpoint_suggestion } `;
 
-					const suggestion = document.createElement( 'a' );
+					const suggestion = document.createElement( 'button' );
 					suggestion.classList.add( 'suggest' );
+					suggestion.classList.add( 'button-link' );
+					suggestion.setAttribute( 'type', 'button' );
 					suggestion.innerText = response.data.endpoint_suggestion;
 
 					endpointResult.appendChild( suggestion );


### PR DESCRIPTION
Fixes #553 

## Description of the Change

Use `button` instead of empty `<a>` without `href` in external connection URL suggestion.

## Benefits

Automatic keyboard support.

## Possible Drawbacks

None.

## Verification Process

1. Edit external connection.
1. Locate External Connection URL field.
1. Add test URL like http://testurl.test.
1. Notice suggestion text below field, "Did you mean: http://testurl.test/wp-json" .
1. Verify that you can navigate to that URL button and select it to populate link in the field.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

## Applicable Issues

#553 