### PR TITLE
Fix: Test against WP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       name: "wp-acceptance: WordPress 5.1"
     - script: travis_retry bash run-wpacceptance.sh fec81ac24227af6554c93d28d9af2bdf
       name: "wp-acceptance: WordPress 5.1 plus Gutenberg 5.3"
-    - script: travis_retry bash run-wpacceptance.sh 713d9d61ec505f51fafc7bb6f8b08839
+    - script: travis_retry bash run-wpacceptance.sh 803989004f4b101a644ebfe9bb67e712
       name: "wp-acceptance: WordPress 5.4.2"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       name: "wp-acceptance: WordPress 5.1"
     - script: travis_retry bash run-wpacceptance.sh fec81ac24227af6554c93d28d9af2bdf
       name: "wp-acceptance: WordPress 5.1 plus Gutenberg 5.3"
+    - script: travis_retry bash run-wpacceptance.sh 713d9d61ec505f51fafc7bb6f8b08839
+      name: "wp-acceptance: WordPress 5.4.2"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Distributor is a WordPress plugin that makes it easy to distribute and reuse content across your websites — whether in a single multisite or across the web.
 
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/distributor.svg?branch=master)](https://travis-ci.org/10up/distributor)
-[![Release Version](https://img.shields.io/github/release/10up/distributor.svg)](https://github.com/10up/distributor/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/distributor.svg)](https://github.com/10up/distributor/blob/develop/LICENSE.md)
+[![Release Version](https://img.shields.io/github/release/10up/distributor.svg)](https://github.com/10up/distributor/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.4.2%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/distributor.svg)](https://github.com/10up/distributor/blob/develop/LICENSE.md)
 
 *You can learn more about Distributor's features at [DistributorPlugin.com](https://distributorplugin.com).*
 

--- a/includes/classes/Authentication.php
+++ b/includes/classes/Authentication.php
@@ -133,7 +133,7 @@ abstract class Authentication {
 			}
 		);
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$time = date( '[d/M/Y:H:i:s]' );
+			$time = gmdate( '[d/M/Y:H:i:s]' );
 			// @codingStandardsIgnoreLine - error_log is only used when WP_DEBUG is true.
 			error_log( $time . ': ' . $error_message );
 		}

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -192,7 +192,7 @@ class PullListTable extends \WP_List_Table {
 						/* translators: %s: a human readable time */
 						$h_time = sprintf( esc_html__( '%s ago', 'distributor' ), human_time_diff( $syndicated_at ) );
 					} else {
-						$h_time = date( 'F j, Y', $syndicated_at );
+						$h_time = gmdate( 'F j, Y', $syndicated_at );
 					}
 
 					/* translators: %s: time of pull */
@@ -380,7 +380,7 @@ class PullListTable extends \WP_List_Table {
 		$remote_get_args = [
 			'posts_per_page' => $per_page,
 			'paged'          => $current_page,
-			'post_type'      => $connection_now->pull_post_type ?: 'post',
+			'post_type'      => $connection_now->pull_post_type ? $connection_now->pull_post_type : 'post',
 			'orderby'        => 'ID', // this is because of include/exclude truncation
 			'order'          => 'DESC', // default but specifying to be safe
 		];

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -84,7 +84,7 @@ function output_status_column( $column_name, $post_id ) {
 			class="connection-status <?php echo esc_attr( $status ); ?>"
 			<?php if ( ! empty( $last_checked ) ) : ?>
 				<?php /* translators: %s: human readable time difference */ ?>
-				title="<?php printf( esc_html__( 'Last Checked on %s' ), esc_html( date( 'F j, Y, g:i a', ( $last_checked + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ) ); ?>"
+				title="<?php printf( esc_html__( 'Last Checked on %s' ), esc_html( gmdate( 'F j, Y, g:i a', ( $last_checked + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ) ); ?>"
 			<?php endif; ?>
 		></span>
 		<a href="<?php echo esc_url( get_edit_post_link( $post_id ) ); ?>"><?php esc_html_e( '(Verify)', 'distributor' ); ?></a>

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -292,7 +292,7 @@ function ajax_push() {
 
 					$external_push_results[ (int) $connection['id'] ] = array(
 						'post_id' => (int) $remote_id,
-						'date'    => date( 'F j, Y g:i a' ),
+						'date'    => gmdate( 'F j, Y g:i a' ),
 						'status'  => 'success',
 						'url'     => sprintf(
 							'%1$s/?p=%2$d',
@@ -305,7 +305,7 @@ function ajax_push() {
 				} else {
 					$external_push_results[ (int) $connection['id'] ] = array(
 						'post_id' => (int) $remote_id,
-						'date'    => date( 'F j, Y g:i a' ),
+						'date'    => gmdate( 'F j, Y g:i a' ),
 						'status'  => 'fail',
 					);
 				}
@@ -342,13 +342,13 @@ function ajax_push() {
 				$internal_push_results[ (int) $connection['id'] ] = array(
 					'post_id' => (int) $remote_id,
 					'url'     => esc_url_raw( $remote_url ),
-					'date'    => date( 'F j, Y g:i a' ),
+					'date'    => gmdate( 'F j, Y g:i a' ),
 					'status'  => 'success',
 				);
 			} else {
 				$internal_push_results[ (int) $connection['id'] ] = array(
 					'post_id' => (int) $remote_id,
-					'date'    => date( 'F j, Y g:i a' ),
+					'date'    => gmdate( 'F j, Y g:i a' ),
 					'status'  => 'fail',
 				);
 			}

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -194,7 +194,7 @@ function syndication_date( $post ) {
 	?>
 
 	<div class="misc-pub-section curtime misc-pub-curtime">
-		<span id="syndicate-time"><?php esc_html_e( 'Distributed on: ', 'distributor' ); ?><strong><?php echo esc_html( date( 'M j, Y @ h:i', ( $syndicate_time + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ); ?></strong></span>
+		<span id="syndicate-time"><?php esc_html_e( 'Distributed on: ', 'distributor' ); ?><strong><?php echo esc_html( gmdate( 'M j, Y @ h:i', ( $syndicate_time + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ); ?></strong></span>
 	</div>
 
 	<?php
@@ -580,7 +580,7 @@ function enqueue_gutenberg_edit_scripts() {
 			'postTypeSingular'     => sanitize_text_field( $post_type_singular ),
 			'postUrl'              => sanitize_text_field( $post_url ),
 			'originalSiteName'     => sanitize_text_field( $original_site_name ),
-			'syndicationTime'      => ( ! empty( $syndication_time ) ) ? esc_html( date( 'M j, Y @ h:i', ( $syndication_time + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ) : 0,
+			'syndicationTime'      => ( ! empty( $syndication_time ) ) ? esc_html( gmdate( 'M j, Y @ h:i', ( $syndication_time + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) ) ) ) : 0,
 			'syndicationCount'     => $total_connections,
 			'originalLocationName' => sanitize_text_field( $original_location_name ),
 			'unlinkNonceUrl'       => wp_nonce_url( add_query_arg( 'action', 'unlink', admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) ) ), "unlink-post_{$post->ID}" ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: 10up
 Tags: content, distribution, syndication, management,
 Requires at least: 4.7
-Tested up to: 5.3
+Tested up to: 5.4.2
 Requires PHP: 5.6
 Stable tag: 1.5.0
 License: GPLv2 or later

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -177,6 +177,23 @@ class SubscriptionsTest extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_send_notifications_none() {
+
+		$post = new \stdClass();
+		$post->ID = 1;
+
+		\WP_Mock::userFunction(
+			'get_post', [
+				'args'   => [ $post->ID ],
+				'return' => $post,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_is_post_revision', [
+				'return' => false,
+			]
+		);
+
 		\WP_Mock::userFunction(
 			'current_user_can', [
 				'return' => true,
@@ -197,7 +214,7 @@ class SubscriptionsTest extends TestCase {
 			]
 		);
 
-		Subscriptions\send_notifications( 1 );
+		Subscriptions\send_notifications( $post->ID );
 
 		$this->assertConditionsMet();
 	}
@@ -215,6 +232,13 @@ class SubscriptionsTest extends TestCase {
 		$remote_post_id       = 9;
 		$target_url           = 'http://target';
 		$signature            = 'signature';
+
+		$post               = new \stdClass();
+		$post->post_content = 'content';
+		$post->post_excerpt = 'excerpt';
+		$post->post_name    = 'slug';
+		$post->post_type    = 'post';
+		$post->ID           = $post_id;
 
 		\WP_Mock::userFunction(
 			'current_user_can', [
@@ -292,15 +316,7 @@ class SubscriptionsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'get_post', [
 				'args'   => [ $post_id ],
-				'return' => function() {
-					$post               = new \stdClass();
-					$post->post_content = 'content';
-					$post->post_excerpt = 'excerpt';
-					$post->post_name    = 'slug';
-					$post->post_type    = 'post';
-
-					return $post;
-				},
+				'return' => $post,
 			]
 		);
 
@@ -383,6 +399,13 @@ class SubscriptionsTest extends TestCase {
 		$target_url           = 'http://target';
 		$signature            = 'signature';
 
+		$post               = new \stdClass();
+		$post->post_content = 'content';
+		$post->post_excerpt = 'excerpt';
+		$post->post_name    = 'slug';
+		$post->post_type    = 'post';
+		$post->ID           = $post_id;
+
 		\WP_Mock::userFunction(
 			'current_user_can', [
 				'return' => true,
@@ -459,15 +482,7 @@ class SubscriptionsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'get_post', [
 				'args'   => [ $post_id ],
-				'return' => function() {
-					$post               = new \stdClass();
-					$post->post_content = 'content';
-					$post->post_excerpt = 'excerpt';
-					$post->post_name    = 'slug';
-					$post->post_type    = 'post';
-
-					return $post;
-				},
+				'return' => $post,
 			]
 		);
 

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -36,10 +36,10 @@ class BlocksTests extends \TestCase {
 		$I->jsClick( '.editor-post-publish-button' );
 
 		try {
-			$I->getElement( '.is-success' );
-			$I->waitUntilElementVisible( '.is-success' );
-		} catch( \Exception $e ) {
+			$I->getElement( '.components-editor-notices__snackbar' );
 			$I->waitUntilElementContainsText( 'Post updated', '.components-editor-notices__snackbar' );
+		} catch( \Exception $e ) {
+			$I->waitUntilElementVisible( '.is-success' );
 		}
 	}
 

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -14,6 +14,8 @@ class BlocksTests extends \TestCase {
 	public function addContentToTestPost( $I ) {
 		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
 
+		$I->refresh();
+
 		try {
 			$I->getElement( '.editor-default-block-appender__content' );
 			$I->waitUntilElementVisible( '.editor-default-block-appender__content' );
@@ -24,6 +26,7 @@ class BlocksTests extends \TestCase {
 		$this->disableFullscreenEditor( $I );
 
 		$this->dismissNUXTip( $I );
+
 		usleep( 500 );
 
 		try {
@@ -32,6 +35,7 @@ class BlocksTests extends \TestCase {
 		} catch( \Exception $e ) {
 			$I->getPage()->type( '.block-editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
 		}
+
 		$I->jsClick( '.editor-post-publish-button' );
 
 		try {
@@ -46,31 +50,6 @@ class BlocksTests extends \TestCase {
 	 * Test network pushing content with blocks.
 	 */
 	public function testBlocksNetworkPushedContent() {
-		$I = $this->openBrowserPage();
-
-		$I->loginAs( 'wpsnapshots' );
-		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
-
-		// Only test for the block editor.
-		if ( ! $this->editorHasBlocks( $I ) ) {
-			return;
-		}
-		$this->addContentToTestPost( $I );
-		$post_info = $this->pushPost( $I, 40, 2 );
-
-		// Now let's navigate to the new post
-		$I->moveTo( $post_info['distributed_edit_url'] );
-		$I->waitUntilElementVisible( '#wpadminbar' );
-
-		// Check that the blocks are intact by looking for the paragraph comment.
-		$source = $I->getPageSource();
-
-		$this->assertTrue(
-			(bool) preg_match( '<!-- wp:paragraph -->', stripslashes( $source ) ),
-			'Blocks were not pushed properly over an external connection'
-		);
-	}
-	public function testBlocksNetworkPushedContent2() {
 		$I = $this->openBrowserPage();
 
 		$I->loginAs( 'wpsnapshots' );

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -14,7 +14,13 @@ class BlocksTests extends \TestCase {
 	public function addContentToTestPost( $I ) {
 		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
 
-		sleep( 3 );
+		try {
+			$I->getElement( '.editor-default-block-appender__content' );
+			$I->waitUntilElementVisible( '.editor-default-block-appender__content' );
+		} catch( \Exception $e ) {
+			$I->waitUntilElementVisible( '.block-editor-default-block-appender__content' );
+		}
+		$I->jsClick( '.editor-post-publish-button' );
 
 		$this->disableFullscreenEditor( $I );
 
@@ -29,7 +35,12 @@ class BlocksTests extends \TestCase {
 		}
 		$I->jsClick( '.editor-post-publish-button' );
 
-		sleep( 3 );
+		try {
+			$I->getElement( '.is-success' );
+			$I->waitUntilElementVisible( '.is-success' );
+		} catch( \Exception $e ) {
+			$I->waitUntilElementContainsText( 'Post updated', '.components-editor-notices__snackbar' );
+		}
 	}
 
 	/**

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -20,7 +20,6 @@ class BlocksTests extends \TestCase {
 		} catch( \Exception $e ) {
 			$I->waitUntilElementVisible( '.block-editor-default-block-appender__content' );
 		}
-		$I->jsClick( '.editor-post-publish-button' );
 
 		$this->disableFullscreenEditor( $I );
 
@@ -47,6 +46,31 @@ class BlocksTests extends \TestCase {
 	 * Test network pushing content with blocks.
 	 */
 	public function testBlocksNetworkPushedContent() {
+		$I = $this->openBrowserPage();
+
+		$I->loginAs( 'wpsnapshots' );
+		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
+
+		// Only test for the block editor.
+		if ( ! $this->editorHasBlocks( $I ) ) {
+			return;
+		}
+		$this->addContentToTestPost( $I );
+		$post_info = $this->pushPost( $I, 40, 2 );
+
+		// Now let's navigate to the new post
+		$I->moveTo( $post_info['distributed_edit_url'] );
+		$I->waitUntilElementVisible( '#wpadminbar' );
+
+		// Check that the blocks are intact by looking for the paragraph comment.
+		$source = $I->getPageSource();
+
+		$this->assertTrue(
+			(bool) preg_match( '<!-- wp:paragraph -->', stripslashes( $source ) ),
+			'Blocks were not pushed properly over an external connection'
+		);
+	}
+	public function testBlocksNetworkPushedContent2() {
 		$I = $this->openBrowserPage();
 
 		$I->loginAs( 'wpsnapshots' );

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -22,9 +22,10 @@ class BlocksTests extends \TestCase {
 		usleep( 500 );
 
 		try {
-			$I->getPage()->type( '.block-editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
-		} catch( Exception $e ) {
+			$I->getElement( '.editor-default-block-appender__content' );
 			$I->getPage()->type( '.editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
+		} catch( \Exception $e ) {
+			$I->getPage()->type( '.block-editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
 		}
 		$I->jsClick( '.editor-post-publish-button' );
 

--- a/tests/wpacceptance/BlocksTest.php
+++ b/tests/wpacceptance/BlocksTest.php
@@ -14,16 +14,21 @@ class BlocksTests extends \TestCase {
 	public function addContentToTestPost( $I ) {
 		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
 
-		$I->waitUntilElementVisible( '.editor-default-block-appender__content' );
+		sleep( 3 );
+
+		$this->disableFullscreenEditor( $I );
 
 		$this->dismissNUXTip( $I );
 		usleep( 500 );
 
-		$I->getPage()->type(  '.editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
+		try {
+			$I->getPage()->type( '.block-editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
+		} catch( Exception $e ) {
+			$I->getPage()->type( '.editor-default-block-appender__content', 'Lorem ipsum dolor sit amet.', [ 'delay' => 10 ] );
+		}
 		$I->jsClick( '.editor-post-publish-button' );
 
-		$I->waitUntilElementVisible( '.is-success' );
-
+		sleep( 3 );
 	}
 
 	/**

--- a/tests/wpacceptance/EditorBlocksTest.php
+++ b/tests/wpacceptance/EditorBlocksTest.php
@@ -9,12 +9,10 @@
  * PHPUnit test class.
  */
 
-class BlocksTests extends \TestCase {
+class EditorBlocksTests extends \TestCase {
 
 	public function addContentToTestPost( $I ) {
 		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
-
-		$I->refresh();
 
 		try {
 			$I->getElement( '.editor-default-block-appender__content' );

--- a/tests/wpacceptance/InternalPushTest.php
+++ b/tests/wpacceptance/InternalPushTest.php
@@ -58,6 +58,8 @@ class InternalPushTest extends \TestCase {
 
 		$I->moveTo( '/wp-admin/post.php?post=40&action=edit' );
 
+		$this->disableFullscreenEditor( $I );
+
 		$I->waitUntilElementVisible( '#wpadminbar' );
 
 		$editor_has_blocks =  $this->editorHasBlocks( $I );

--- a/tests/wpacceptance/LinkUnlinkTest.php
+++ b/tests/wpacceptance/LinkUnlinkTest.php
@@ -36,6 +36,8 @@ class LinkUnlinkTest extends \TestCase {
 
 			$I->waitUntilElementVisible( 'body.post-php' );;
 
+			sleep( 1 );
+
 			// I see unlinked text
 			$I->seeText( 'Originally distributed from Site One. This Post has been unlinked from the original. However, you can alwaysrestore it.View Original', '.components-notice__content' );
 

--- a/tests/wpacceptance/PushMenuTest.php
+++ b/tests/wpacceptance/PushMenuTest.php
@@ -44,6 +44,8 @@ class PushMenuTest extends \TestCase {
 
 		$I->moveTo( 'wp-admin/post.php?post=40&action=edit' );
 
+		$this->disableFullscreenEditor( $I );
+
 		$I->waitUntilElementVisible( '#wp-admin-bar-distributor a' );
 
 		$this->dismissNUXTip( $I );
@@ -86,7 +88,7 @@ class PushMenuTest extends \TestCase {
 		$I->moveMouse( '#wp-admin-bar-distributor a' );
 
 		$I->click( '#wp-admin-bar-distributor a' );
-		
+
 		$I->click( '#wp-admin-bar-distributor a' );
 
 		$I->waitUntilElementVisible( '#distributor-push-wrapper .new-connections-list' );

--- a/tests/wpacceptance/PushMenuTest.php
+++ b/tests/wpacceptance/PushMenuTest.php
@@ -19,9 +19,13 @@ class PushMenuTest extends \TestCase {
 
 		$I->moveTo( 'wp-admin/post.php?post=40&action=edit' );
 
+		$this->disableFullscreenEditor( $I );
+
 		$I->waitUntilElementVisible( '#wp-admin-bar-distributor a' );
 
 		$I->moveMouse( '#wp-admin-bar-distributor a' );
+
+		$I->click( '#wp-admin-bar-distributor a' );
 
 		$I->click( '#wp-admin-bar-distributor a' );
 
@@ -73,12 +77,16 @@ class PushMenuTest extends \TestCase {
 
 		$I->moveTo( 'wp-admin/post.php?post=40&action=edit' );
 
+		$this->disableFullscreenEditor( $I );
+
 		$I->waitUntilElementVisible( '#wp-admin-bar-distributor a' );
 
 		$this->dismissNUXTip( $I );
 
 		$I->moveMouse( '#wp-admin-bar-distributor a' );
 
+		$I->click( '#wp-admin-bar-distributor a' );
+		
 		$I->click( '#wp-admin-bar-distributor a' );
 
 		$I->waitUntilElementVisible( '#distributor-push-wrapper .new-connections-list' );

--- a/tests/wpacceptance/PushMenuTest.php
+++ b/tests/wpacceptance/PushMenuTest.php
@@ -54,6 +54,8 @@ class PushMenuTest extends \TestCase {
 
 		$I->click( '#wp-admin-bar-distributor a' );
 
+		$I->click( '#wp-admin-bar-distributor a' );
+
 		$I->waitUntilElementVisible( '#distributor-push-wrapper .new-connections-list' );
 
 		$I->click( '#distributor-push-wrapper .new-connections-list .add-connection[data-connection-id="2"]' );

--- a/tests/wpacceptance/includes/TestCase.php
+++ b/tests/wpacceptance/includes/TestCase.php
@@ -36,12 +36,15 @@ class TestCase extends \WPAcceptance\PHPUnit\TestCase {
 			$info['original_front_url'] = $I->getElementAttribute( '#wp-admin-bar-preview a', 'href' );
 		}
 
+		$this->disableFullscreenEditor( $I );
+
 		$I->waitUntilElementVisible( '#wp-admin-bar-distributor a' );
 
 		$this->dismissNUXTip( $I );
 
 		$I->moveMouse( '#wp-admin-bar-distributor a' );
 
+		$I->click( '#wp-admin-bar-distributor a' );
 		$I->click( '#wp-admin-bar-distributor a' );
 
 		$I->waitUntilElementVisible( '#distributor-push-wrapper .new-connections-list' );
@@ -166,4 +169,14 @@ class TestCase extends \WPAcceptance\PHPUnit\TestCase {
 		} catch ( \Exception $e ) {}
 	}
 
+	/**
+	 * Disable new default fullscreen mode in WP 5.4.
+	 *
+	 * @param \WPAcceptance\PHPUnit\Actor $actor The actor.
+	 */
+	protected function disableFullscreenEditor( $actor ) {
+		$script = "if ( wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) ) { wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' ); }";
+
+		$actor->executeJavascript( $script );
+	}
 }

--- a/tests/wpacceptance/includes/TestCase.php
+++ b/tests/wpacceptance/includes/TestCase.php
@@ -175,7 +175,7 @@ class TestCase extends \WPAcceptance\PHPUnit\TestCase {
 	 * @param \WPAcceptance\PHPUnit\Actor $actor The actor.
 	 */
 	protected function disableFullscreenEditor( $actor ) {
-		$script = "if ( wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) ) { wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' ); }";
+		$script = "if ( !! wp.data && wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) ) { wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' ); }";
 
 		$actor->executeJavascript( $script );
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR:

- Fixes failing unit test cases.
- Fixes fail negative acceptance test cases.
- Fixes some code style issues.
- Follows the [core change](https://core.trac.wordpress.org/ticket/46438) by replace `date` with `gmdate`.
- Adds a new snapshot for WP 5.4.2.
- Updates WP Acceptance test cases in favor of new changes in the block editor.
- Bumps WP Tested up to version to 5.4.2.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process

See CI passes.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #568 

<!-- Enter any applicable Issues here -->
