### PR TITLE
Fix some Gutenberg related issues

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -655,10 +655,10 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		if ( ! empty( $response_headers['X-Distributor'] ) ) {
 			// We have Distributor on the other side
-			\Distributor\Subscriptions\create_subscription( $post_id, $remote_id, untrailingslashit( $this->base_url ), $signature );
+			\Distributor\Subscriptions\create_subscription( $post_id, $body_array['id'], untrailingslashit( $this->base_url ), $signature );
 		}
 
-		return $remote_id;
+		return $body_array['id'];
 	}
 
 	/**

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -655,10 +655,10 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		if ( ! empty( $response_headers['X-Distributor'] ) ) {
 			// We have Distributor on the other side
-			\Distributor\Subscriptions\create_subscription( $post_id, $body_array['id'], untrailingslashit( $this->base_url ), $signature );
+			\Distributor\Subscriptions\create_subscription( $post_id, $remote_id, untrailingslashit( $this->base_url ), $signature );
 		}
 
-		return $body_array['id'];
+		return $remote_id;
 	}
 
 	/**

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -594,6 +594,7 @@ class NetworkSiteConnection extends Connection {
 	public static function update_syndicated( $post ) {
 		$post    = get_post( $post );
 		$post_id = $post->ID;
+
 		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || wp_is_post_revision( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -43,9 +43,26 @@ function is_using_gutenberg( $post ) {
 		return false;
 	}
 
+	$post = get_post( $post );
+
+	if ( ! $post ) {
+		return false;
+	}
+
 	if ( ! empty( $post->post_content ) ) {
-		if ( function_exists( 'use_block_editor_for_post' ) && ! isset( $_GET['meta-box-loader'] ) ) {
-			return use_block_editor_for_post( $post );
+		// This duplicates the check from `use_block_editor_for_post()` as of WP 5.0.
+		// We duplicate this here to remove the $_GET['meta-box-loader'] check
+		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+			// The posts page can't be edited in the block editor.
+			if ( absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
+				return false;
+			}
+
+			// Make sure this post type supports Gutenberg
+			$use_block_editor = use_block_editor_for_post_type( $post->post_type );
+
+			/** This filter is documented in wp-admin/includes/post.php */
+			return apply_filters( 'use_block_editor_for_post', $use_block_editor, $post );
 		}
 
 		// This duplicates the check from `has_blocks()` as of WP 5.2.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -44,7 +44,7 @@ function is_using_gutenberg( $post ) {
 	}
 
 	if ( ! empty( $post->post_content ) ) {
-		if ( function_exists( 'use_block_editor_for_post' ) ) {
+		if ( function_exists( 'use_block_editor_for_post' ) && ! isset( $_GET['meta-box-loader'] ) ) {
 			return use_block_editor_for_post( $post );
 		}
 


### PR DESCRIPTION
### Description of the Change

In #518, we added a check for Internal/Network connections, that when sending updates for Gutenberg posts, we run those updates on a later hook, to ensure all data is sent properly (as the REST API saves some things after the `save_post` hook we were using).

We never brought those same changes over to External connections, so this PR brings that same code to there. If using Gutenberg and we are in the `save_post` action, we utilize the `rest_after_insert_{$post->post_type}` hook instead, to ensure things like featured images and term information have been saved before we send updates.

In addition, as noted in #561, we have an issue where Gutenberg content will distribute correctly but when updates are pushed, all content will get put into a Classic block. The issue happens when you have custom meta boxes, Gutenberg will fire two save events: one for the actual post, one to save the custom meta. The first save request works fine but the second request will not correctly see our post as using Gutenberg, so the rendered content is distributed, not the raw content.

The issue lies within the core `use_block_editor_for_post` function we use. Within that, it checks for the existence of the `$_GET['meta-box-loader']` variable. If that exists (which it always will when custom meta boxes are being saved), it will always return `false`, which we assume that means the post isn't using Gutenberg. For now, I've added a check within our own `is_using_gutenberg` function, to bypass using `use_block_editor_for_post` if `$_GET['meta-box-loader']` is set.

### Alternate Designs

There are other ways to check if an item is using Gutenberg. I went with the most simple approach here but one of the other approaches might be better. One I had thought of but didn't take was duplicating the core `use_block_editor_for_post` function and removing the part that was failing, instead of bypassing that function all together.

### Benefits

Updates made to items that have already been distributed to external connections should now properly distribute those updates, including featured image and term information.

Also, updates made to Gutenberg items, for both internal and external connections, should now properly distribute the block information, instead of putting everything into a Classic block. 

### Possible Drawbacks

For the first change, none. For the change made to our `is_using_gutenberg` function, I don't think there are any but we are slightly changing how we detect Gutenberg posts, so there could be some unintentional impact there.

### Verification Process

1. Push a post to an external connection
2. Update the featured image of that post
3. Ensure that change was updated on the external site

1. Create a Gutenberg post and push to a connection
2. Update that post
3. Ensure that the syndicated item still retains block information

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#561

