### PR TITLE
Fix: Application Passwords handling for WordPress 5.6

### DIFF
--- a/distributor.php
+++ b/distributor.php
@@ -113,7 +113,10 @@ require_once __DIR__ . '/includes/debug-info.php';
 add_action(
 	'plugins_loaded',
 	function() {
-		if ( ! class_exists( 'Application_Passwords' ) ) {
+		if (
+			! class_exists( 'Application_Passwords' ) && ! class_exists( 'WP_Application_Passwords' )
+			|| class_exists( 'WP_Application_Passwords' ) && function_exists( 'wp_is_application_passwords_available' ) && ! wp_is_application_passwords_available()
+		) {
 			require_once __DIR__ . '/vendor/georgestephanis/application-passwords/application-passwords.php';
 		}
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
With Application Password in core since 5.6, the Application Passwords section on the user profile edit page now is duplicated. This PR fixes that issue by loading only one Application Password class. The class can be one of three sources: WordPress core, Application Password Plugin, and the plugin bundled with Distributor.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process
* Update the site to 5.6.
* Go to user profile edit page.
* See only one Application password section.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes #661 
### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
