### PR TITLE
Announce dynamic changes in external connection URL field 

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -1,8 +1,7 @@
-/* global wp */
-
 import jQuery from 'jquery';
 import _ from 'underscores';
 import { dt, ajaxurl } from 'window';
+import wp from 'wp';
 
 const [ externalConnectionUrlField ]  = document.getElementsByClassName( 'external-connection-url-field' );
 const externalConnectionMetaBox       = document.getElementById( 'dt_external_connection_details' );

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -1,3 +1,5 @@
+/* global wp */
+
 import jQuery from 'jquery';
 import _ from 'underscores';
 import { dt, ajaxurl } from 'window';
@@ -79,8 +81,12 @@ function checkConnections() {
 					suggestion.innerText = response.data.endpoint_suggestion;
 
 					endpointResult.appendChild( suggestion );
+
+					wp.a11y.speak( `${ dt.endpoint_suggestion } ${ response.data.endpoint_suggestion }`, 'polite' );
 				} else {
 					endpointResult.innerText = dt.bad_connection;
+
+					wp.a11y.speak( dt.bad_connection, 'polite' );
 				}
 			} else {
 				if ( response.data.errors.no_distributor || ! response.data.can_post.length ) {
@@ -91,8 +97,10 @@ function checkConnections() {
 
 					if ( response.data.errors.no_distributor ) {
 						endpointResult.innerText += ` ${ dt.no_distributor }`;
+						wp.a11y.speak( `${ dt.limited_connection } ${ dt.no_distributor }`, 'polite' );
 					} else {
 						endpointResult.innerText += ` ${ dt.bad_auth }`;
+						wp.a11y.speak( `${ dt.limited_connection } ${ dt.bad_auth }`, 'polite' );
 					}
 
 					warnings.push( dt.no_push );
@@ -107,6 +115,8 @@ function checkConnections() {
 				} else {
 					endpointResult.setAttribute( 'data-endpoint-state', 'valid' );
 					endpointResult.innerText = dt.good_connection;
+
+					wp.a11y.speak( dt.good_connection, 'polite' );
 				}
 			}
 		}

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -267,7 +267,7 @@ function admin_enqueue_scripts( $hook ) {
 	if ( ( 'post.php' === $hook && 'dt_ext_connection' === get_post_type() ) || ( 'post-new.php' === $hook && ! empty( $_GET['post_type'] ) && 'dt_ext_connection' === $_GET['post_type'] ) ) { // @codingStandardsIgnoreLine Nonce not required.
 
 		wp_enqueue_style( 'dt-admin-external-connection', plugins_url( '/dist/css/admin-external-connection.min.css', __DIR__ ), array(), DT_VERSION );
-		wp_enqueue_script( 'dt-admin-external-connection', plugins_url( '/dist/js/admin-external-connection.min.js', __DIR__ ), array( 'jquery', 'underscore' ), DT_VERSION, true );
+		wp_enqueue_script( 'dt-admin-external-connection', plugins_url( '/dist/js/admin-external-connection.min.js', __DIR__ ), array( 'jquery', 'underscore', 'wp-a11y' ), DT_VERSION, true );
 
 		wp_localize_script(
 			'dt-admin-external-connection',


### PR DESCRIPTION
Fixes issue #554 

## Description of the Change

Add `wp.a11y.speak` for dynamic changes in external connection URL field.

## Benefits

Screen reader users get the same information which appears dynamically below the field.

## Possible Drawbacks

None.

## Verification Process
1. Open screen reader live Voiceover.
1. Navigate to the external connection URL field.
1. Update field value and check that screen reader is announcing the same info as appear under the field.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

## Applicable Issues

#554 