### PR TITLE
Make sure the Distributor admin bar works correctly when loading via AMP

### DIFF
--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -192,9 +192,14 @@ jQuery( window ).on( 'load', () => {
 			}
 
 			if ( 'mustache' === template ) {
+				if ( selectedConnections[connection.type + connection.id] ) {
+					connection.added = true;
+				} else {
+					connection.added = false;
+				}
+
 				showConnection = Mustache.render( document.getElementById( 'dt-add-connection' ).innerHTML, {
 					connection: connection,
-					selectedConnections: selectedConnections
 				} );
 			} else {
 				showConnection = template( {
@@ -276,12 +281,12 @@ jQuery( window ).on( 'load', () => {
 			if ( 'mustache' === template ) {
 				const mustacheData = { 'connections' : [] };
 				for ( const prop in dtConnections ) {
-					mustacheData['connections'].push( dtConnections[prop] );
+					mustacheData.connections.push( dtConnections[prop] );
 				}
 
 				distributorPushWrapper.innerHTML = Mustache.render( document.getElementById( 'dt-show-connections' ).innerHTML, {
-					connections: mustacheData['connections'],
-					foundConnections: mustacheData['connections'].length
+					connections: mustacheData.connections,
+					foundConnections: mustacheData.connections.length
 				} );
 			} else {
 				distributorPushWrapper.innerHTML = template( {
@@ -404,7 +409,6 @@ jQuery( window ).on( 'load', () => {
 
 			element.appendChild( removeLink );
 			element.classList = 'added-connection';
-
 			connectionsSelectedList.appendChild( element );
 
 			if ( selectNoConnections.classList.contains ( 'unavailable' ) ) {

--- a/distributor.php
+++ b/distributor.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'DT_VERSION', '1.6.0-dev' );
 define( 'DT_PLUGIN_FILE', preg_replace( '#^.*plugins/(.*)$#i', '$1', __FILE__ ) );
+define( 'DT_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 // Define a constant if we're network activated to allow plugin to respond accordingly.
 $active_plugins = get_site_option( 'active_sitewide_plugins' );

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -7,8 +7,6 @@
 
 namespace Distributor\PushUI;
 
-use AmpProject\Dom\Document;
-
 /**
  * Setup actions and filters
  *

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -456,6 +456,7 @@ function add_dev_mode_to_assets( $tag, $handle ) {
 
 	$script_handles = [
 		'jquery',
+		'jquery-core',
 		'underscore',
 	];
 
@@ -565,7 +566,7 @@ function menu_content() {
 		</div>
 		<?php
 	} else {
-		if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
+		if ( function_exists( 'amp_is_request' ) && amp_is_request() && ! is_admin() ) {
 			include DT_PLUGIN_PATH . 'templates/show-connections-amp.php';
 			include DT_PLUGIN_PATH . 'templates/add-connection-amp.php';
 		} else {

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -7,6 +7,8 @@
 
 namespace Distributor\PushUI;
 
+use AmpProject\Dom\Document;
+
 /**
  * Setup actions and filters
  *
@@ -18,6 +20,7 @@ function setup() {
 		function() {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+			add_filter( 'amp_dev_mode_element_xpaths', __NAMESPACE__ . '\add_dev_mode_to_assets' );
 			add_action( 'wp_ajax_dt_load_connections', __NAMESPACE__ . '\get_connections' );
 			add_action( 'wp_ajax_dt_push', __NAMESPACE__ . '\ajax_push' );
 			add_action( 'admin_bar_menu', __NAMESPACE__ . '\menu_button', 999 );
@@ -417,6 +420,32 @@ function enqueue_scripts( $hook ) {
 }
 
 /**
+ * Add the amp dev mode to assets we need for distribution to work
+ *
+ * @param array $xpaths Current array of element paths
+ * @return array
+ */
+function add_dev_mode_to_assets( $xpaths = [] ) {
+	if ( ! syndicatable() ) {
+		return;
+	}
+
+	$ids = [
+		'dt-push-css',
+		'dt-push-js',
+		'dt-push-js-extra',
+		'jquery-core-js',
+		'underscore-js',
+	];
+
+	foreach ( $ids as $id ) {
+		$xpaths[] = sprintf( '//*[ @id = "%s" ]', $id );
+	}
+
+	return $xpaths;
+}
+
+/**
  * Let's setup our distributor menu in the toolbar
  *
  * @param object $wp_admin_bar Admin bar object.
@@ -511,108 +540,14 @@ function menu_content() {
 		</div>
 		<?php
 	} else {
+		if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
+			include DT_PLUGIN_PATH . 'templates/show-connections-amp.php';
+			include DT_PLUGIN_PATH . 'templates/add-connection-amp.php';
+		} else {
+			include DT_PLUGIN_PATH . 'templates/show-connections.php';
+			include DT_PLUGIN_PATH . 'templates/add-connection.php';
+		}
 		?>
-
-		<script id="dt-show-connections" type="text/html">
-			<div class="inner">
-			<# if ( ! _.isEmpty( connections ) ) { #>
-				<?php /* translators: %s the post title */ ?>
-				<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), esc_html( get_the_title( $post->ID ) ) ); ?></p>
-
-				<div class="connections-selector">
-					<div>
-						<# if ( 5 < _.keys( connections ).length ) { #>
-							<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
-						<# } #>
-						<div class="new-connections-list">
-							<# for ( var key in connections ) { #>
-								<button
-									class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>"
-									data-connection-type="{{ connections[ key ]['type'] }}"
-									data-connection-id="{{ connections[ key ]['id'] }}"
-									<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) && connections[ key ]['syndicated'] ) { #>disabled<# } #>
-								>
-									<# if ( 'external' === connections[ key ]['type'] ) { #>
-										<span>{{ connections[ key ]['name'] }}</span>
-									<# } else { #>
-										<span>{{ connections[ key ]['url'] }}</span>
-									<# } #>
-									<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) && connections[ key ]['syndicated'] ) { #>
-										<a href="{{ connections[ key ]['syndicated'] }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
-									<# } #>
-								</button>
-							<# } #>
-						</div>
-
-						<button class="button button-primary selectall-connections unavailable"><?php esc_html_e( 'Select All', 'distributor' ); ?></button>
-
-					</div>
-				</div>
-				<div class="connections-selected empty">
-					<header class="with-selected">
-						<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
-						<button class="button button-link selectno-connections unavailable"><?php esc_html_e( 'Clear', 'distributor' ); ?></button>
-					</header>
-					<header class="no-selected">
-						<?php esc_html_e( 'No connections selected', 'distributor' ); ?>
-					</header>
-
-					<div class="selected-connections-list"></div>
-
-					<div class="action-wrapper">
-						<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
-						<?php
-						$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
-						/**
-						 * Filter whether the 'As Draft' option appears in the push ui.
-						 *
-						 * @hook dt_allow_as_draft_distribute
-						 *
-						 * @param {bool}    $as_draft   Whether the 'As Draft' option should appear.
-						 * @param {object}  $connection The connection being used to push.
-						 * @param {WP_Post} $post       The post being pushed.
-						 *
-						 * @return {bool} Whether the 'As Draft' option should appear.
-						 */
-						$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection = null, $post );
-						?>
-						<button class="button button-primary syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
-					</div>
-
-				</div>
-
-				<div class="messages">
-					<div class="dt-success">
-						<?php esc_html_e( 'Post successfully distributed.', 'distributor' ); ?>
-					</div>
-					<div class="dt-error">
-						<?php esc_html_e( 'There were some issues distributing the post.', 'distributor' ); ?>
-						<ul class="details">
-						</ul>
-					</div>
-				</div>
-
-			<# } else { #>
-				<p class="no-connections-notice">
-					<?php esc_html_e( 'No connections available for distribution.', 'distributor' ); ?>
-				</p>
-			<# } #>
-			</div>
-		</script>
-
-		<script id="dt-add-connection" type="text/html">
-			<button class="<# if (selectedConnections[connection.type + connection.id]) { #>added<# }#> add-connection <# if (connection.syndicated) { #>syndicated<# } #>" data-connection-type="{{ connection.type }}" data-connection-id="{{ connection.id }}" <# if (connection.syndicated) { #>disabled<# } #>>
-				<# if ('internal' === connection.type) { #>
-					<span>{{ connection.url }}</span>
-				<# } else { #>
-					<span>{{{ connection.name }}}</span>
-				<# } #>
-
-				<# if (connection.syndicated) { #>
-					<a href="{{ connection.syndicated }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
-				<# } #>
-			</button>
-		</script>
 
 		<div id="distributor-push-wrapper">
 			<div class="inner">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,7 +1314,8 @@
     "@types/mustache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
-      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==",
+      "dev": true
     },
     "@types/node": {
       "version": "12.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1311,6 +1311,11 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+    },
     "@types/node": {
       "version": "12.12.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
@@ -6947,6 +6952,11 @@
         "arrify": "^2.0.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
     "mute-stdout": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
   },
   "engines": {
     "node": ">=8.9.10"
+  },
+  "dependencies": {
+    "@types/mustache": "^4.0.1",
+    "mustache": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",
     "@babel/register": "^7.9.0",
+    "@types/mustache": "^4.0.1",
     "@wordpress/url": "^2.5.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
@@ -55,7 +56,6 @@
     "node": ">=8.9.10"
   },
   "dependencies": {
-    "@types/mustache": "^4.0.1",
     "mustache": "^4.0.1"
   }
 }

--- a/templates/add-connection-amp.php
+++ b/templates/add-connection-amp.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Add connection AMP template
+ *
+ * @package  distributor
  */
+
 ?>
 
 <script id="dt-add-connection" type="text/plain" template="amp-mustache" data-ampdevmode>

--- a/templates/add-connection-amp.php
+++ b/templates/add-connection-amp.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Add connection AMP template
+ */
+?>
+
+<script id="dt-add-connection" type="text/plain" template="amp-mustache" data-ampdevmode>
+	<button class="{{#selectedConnections[connection.type + connection.id]}}added{{/selectedConnections[connection.type + connection.id]}} add-connection {{#connection.syndicated}}syndicated{{/connection.syndicated}}" data-connection-type="{{{connection.type}}}" data-connection-id="{{{connection.id}}}" {{#connection.syndicated}}disabled{{/connection.syndicated}}>
+		<span>{{{connection.name}}}</span>
+
+		{{#connection.syndicated}}
+			<a href="{{{connection.syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+		{{/connection.syndicated}}
+	</button>
+</script>

--- a/templates/add-connection-amp.php
+++ b/templates/add-connection-amp.php
@@ -10,7 +10,7 @@
 			class="add-connection{{#added}} added{{/added}}{{#syndicated}} syndicated{{/syndicated}}"
 			data-connection-type="{{{type}}}"
 			data-connection-id="{{{id}}}"
-			{{#syndicated}} disabled="true"{{/syndicated}}
+			{{#syndicated}}disabled{{/syndicated}}
 		>
 			<span>{{{name}}}</span>
 

--- a/templates/add-connection-amp.php
+++ b/templates/add-connection-amp.php
@@ -5,11 +5,18 @@
 ?>
 
 <script id="dt-add-connection" type="text/plain" template="amp-mustache" data-ampdevmode>
-	<button class="{{#selectedConnections[connection.type + connection.id]}}added{{/selectedConnections[connection.type + connection.id]}} add-connection {{#connection.syndicated}}syndicated{{/connection.syndicated}}" data-connection-type="{{{connection.type}}}" data-connection-id="{{{connection.id}}}" {{#connection.syndicated}}disabled{{/connection.syndicated}}>
-		<span>{{{connection.name}}}</span>
+	{{#connection}}
+		<button
+			class="add-connection{{#added}} added{{/added}}{{#syndicated}} syndicated{{/syndicated}}"
+			data-connection-type="{{{type}}}"
+			data-connection-id="{{{id}}}"
+			{{#syndicated}} disabled="true"{{/syndicated}}
+		>
+			<span>{{{name}}}</span>
 
-		{{#connection.syndicated}}
-			<a href="{{{connection.syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
-		{{/connection.syndicated}}
-	</button>
+			{{#syndicated}}
+				<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+			{{/syndicated}}
+		</button>
+	{{/connection}}
 </script>

--- a/templates/add-connection-amp.php
+++ b/templates/add-connection-amp.php
@@ -10,9 +10,13 @@
 			class="add-connection{{#added}} added{{/added}}{{#syndicated}} syndicated{{/syndicated}}"
 			data-connection-type="{{{type}}}"
 			data-connection-id="{{{id}}}"
-			{{#syndicated}}disabled{{/syndicated}}
 		>
-			<span>{{{name}}}</span>
+			{{#internal}}
+				<span>{{{url}}}</span>
+			{{/internal}}
+			{{^internal}}
+				<span>{{{name}}}</span>
+			{{/internal}}
 
 			{{#syndicated}}
 				<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>

--- a/templates/add-connection.php
+++ b/templates/add-connection.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Add connection template
+ */
+?>
+
+<script id="dt-add-connection" type="text/html">
+	<button class="<# if (selectedConnections[connection.type + connection.id]) { #>added<# }#> add-connection <# if (connection.syndicated) { #>syndicated<# } #>" data-connection-type="{{ connection.type }}" data-connection-id="{{ connection.id }}" <# if (connection.syndicated) { #>disabled<# } #>>
+		<# if ('internal' === connection.type) { #>
+			<span>{{ connection.url }}</span>
+		<# } else { #>
+			<span>{{{ connection.name }}}</span>
+		<# } #>
+
+		<# if (connection.syndicated) { #>
+			<a href="{{ connection.syndicated }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+		<# } #>
+	</button>
+</script>

--- a/templates/add-connection.php
+++ b/templates/add-connection.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Add connection template
+ *
+ * @package  distributor
  */
+
 ?>
 
 <script id="dt-add-connection" type="text/html">

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Show connections AMP template
+ */
+?>
+
+<script id="dt-show-connections" type="text/plain" template="amp-mustache" data-ampdevmode>
+	<div class="inner">
+	{{#foundConnections}}
+		<?php /* translators: %s the post title */ ?>
+		<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), esc_html( get_the_title( $post->ID ) ) ); ?></p>
+
+		<div class="connections-selector">
+			<div>
+				<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
+				<div class="new-connections-list">
+					{{#connections}}
+						<button
+							class="add-connection{{#syndicated}} syndicated{{/syndicated}}"
+							data-connection-type="{{{type}}}"
+							data-connection-id="{{{id}}}"
+							{{#syndicated}} disabled="true"{{/syndicated}}
+						>
+								<span>{{{name}}}</span>
+							{{#syndicated}}
+								<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+							{{/syndicated}}
+						</button>
+					{{/connections}}
+				</div>
+
+				<button class="button button-primary selectall-connections unavailable"><?php esc_html_e( 'Select All', 'distributor' ); ?></button>
+			</div>
+		</div>
+
+		<div class="connections-selected empty">
+			<header class="with-selected">
+				<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
+				<button class="button button-link selectno-connections unavailable"><?php esc_html_e( 'Clear', 'distributor' ); ?></button>
+			</header>
+			<header class="no-selected">
+				<?php esc_html_e( 'No connections selected', 'distributor' ); ?>
+			</header>
+
+			<div class="selected-connections-list"></div>
+
+			<div class="action-wrapper">
+				<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
+				<?php
+				$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
+				/**
+				 * Filter whether the 'As Draft' option appears in the push ui.
+				 *
+				 * @hook dt_allow_as_draft_distribute
+				 *
+				 * @param {bool}    $as_draft   Whether the 'As Draft' option should appear.
+				 * @param {object}  $connection The connection being used to push.
+				 * @param {WP_Post} $post       The post being pushed.
+				 *
+				 * @return {bool} Whether the 'As Draft' option should appear.
+				 */
+				$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection = null, $post );
+				?>
+				<button class="button button-primary syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
+			</div>
+
+		</div>
+
+		<div class="messages">
+			<div class="dt-success">
+				<?php esc_html_e( 'Post successfully distributed.', 'distributor' ); ?>
+			</div>
+			<div class="dt-error">
+				<?php esc_html_e( 'There were some issues distributing the post.', 'distributor' ); ?>
+			</div>
+		</div>
+
+	{{/foundConnections}}
+	{{^foundConnections}}
+		<p class="no-connections-notice">
+			<?php esc_html_e( 'No connections available for distribution.', 'distributor' ); ?>
+		</p>
+	{{/foundConnections}}
+	</div>
+</script>

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -19,7 +19,7 @@
 							class="add-connection{{#syndicated}} syndicated{{/syndicated}}"
 							data-connection-type="{{{type}}}"
 							data-connection-id="{{{id}}}"
-							{{#syndicated}} disabled="true"{{/syndicated}}
+							{{#syndicated}}disabled{{/syndicated}}
 						>
 								<span>{{{name}}}</span>
 								{{#syndicated}}

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -12,16 +12,23 @@
 
 		<div class="connections-selector">
 			<div>
-				<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
+				{{#showSearch}}
+					<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
+				{{/showSearch}}
 				<div class="new-connections-list">
 					{{#connections}}
 						<button
 							class="add-connection{{#syndicated}} syndicated{{/syndicated}}"
 							data-connection-type="{{{type}}}"
 							data-connection-id="{{{id}}}"
-							{{#syndicated}}disabled{{/syndicated}}
 						>
-								<span>{{{name}}}</span>
+								{{#internal}}
+									<span>{{{url}}}</span>
+								{{/internal}}
+								{{^internal}}
+									<span>{{{name}}}</span>
+								{{/internal}}
+
 								{{#syndicated}}
 									<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
 								{{/syndicated}}

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -22,9 +22,9 @@
 							{{#syndicated}} disabled="true"{{/syndicated}}
 						>
 								<span>{{{name}}}</span>
-							{{#syndicated}}
-								<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
-							{{/syndicated}}
+								{{#syndicated}}
+									<a href="{{{syndicated}}}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+								{{/syndicated}}
 						</button>
 					{{/connections}}
 				</div>

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Show connections AMP template
+ *
+ * @package  distributor
  */
+
 ?>
 
 <script id="dt-show-connections" type="text/plain" template="amp-mustache" data-ampdevmode>

--- a/templates/show-connections.php
+++ b/templates/show-connections.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Show connections template
+ */
+?>
+
+<script id="dt-show-connections" type="text/html">
+	<div class="inner">
+	<# if ( ! _.isEmpty( connections ) ) { #>
+		<?php /* translators: %s the post title */ ?>
+		<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), esc_html( get_the_title( $post->ID ) ) ); ?></p>
+
+		<div class="connections-selector">
+			<div>
+				<# if ( 5 < _.keys( connections ).length ) { #>
+					<input type="text" id="dt-connection-search" placeholder="<?php esc_attr_e( 'Search available connections', 'distributor' ); ?>">
+				<# } #>
+				<div class="new-connections-list">
+					<# for ( var key in connections ) { #>
+						<button
+							class="add-connection<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) ) { #> syndicated<# } #>"
+							data-connection-type="{{ connections[ key ]['type'] }}"
+							data-connection-id="{{ connections[ key ]['id'] }}"
+							<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) && connections[ key ]['syndicated'] ) { #>disabled<# } #>
+						>
+							<# if ( 'external' === connections[ key ]['type'] ) { #>
+								<span>{{ connections[ key ]['name'] }}</span>
+							<# } else { #>
+								<span>{{ connections[ key ]['url'] }}</span>
+							<# } #>
+							<# if ( ! _.isEmpty( connections[ key ]['syndicated'] ) && connections[ key ]['syndicated'] ) { #>
+								<a href="{{ connections[ key ]['syndicated'] }}"><?php esc_html_e( 'View', 'distributor' ); ?></a>
+							<# } #>
+						</button>
+					<# } #>
+				</div>
+
+				<button class="button button-primary selectall-connections unavailable"><?php esc_html_e( 'Select All', 'distributor' ); ?></button>
+			</div>
+		</div>
+		<div class="connections-selected empty">
+			<header class="with-selected">
+				<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
+				<button class="button button-link selectno-connections unavailable"><?php esc_html_e( 'Clear', 'distributor' ); ?></button>
+			</header>
+			<header class="no-selected">
+				<?php esc_html_e( 'No connections selected', 'distributor' ); ?>
+			</header>
+
+			<div class="selected-connections-list"></div>
+
+			<div class="action-wrapper">
+				<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
+				<?php
+				$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
+				/**
+				* Filter whether the 'As Draft' option appears in the push ui.
+				*
+				* @hook dt_allow_as_draft_distribute
+				*
+				* @param {bool}    $as_draft   Whether the 'As Draft' option should appear.
+				* @param {object}  $connection The connection being used to push.
+				* @param {WP_Post} $post       The post being pushed.
+				*
+				* @return {bool} Whether the 'As Draft' option should appear.
+				*/
+				$as_draft = apply_filters( 'dt_allow_as_draft_distribute', $as_draft, $connection = null, $post );
+				?>
+				<button class="button button-primary syndicate-button"><?php esc_html_e( 'Distribute', 'distributor' ); ?></button> <?php if ( $as_draft ) : ?><label class="as-draft" for="dt-as-draft"><input type="checkbox" id="dt-as-draft" checked> <?php esc_html_e( 'As draft', 'distributor' ); ?></label><?php endif; ?>
+			</div>
+
+		</div>
+
+		<div class="messages">
+			<div class="dt-success">
+				<?php esc_html_e( 'Post successfully distributed.', 'distributor' ); ?>
+			</div>
+			<div class="dt-error">
+				<?php esc_html_e( 'There were some issues distributing the post.', 'distributor' ); ?>
+			</div>
+		</div>
+
+	<# } else { #>
+		<p class="no-connections-notice">
+			<?php esc_html_e( 'No connections available for distribution.', 'distributor' ); ?>
+		</p>
+	<# } #>
+	</div>
+</script>

--- a/templates/show-connections.php
+++ b/templates/show-connections.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Show connections template
+ *
+ * @package  distributor
  */
+
 ?>
 
 <script id="dt-show-connections" type="text/html">


### PR DESCRIPTION
### Description of the Change

When using the official [AMP WP plugin](https://github.com/ampproject/amp-wp), if you have the front-end of your site set to always use AMP and you're logged in, the Distributor admin bar item shows but does not work. The issue lies with AMP removing the assets we rely on, as well as mangling the templates we output.

This PR ensures all of our assets are loaded via amp-dev-mode, so they don't get removed. It also changes our template system too utilizing Mustache, which AMP supports.

### Alternate Designs

None

### Benefits

Front-end distribution will now work properly when using AMP

### Possible Drawbacks

We now have two different template systems: one used only for AMP and the previous one we use elsewhere. Ideally we would use the same templates for both but for now, I think it's safer to keep those separate.

### Verification Process

1. Install the AMP WP plugin and get that set up
2. Ensure you are logged in and visit the frontend view of a single post
3. Hover over the Distributor admin bar item and make sure it loads
4. Choose a connection to distribute to and make sure that works

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #658 
