### PR TITLE
Fix: Application Password on WP 5.6

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -299,7 +299,11 @@ function checkConnections() {
 // Initialize after load.
 setTimeout( () => {
 	// Repopulate fields on wizard flow.
-	const { wizard_return } = dt;
+	const { wizard_return, wizard_available } = dt;
+
+	if ( ! wizard_available ) {
+		jQuery( manualSetupButton ).trigger( 'click' );
+	}
 
 	if ( wizard_return ) {
 		if ( '' === titleField.value ) {

--- a/distributor.php
+++ b/distributor.php
@@ -113,10 +113,33 @@ require_once __DIR__ . '/includes/debug-info.php';
 add_action(
 	'plugins_loaded',
 	function() {
-		if (
-			! class_exists( 'Application_Passwords' ) && ! class_exists( 'WP_Application_Passwords' )
-			|| class_exists( 'WP_Application_Passwords' ) && function_exists( 'wp_is_application_passwords_available' ) && ! wp_is_application_passwords_available()
-		) {
+		if ( function_exists( 'wp_is_application_passwords_available' ) ) {
+			if ( ! wp_is_application_passwords_available() ) {
+				add_action(
+					'admin_notices',
+					function() {
+						if ( get_current_screen()->id !== 'toplevel_page_distributor' ) {
+							return;
+						}
+						?>
+						<div class="notice notice-warning">
+							<p>
+								<?php
+								echo wp_kses_post(
+									sprintf(
+										/* translators: %s is the URL to the guide to enable Application Password for non HTTPS sites. */
+										__( 'Your site is not using HTTPS or is a local environment. Follow this <a href="%s">guide</a> to enable Application Password.', 'distributor' ),
+										'https://github.com/10up/distributor/'
+									)
+								);
+								?>
+							</p>
+						</div>
+						<?php
+					}
+				);
+			}
+		} elseif ( ! class_exists( 'Application_Passwords' ) ) {
 			require_once __DIR__ . '/vendor/georgestephanis/application-passwords/application-passwords.php';
 		}
 	}

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -270,8 +270,14 @@ function admin_enqueue_scripts( $hook ) {
 		wp_enqueue_style( 'dt-admin-external-connection', plugins_url( '/dist/css/admin-external-connection.min.css', __DIR__ ), array(), DT_VERSION );
 		wp_enqueue_script( 'dt-admin-external-connection', plugins_url( '/dist/js/admin-external-connection.min.js', __DIR__ ), array( 'jquery', 'underscore', 'wp-a11y' ), DT_VERSION, true );
 
-		$blog_name     = get_bloginfo( 'name ' );
-		$wizard_return = get_wizard_return_data();
+		$blog_name        = get_bloginfo( 'name ' );
+		$wizard_return    = get_wizard_return_data();
+		$wizard_available = true;
+
+		if ( function_exists( 'wp_is_application_passwords_available' ) && ! wp_is_application_passwords_available() ) {
+			$wizard_available = false;
+		}
+
 		wp_localize_script(
 			'dt-admin-external-connection',
 			'dt',
@@ -298,6 +304,7 @@ function admin_enqueue_scripts( $hook ) {
 				/* translators: %1$s: site name, %2$s: site URL */
 				'distributor_from'          => sprintf( esc_html__( 'Distributor on %1$s (%2$s)', 'distributor' ), $blog_name, esc_url( home_url() ) ),
 				'wizard_return'             => $wizard_return,
+				'wizard_available'          => $wizard_available,
 			)
 		);
 


### PR DESCRIPTION
This PR continues adding compatibility for Distributor and WP 5.6.

If the site is a local site or doesn't use HTTPS, a warning will be shown with a link to the guide to enable Application Password on WP 5.6. Besides, the Auth Wizard will be disabled as well, Adding a new external connection will show the manual setup only.

Fix #661