### PR TITLE
Add a default permission_callback to all of our custom REST routes

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -137,8 +137,9 @@ function register_rest_routes() {
 		'wp/v2',
 		'distributor/post-types-permissions',
 		array(
-			'methods'  => 'GET',
-			'callback' => __NAMESPACE__ . '\check_post_types_permissions',
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\check_post_types_permissions',
+			'permission_callback' => '__return_true',
 		)
 	);
 }
@@ -273,8 +274,9 @@ function register_endpoints() {
 		'wp/v2',
 		'/dt_meta',
 		array(
-			'methods'  => 'GET',
-			'callback' => __NAMESPACE__ . '\distributor_meta',
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\distributor_meta',
+			'permission_callback' => '__return_true',
 		)
 	);
 


### PR DESCRIPTION
### Description of the Change

Adds a `permission_callback` parameter to all of our `register_rest_route` calls. This was previously not required but in WordPress 5.5, this will now throw a PHP notice if debug is on and this parameter isn't passed. Because we currently aren't doing any sort of permission check, we utilize the `__return_true` function here, which will always return true.

### Alternate Designs

None

### Benefits

Removes PHP notices in WordPress 5.5+ when debug is on

### Possible Drawbacks

None

### Verification Process

With debug on and prior to any changes, tested out the plugin locally. Saw that I was getting 2 PHP notices. After this fix, tested again and didn't get any PHP notices

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #631 