### PR TITLE
Style and UX fixes for push UI

### DIFF
--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -65,12 +65,17 @@
 
 #wpadminbar #distributor-push-wrapper .new-connections-list {
 	border: 1px solid var(--borderColor);
-	max-height: 125px;
+	max-height: 155px;
 	overflow: auto;
+
+	& .no-results {
+		margin: 0 !important;
+		padding: 0.5em;
+	}
 }
 
 #wpadminbar #distributor-push-wrapper .selected-connections-list {
-	margin-bottom: 1em;
+	margin-bottom: 0.5em;
 	max-height: 145px;
 	overflow: auto;
 }
@@ -223,6 +228,7 @@
 
 	&.selectall-connections {
 		margin-top: .5em;
+		margin-bottom: -10px; /* compensation for margin above messages div to reduce jumping */
 	}
 }
 

--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -95,13 +95,15 @@
 		display: none;
 	}
 }
-#wpadminbar #distributor-push-wrapper .selectall-connections.unavailable,
-#wpadminbar #distributor-push-wrapper .selectno-connections.unavailable {
-	opacity: .5;
+
+#wpadminbar #distributor-push-wrapper .connections-selected button.selectno-connections {
+	margin-left: 10px;
 }
+
 #wpadminbar #distributor-push-wrapper .connections-selected label {
 	color: inherit;
 }
+
 #wpadminbar #distributor-push-wrapper .connections-selected input[type="checkbox"] {
 	vertical-align: middle;
 	margin-right: 2px;
@@ -170,9 +172,9 @@
 #wpadminbar #distributor-push-wrapper input[type=text] {
 	font-size: inherit;
 	padding: 0.5278em;
-    width: 96%;
+    width: calc( 100% - 1.0556em - 2px );
 	background-color: var(--backgroundColor);
-	border: 3px solid var(--borderColor);
+	border: 2px solid var(--borderColor);
 	color: var(--fontColor);
 	margin-bottom: .5em;
 
@@ -183,17 +185,45 @@
 	&:focus {
 		color: var(--fontColor);
 		background-color: var(--backgroundColor);
-		border: 2px solid var(--borderColor);
+		border-color: color(var(--fontColor) blackness(50%));
 	}
 }
 
 #wpadminbar #distributor-push-wrapper button {
-	padding: 0 10px;
+	padding: .5em 1em;
 	border-radius: 3px;
-}
 
-#wpadminbar #distributor-push-wrapper .selectall-connections {
-	margin-bottom: 1em;
+	&.button-link {
+		margin: 0;
+		padding: 0;
+		box-shadow: none;
+		border: 0;
+		border-radius: 0;
+		background: none;
+		cursor: pointer;
+		text-align: left;
+		/* Mimics the default link style in common.css but brighter due to dark bg */
+		color: #00a0d2;
+		text-decoration: underline;
+		transition-property: border, background, color;
+		transition-duration: .05s;
+		transition-timing-function: ease-in-out;
+
+		&:hover {
+			color: #fff;
+			text-decoration: none;
+		}
+	}
+
+	/* avoid being overridden by themes, darker than admin due to dark bg */
+	&.button-primary:hover {
+		background-color: #005b85;
+		border-color: #005b85;
+	}
+
+	&.selectall-connections {
+		margin-top: .5em;
+	}
 }
 
 #wpadminbar #distributor-push-wrapper .new-connections-list > .add-connection:nth-child(odd) {
@@ -204,6 +234,7 @@
 #wpadminbar #distributor-push-wrapper .added-connection {
 	background-color: transparent;
 	border: 0;
+	border-radius: 0;
 	box-shadow: none;
 	display: block;
 	width: 100%;
@@ -218,28 +249,46 @@
 		outline: 2px solid transparent;
 		outline-offset: 0;
 	}
+
+	&:hover {
+		text-decoration: underline;
+	}
 }
 
 #wpadminbar #distributor-push-wrapper .new-connections-list .add-connection.added {
-	background-color: color(var(--backgroundColor) lightness(25%));
+	background-color: color(var(--backgroundColor) lightness(40%));
 }
 
 #wpadminbar #distributor-push-wrapper .add-connection.syndicated {
 	cursor: not-allowed;
-}
 
-#wpadminbar #distributor-push-wrapper .add-connection.syndicated span {
-	color: var(--borderColor);
-}
+	&:after {
+		content: "\f147";
+		font-family: dashicons;
+		color: var(--borderColor);
+	}
 
-#wpadminbar #distributor-push-wrapper .add-connection.syndicated a {
-	color: inherit;
-	text-decoration: underline;
-	float: right;
-	height: auto;
+	&:hover {
+		text-decoration: none;
+	}
 
-	&:focus {
-		box-shadow: inset 0 0 0 1px #fff;
+	& span {
+		color: var(--borderColor);
+	}
+
+	& a {
+		color: inherit;
+		text-decoration: underline;
+		float: right;
+		height: auto;
+	
+		&:focus {
+			box-shadow: inset 0 0 0 1px #fff;
+		}
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 }
 
@@ -248,6 +297,14 @@
 	margin-bottom: .5em;
 	cursor: normal;
 	position: relative;
+
+	&:hover {
+		text-decoration: none;
+
+		& .remove-connection:after {
+			color: #f00;
+		}
+	}
 
 	& .remove-connection {
 		cursor: pointer;
@@ -258,7 +315,7 @@
 		line-height: 19px;
 		vertical-align: middle;
 		margin-left: 6px;
-   		position: relative;
+		position: relative;
 	}
 
 	& .remove-connection:after {

--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -197,6 +197,7 @@
 #wpadminbar #distributor-push-wrapper button {
 	padding: .5em 1em;
 	border-radius: 3px;
+	min-height: 0;
 
 	&.button-link {
 		margin: 0;

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -152,6 +152,10 @@ jQuery( window ).on( 'load', () => {
 
 			connectionsNewList.innerHTML += showConnection;
 		} );
+
+		if ( '' === connectionsNewList.innerHTML ) {
+			connectionsNewList.innerHTML = '<p class="no-results">No results</p>';
+		}
 	}
 
 	/**

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -339,7 +339,7 @@ function ajax_push() {
 					'time'    => time(),
 				);
 
-				$internal_push_results[ (int) $connection['id']  ] = array(
+				$internal_push_results[ (int) $connection['id'] ] = array(
 					'post_id' => (int) $remote_id,
 					'url'     => esc_url_raw( $remote_url ),
 					'date'    => date( 'F j, Y g:i a' ),

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -506,12 +506,9 @@ function menu_content() {
 
 				<div class="connections-selector">
 					<div>
-						<button class="button button-primary selectall-connections unavailable"><?php esc_html_e( 'Select All', 'distributor' ); ?></button>
-						<button class="button button-secondary selectno-connections unavailable"><?php esc_html_e( 'None', 'distributor' ); ?></button>
 						<# if ( 5 < _.keys( connections ).length ) { #>
 							<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
 						<# } #>
-
 						<div class="new-connections-list">
 							<# for ( var key in connections ) { #>
 								<button
@@ -532,11 +529,14 @@ function menu_content() {
 							<# } #>
 						</div>
 
+						<button class="button button-primary selectall-connections unavailable"><?php esc_html_e( 'Select All', 'distributor' ); ?></button>
+
 					</div>
 				</div>
 				<div class="connections-selected empty">
 					<header class="with-selected">
 						<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
+						<button class="button button-link selectno-connections unavailable"><?php esc_html_e( 'Clear', 'distributor' ); ?></button>
 					</header>
 					<header class="no-selected">
 						<?php esc_html_e( 'No connections selected', 'distributor' ); ?>


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Polishing style and UX bits for the push UI after adding `Select All` button.

I currently have 3 things left on my list of nice-to-have items for this PR:
- [x] Better no search results state (currently shows empty box with collapsed border, should probably show a "No results" item in the box)
- [ ] Show the number of selected connections - this needs i18n consideration in whatever string, easier to just put the count in parens rather than trying to pluralize
- [x] ~Add some kind of subtle indicator that a list can be scrolled, this tripped me up a few times. [Example](https://css-scroll-shadows.now.sh/?bgColor=8680ce&shadowColor=222222&pxSize=15)~ Can't use this method due to background colors, haven't found anything else, skipping for now

#### Before
![Screen Shot 2020-06-08 at 8 15 15 PM](https://user-images.githubusercontent.com/906334/84098558-c9a5ec80-a9c4-11ea-903a-eedb2129643e.png)

#### After
![Screen Shot 2020-06-08 at 8 08 54 PM](https://user-images.githubusercontent.com/906334/84098565-ce6aa080-a9c4-11ea-94c7-6841d11c1d44.png)

### Alternate Designs

n/a

### Benefits

A UI that's easier to understand.

### Possible Drawbacks

Not sure.

### Verification Process

Local testing with various states (search, selection, distributed, clearing). I also tested keyboard nav which looks fine to me.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #577 

### Changelog Entry

Needs.