### PR TITLE
Fix: Auth Wizard not properly handling enter key actions

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -9,7 +9,7 @@ import {
 import compareVersions from 'compare-versions';
 import wp from 'wp';
 
-const [ externalConnectionUrlField ]  = document.getElementsByClassName( 'external-connection-url-field' );
+const externalConnectionUrlField      = document.getElementById( 'dt_external_connection_url' );
 const externalConnectionMetaBox       = document.getElementById( 'dt_external_connection_details' );
 const [ externalConnectionTypeField ] = document.getElementsByClassName( 'external-connection-type-field' );
 const authFields                      = document.getElementsByClassName( 'auth-field' );
@@ -289,7 +289,17 @@ jQuery( externalConnectionMetaBox ).on( 'click', '.suggest', ( event ) => {
 	jQuery( externalConnectionUrlField ).trigger( 'input' );
 } );
 
-jQuery( externalConnectionMetaBox ).on( 'keyup input', '.auth-field, .external-connection-url-field', _.debounce( checkConnections, 250 ) );
+jQuery( externalConnectionUrlField ).on( 'focus click', event => {
+	event.target.setAttribute( 'initial-url', event.target.value );
+} );
+
+jQuery( externalConnectionUrlField ).on( 'blur', event => {
+	if ( event.target.value.replace( /\/$/, '' ) === event.target.getAttribute( 'initial-url' ).replace( /\/$/, '' ) ) {
+		return;
+	}
+
+	checkConnections();
+} );
 
 jQuery( externalConnectionUrlField ).on( 'blur', ( event ) => {
 	if ( '' === titleField.value && '' !== event.currentTarget.value ) {
@@ -306,10 +316,12 @@ jQuery( externalConnectionUrlField ).on( 'blur', ( event ) => {
 const passwordField   = document.getElementById( 'dt_password' );
 const usernameField   = document.getElementById( 'dt_username' );
 const changePassword  = document.querySelector( '.change-password' );
-const initialUsername = usernameField.value;
 
+jQuery( usernameField ).on( 'focus click', event => {
+	event.target.setAttribute( 'initial-username', event.target.value );
+} );
 jQuery( usernameField ).on( 'blur', event => {
-	if ( initialUsername == event.target.value ) {
+	if ( event.target.getAttribute( 'initial-username' ) === event.target.value ) {
 		return;
 	}
 	if ( changePassword ) {

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -326,8 +326,8 @@ jQuery( usernameField ).on( 'focus click', event => {
 	event.target.setAttribute( 'initial-username', event.target.value );
 } );
 
-jQuery( usernameField ).on( 'blur', event => {
-	if ( event.target.getAttribute( 'initial-username' ) === event.target.value ) {
+jQuery( usernameField ).on( 'keyup input', _.debounce( () => {
+	if ( usernameField.getAttribute( 'initial-username' ) === usernameField.value ) {
 		return;
 	}
 	if ( changePassword ) {
@@ -335,7 +335,11 @@ jQuery( usernameField ).on( 'blur', event => {
 		passwordField.value = '';
 		changePassword.style.display = 'none';
 	}
-} );
+}, 250 ) );
+
+jQuery( passwordField ).on( 'keyup input', _.debounce( () => {
+	checkConnections();
+}, 250 ) );
 
 jQuery( changePassword ).on( 'click', ( event ) => {
 	event.preventDefault();

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -9,6 +9,7 @@ import {
 import compareVersions from 'compare-versions';
 import wp from 'wp';
 
+const [ body ]                    = document.getElementsByTagName( 'body' );
 const externalConnectionUrlField  = document.getElementById( 'dt_external_connection_url' );
 const externalConnectionMetaBox   = document.getElementById( 'dt_external_connection_details' );
 const externalConnectionTypeField = document.getElementById( 'dt_external_connection_type' );
@@ -23,6 +24,7 @@ const wpbody                      = document.getElementById( 'wpbody' );
 const externalSiteUrlField        = document.getElementById( 'dt_external_site_url' );
 const wizardError                 = document.getElementsByClassName( 'dt-wizard-error' );
 const authorizeConnectionButton   = document.getElementsByClassName( 'establish-connection-button' );
+const beginOauthConnectionButton  = document.getElementById( 'begin-authorization' );
 const createOauthConnectionButton = document.getElementById( 'create-oauth-connection' );
 const manualSetupButton           = document.getElementsByClassName( 'manual-setup-button' );
 let $apiVerify                    = false;
@@ -32,7 +34,7 @@ wpbody.className                  = slug;
 
 // Prevent the `enter` key from submitting the form.
 jQuery( '#post' ).on( 'keypress', function ( event ) {
-	if ( 13 != event.which || wpbody.classList.contains( 'post-php' ) ) {
+	if ( 13 != event.which || body.classList.contains( 'post-php' ) ) {
 		return true;
 	}
 
@@ -41,7 +43,8 @@ jQuery( '#post' ).on( 'keypress', function ( event ) {
 	}
 
 	if ( 'wpdotcom' === jQuery( externalConnectionTypeField ).val() ) {
-		jQuery( createOauthConnectionButton ).trigger( 'click' );
+		! isHidden( beginOauthConnectionButton ) && jQuery( beginOauthConnectionButton ).trigger( 'click' );
+		! isHidden( createOauthConnectionButton ) && jQuery( createOauthConnectionButton ).trigger( 'click' );
 	}
 
 	return false;
@@ -508,4 +511,12 @@ if ( beginAuthorize ) {
 			} );
 		}
 	} );
+}
+
+/**
+ * Check if an element is hidden or not.
+ * @param {*} el Element to check.
+ */
+function isHidden( el ) {
+	return ( null === el.offsetParent );
 }

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -318,13 +318,14 @@ jQuery( externalConnectionUrlField ).on( 'blur', ( event ) => {
  *
  * @todo  separate
  */
-const passwordField   = document.getElementById( 'dt_password' );
-const usernameField   = document.getElementById( 'dt_username' );
-const changePassword  = document.querySelector( '.change-password' );
+const passwordField  = document.getElementById( 'dt_password' );
+const usernameField  = document.getElementById( 'dt_username' );
+const changePassword = document.querySelector( '.change-password' );
 
 jQuery( usernameField ).on( 'focus click', event => {
 	event.target.setAttribute( 'initial-username', event.target.value );
 } );
+
 jQuery( usernameField ).on( 'blur', event => {
 	if ( event.target.getAttribute( 'initial-username' ) === event.target.value ) {
 		return;

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -303,17 +303,21 @@ jQuery( externalConnectionUrlField ).on( 'blur', ( event ) => {
  *
  * @todo  separate
  */
-const passwordField  = document.getElementById( 'dt_password' );
-const usernameField  = document.getElementById( 'dt_username' );
-const changePassword = document.querySelector( '.change-password' );
+const passwordField   = document.getElementById( 'dt_password' );
+const usernameField   = document.getElementById( 'dt_username' );
+const changePassword  = document.querySelector( '.change-password' );
+const initialUsername = usernameField.value;
 
-jQuery( usernameField ).on( 'keyup change', _.debounce( () => {
+jQuery( usernameField ).on( 'blur', event => {
+	if ( initialUsername == event.target.value ) {
+		return;
+	}
 	if ( changePassword ) {
-		passwordField.disabled       = false;
-		passwordField.value          = '';
+		passwordField.disabled = false;
+		passwordField.value = '';
 		changePassword.style.display = 'none';
 	}
-}, 250 ) );
+} );
 
 jQuery( changePassword ).on( 'click', ( event ) => {
 	event.preventDefault();

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -38,6 +38,15 @@ jQuery( '#post' ).on( 'keypress', function ( e ) {
 } );
 
 /**
+ * Handle pressing enter key on site URL field.
+ */
+jQuery( externalSiteUrlField ).on( 'keypress', function( event ) {
+	if ( 13 === event.which ) {
+		jQuery( authorizeConnectionButton ).trigger( 'click' );
+	}
+} );
+
+/**
  * Handle Setup Connection Wizard "Authorize Connection" button.
  */
 jQuery( authorizeConnectionButton ).on( 'click', ( event ) => {

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -9,41 +9,42 @@ import {
 import compareVersions from 'compare-versions';
 import wp from 'wp';
 
-const externalConnectionUrlField      = document.getElementById( 'dt_external_connection_url' );
-const externalConnectionMetaBox       = document.getElementById( 'dt_external_connection_details' );
-const [ externalConnectionTypeField ] = document.getElementsByClassName( 'external-connection-type-field' );
-const authFields                      = document.getElementsByClassName( 'auth-field' );
-const rolesAllowed                    = document.getElementsByClassName( 'dt-roles-allowed' );
-const titleField                      = document.getElementById( 'title' );
-const endpointResult                  = document.querySelector( '.endpoint-result' );
-const endpointErrors                  = document.querySelector( '.endpoint-errors' );
-const postIdField                     = document.getElementById( 'post_ID' );
-const createConnection                = document.getElementById( 'create-connection' );
-const wpbody                          = document.getElementById( 'wpbody' );
-const externalSiteUrlField            = document.getElementById( 'dt_external_site_url' );
-const wizardError                     = document.getElementsByClassName( 'dt-wizard-error' );
-const authorizeConnectionButton       = document.getElementsByClassName( 'establish-connection-button' );
-const manualSetupButton               = document.getElementsByClassName( 'manual-setup-button' );
-let $apiVerify                        = false;
-const titlePrompt                     = document.getElementById( '#title-prompt-text' );
-const slug                            = externalConnectionTypeField.value;
-wpbody.className                      = slug;
+const externalConnectionUrlField  = document.getElementById( 'dt_external_connection_url' );
+const externalConnectionMetaBox   = document.getElementById( 'dt_external_connection_details' );
+const externalConnectionTypeField = document.getElementById( 'dt_external_connection_type' );
+const authFields                  = document.getElementsByClassName( 'auth-field' );
+const rolesAllowed                = document.getElementsByClassName( 'dt-roles-allowed' );
+const titleField                  = document.getElementById( 'title' );
+const endpointResult              = document.querySelector( '.endpoint-result' );
+const endpointErrors              = document.querySelector( '.endpoint-errors' );
+const postIdField                 = document.getElementById( 'post_ID' );
+const createConnection            = document.getElementById( 'create-connection' );
+const wpbody                      = document.getElementById( 'wpbody' );
+const externalSiteUrlField        = document.getElementById( 'dt_external_site_url' );
+const wizardError                 = document.getElementsByClassName( 'dt-wizard-error' );
+const authorizeConnectionButton   = document.getElementsByClassName( 'establish-connection-button' );
+const createOauthConnectionButton = document.getElementById( 'create-oauth-connection' );
+const manualSetupButton           = document.getElementsByClassName( 'manual-setup-button' );
+let $apiVerify                    = false;
+const titlePrompt                 = document.getElementById( '#title-prompt-text' );
+const slug                        = externalConnectionTypeField.value;
+wpbody.className                  = slug;
 
 // Prevent the `enter` key from submitting the form.
-jQuery( '#post' ).on( 'keypress', function ( e ) {
-	if ( 13 === e.which ) {
-		return false;
+jQuery( '#post' ).on( 'keypress', function ( event ) {
+	if ( 13 != event.which || wpbody.classList.contains( 'post-php' ) ) {
+		return true;
 	}
-	return true;
-} );
 
-/**
- * Handle pressing enter key on site URL field.
- */
-jQuery( externalSiteUrlField ).on( 'keypress', function( event ) {
-	if ( 13 === event.which ) {
+	if ( 'wp' === jQuery( externalConnectionTypeField ).val() ) {
 		jQuery( authorizeConnectionButton ).trigger( 'click' );
 	}
+
+	if ( 'wpdotcom' === jQuery( externalConnectionTypeField ).val() ) {
+		jQuery( createOauthConnectionButton ).trigger( 'click' );
+	}
+
+	return false;
 } );
 
 /**
@@ -293,13 +294,14 @@ jQuery( externalConnectionUrlField ).on( 'focus click', event => {
 	event.target.setAttribute( 'initial-url', event.target.value );
 } );
 
-jQuery( externalConnectionUrlField ).on( 'blur', event => {
-	if ( event.target.value.replace( /\/$/, '' ) === event.target.getAttribute( 'initial-url' ).replace( /\/$/, '' ) ) {
+jQuery( externalConnectionUrlField ).on( 'keyup input', _.debounce( () => {
+	if ( externalConnectionUrlField.value.replace( /\/$/, '' ) === externalConnectionUrlField.getAttribute( 'initial-url' ).replace( /\/$/, '' ) ) {
 		return;
 	}
 
+	externalConnectionUrlField.setAttribute( 'initial-url', externalConnectionUrlField.value );
 	checkConnections();
-} );
+}, 250 ) );
 
 jQuery( externalConnectionUrlField ).on( 'blur', ( event ) => {
 	if ( '' === titleField.value && '' !== event.currentTarget.value ) {
@@ -417,9 +419,8 @@ if ( 'wpdotcom' === externalConnectionTypeField.value ) {
 }
 
 // When authorization is initiated, ensure fields are non-empty.
-const createConnectionButton = document.getElementById( 'create-oauth-connection' );
-if ( createConnectionButton ) {
-	jQuery( createConnectionButton ).on( 'click', ( event ) => {
+if ( createOauthConnectionButton ) {
+	jQuery( createOauthConnectionButton ).on( 'click', ( event ) => {
 		const validateClientSecret = validateField( $clientSecret, event ),
 			validateClientId       = validateField( $clientId, event );
 		if (


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes/implements the following behavior:
- Trigger click event of Authorize Connection button when press enter key on External connection site URL field.
- When editing an external connection, the submit action is updating the action, not starting the auth process.
- For .com apps, the enter key needs to submit the client ID/secret and start that auth process.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/distributor/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

