### PR TITLE
Fix an an undefined variable issue

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -655,10 +655,10 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		if ( ! empty( $response_headers['X-Distributor'] ) ) {
 			// We have Distributor on the other side
-			\Distributor\Subscriptions\create_subscription( $post_id, $remote_id, untrailingslashit( $this->base_url ), $signature );
+			\Distributor\Subscriptions\create_subscription( $post_id, $body_array['id'], untrailingslashit( $this->base_url ), $signature );
 		}
 
-		return $remote_id;
+		return $body_array['id'];
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

In #574, we removed a try/catch block in order to fix an issue where distribution didn't fully work and the post ID value is 0, instead of undefined. But within that try/catch block, we were setting a `$remote_id` variable that is then used twice after that.

Because that code was removed, that variable then becomes undefined when it is referenced later, causing issues. Items will still distribute correctly but the connection will not be fully set up, so updates will not be pushed through.

This PR fixes this issue.

### Alternate Designs

None

### Benefits

Fixes undefined variable PHP errors and ensures connections are set up properly.

### Possible Drawbacks

None

### Verification Process

1. Prior to this change, distribute a post to an external connection
2. Notice that the post was distributed successfully.
3. Try updating the post that was distributed
4. Notice updates were not pushed through
5. Check out this PR and run the same test, ensuring that updates happen now

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.