### PR TITLE
Redirect to pulled content tab after content is pulled via the settings

### DIFF
--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -253,7 +253,8 @@ function process_actions() {
 				setcookie( 'dt-duplicated', 1, time() + DAY_IN_SECONDS, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, is_ssl() );
 			}
 
-			wp_safe_redirect( wp_get_referer() );
+			// Redirect to the pulled content tab
+			wp_safe_redirect( add_query_arg( 'status', 'pulled', wp_get_referer() ) );
 			exit;
 		case 'bulk-skip':
 		case 'skip':

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -297,7 +297,8 @@ function process_actions() {
 
 			setcookie( 'dt-skipped', 1, time() + DAY_IN_SECONDS, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, is_ssl() );
 
-			wp_safe_redirect( wp_get_referer() );
+			// Redirect to the skipped content tab
+			wp_safe_redirect( add_query_arg( 'status', 'skipped', wp_get_referer() ) );
 			exit;
 	}
 }


### PR DESCRIPTION
Takes care of #504 

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Redirect to the pulled content tab after content is pulled via the Pull Content Dashboard page

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Benefits
The user will be taken to the Pulled Content page where in they will be able to view or edit the pulled content right after pulling it.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
If the user wants to pull more than a single post but does not use the bulk pull feature, then they may get annoyed that they would need to head back to the "New" tab. Although for multiple pulls, the bulk pull feature should be used instead.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Head over to Dashboard -> Distributor -> Pull Content
1. Identify any post to be pulled and hit the "Pull" action or bulk "Pull" more than a single post
1. Verify that you are now on the "Pull" tab which should have a list of the most recently pulled items

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
#504 

<!-- Enter any applicable Issues here -->

### Changelog Entry

- Changed - Once content is pulled successfully via the "Pull Content" settings page, it redirects over to the "Pull" tab of the page instead of remaining in the default "New" tab

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
