### PR TITLE
Ensure there isn't a trailing slash on the REST URL before we break t…

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -440,7 +440,7 @@ function menu_button( $wp_admin_bar ) {
  * @return string Site URL.
  */
 function get_site_url_from_rest_url( $rest_url ) {
-	$_url = explode( '/', $rest_url );
+	$_url = explode( '/', untrailingslashit( $rest_url ) );
 
 	if ( count( $_url ) < 2 ) {
 		return $rest_url;


### PR DESCRIPTION
### Description of the Change

Ensure there isn't a trailing slash on the REST URL before we break that URL into it's various pieces, in our `get_site_url_from_rest_url` function.

Fixes #585

### Benefits

View links for external connections will be correct if that external connection is set up with a trailing slash

### Possible Drawbacks

None

### Verification Process

1. Created a new external connection with a trailing slash
2. Pushed a post to this connection
3. Verified the View link pointed to the REST URL (i.e. example.com/wp-json/?p=10)
4. Added the fixes here and tested again
5. Verified the View link pointed to the FE URL (i.e. example.com/?p=10)

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#585
