### PR TITLE
Use filesystem for copying media when doing a network pull/push

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -144,7 +144,7 @@ class NetworkSiteConnection extends Connection {
 			 * @return {bool} If Distributor should push the post media.
 			 */
 			if ( apply_filters( 'dt_push_post_media', true, $new_post_id, $media, $post_id, $args, $this ) ) {
-				\Distributor\Utils\set_media( $new_post_id, $media );
+				\Distributor\Utils\set_media( $new_post_id, $media, [ 'use_filesystem' => true ] );
 			};
 		}
 
@@ -250,7 +250,7 @@ class NetworkSiteConnection extends Connection {
 				 * @return {bool} If Distributor should set the post media.
 				 */
 				if ( apply_filters( 'dt_pull_post_media', true, $new_post_id, $post->media, $item_array['remote_post_id'], $post_array, $this ) ) {
-					\Distributor\Utils\set_media( $new_post_id, $post->media );
+					\Distributor\Utils\set_media( $new_post_id, $post->media, [ 'use_filesystem' => true ] );
 				};
 			}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -818,9 +818,6 @@ function process_media( $url, $post_id, $args = [] ) {
 
 		$source_file = $args['source_file'];
 
-		// For debugging, defaults to not saving.
-		$save_source_file_path = apply_filters( 'dt_process_media_save_source_file_path', false );
-
 		if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
 			$creds = request_filesystem_credentials( site_url() );
 			wp_filesystem( $creds );
@@ -834,6 +831,10 @@ function process_media( $url, $post_id, $args = [] ) {
 			$copied = $wp_filesystem->copy( $source_file, $temp_name, true );
 
 			if ( $copied ) {
+
+				// For debugging, defaults to not saving.
+				$save_source_file_path = apply_filters( 'dt_process_media_save_source_file_path', false );
+
 				$file_array['tmp_name'] = $temp_name;
 				$download_url = false;
 			}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -818,8 +818,8 @@ function process_media( $url, $post_id, $args = [] ) {
 
 		$source_file = $args['source_file'];
 
-		// For debugging.
-		$save_source_file_path = apply_filters( 'dt_process_media_save_source_file_path', true );
+		// For debugging, defaults to not saving.
+		$save_source_file_path = apply_filters( 'dt_process_media_save_source_file_path', false );
 
 		if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
 			$creds = request_filesystem_credentials( site_url() );

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -472,6 +472,14 @@ class UtilsTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_attached_file', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => '/var/www/html/wp-content/uploads/mediaitem.jpg',
+			]
+		);
+
+		\WP_Mock::userFunction(
 			'get_post_meta', [
 				'times'  => 1,
 				'args'   => [ $media_post->ID ],
@@ -552,6 +560,14 @@ class UtilsTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'get_attached_file', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => '/var/www/html/wp-content/uploads/mediaitem.jpg',
+			]
+		);
+
+		\WP_Mock::userFunction(
 			'get_post_meta', [
 				'times'  => 1,
 				'args'   => [ $media_post->ID ],
@@ -618,6 +634,19 @@ class UtilsTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
+			'wp_parse_args', [
+				'times'  => 1,
+				'args'   => [
+					[ 'use_filesystem' => false ],
+					[ 'use_filesystem' => false ],
+				],
+				'return' => [
+					'use_filesystem' => false,
+				],
+			]
+		);
+
+		\WP_Mock::userFunction(
 			'wp_delete_attachment', [
 				'times' => 1,
 				'args'  => [ $attached_media_post->ID, true ],
@@ -643,7 +672,12 @@ class UtilsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'Distributor\Utils\process_media', [
 				'times'  => 1,
-				'args'   => [ $media_item['source_url'], $post_id ],
+				'args'   => [ $media_item['source_url'], $post_id,
+					[
+						'source_file'    => $media_item['source_file'],
+						'use_filesystem' => false,
+					]
+				],
 				'return' => $new_image_id,
 			]
 		);
@@ -705,7 +739,7 @@ class UtilsTest extends TestCase {
 			]
 		);
 
-		Utils\set_media( $post_id, [ $media_item ] );
+		Utils\set_media( $post_id, [ $media_item ], [ 'use_filesystem' => false ] );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Use filesystem for copying media when doing a network pull/push instead of `download_url()`

### Benefits
For network/multisite on the same server, there should be no need to make an HTTP request to download media when doing a pull or push. In some instances, due to DNS resolution, firewalls, HTTP authentication, etc, downloading media via a URL may fail. This update uses the filesystem to copy media rather than downloading it.

### Possible Drawbacks
None that I am aware of.

### Verification Process
Added some debugging code to save `dt_original_file_path` to post meta that is only updated when a file is copied successfully. Performed both multisite pushes and pulls to confirm the media is copied.

### Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.


### Applicable Issues
#380 

### Changelog Entry
* Use filesystem for copying media when doing a network pull/push instead of `download_url()`
