### PR TITLE
Docs: Add guide for enabling Application Passwords on 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ In WordPress 5.6, Application Passwords is merged into the WordPress core with s
 ```php
 add_filter( 'wp_is_application_passwords_available', '__return_true' );
 
-add_action('wp_authorize_application_password_request_errors', function( $error ) {
+add_action( 'wp_authorize_application_password_request_errors', function( $error ) {
     $error->remove( 'invalid_redirect_scheme' );
-});
+} );
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _Note:_ The latest stable version of the plugin is the _stable_ branch. [Downloa
   * [Running Locally](#running-locally)
   * [Testing](#testing)
   * [Debugging](#debugging)
+  * [Application Passwords](#application-passwords-and-wordpress-56)
 * [Changelog](#changelog)
 * [Contributing](#contributing)
 
@@ -169,7 +170,7 @@ Enabling this will also provide more debugging information in your error log for
 
 ### Application Passwords and WordPress 5.6
 
-In WordPress 5.6, Application Passwords is merged into the WordPress core with some limitations. From 5.6, Application Passwords is enabled by default only for live sites with HTTPS. To enable Application Passwords for development sites, you will need the following snippet:
+In WordPress 5.6, Application Passwords was merged into WordPress core with some limitations. From 5.6, Application Passwords is enabled by default only for live sites with HTTPS. To enable Application Passwords for development sites, you will need the following snippet:
 
 ```php
 add_filter( 'wp_is_application_passwords_available', '__return_true' );

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To help inform our roadmap, keep adopters apprised of major updates and changes 
 
 ### Setup External Connections using Application Passwords
 
-1. Ensure Distributor is installed on BOTH sites being connected.  We'll refer to these as mainsite.com and remotesite.com.
+1. Ensure that the current version of Distributor is active on BOTH sites being connected.  We'll refer to these as mainsite.com and remotesite.com.
 2. On mainsite.com, navigate to `Distributor` > `External Connections` and click `Add New`.
 3. Enter a label for the connection (e.g., `remotesite.com`), select `Username / Password` for the `Authentication Method`, and a username from remotesite.com.
 4. On remotesite.com, ensure that [Application Passwords](https://wordpress.org/plugins/application-passwords/) is installed. (_Note: Using this plugin instead of a normal WordPress users password helps limit the use of your primary password and will allow you to revoke access to Distributor in the future if needed._) Then navigate to the user profile that will be used to create the External Connection on mainsite.com and then to the `Application Passwords` section of the user profile (not the `Account Management` section).  Add a label for the New Application Password Name (e.g., `mainsite.com`) and click `Add New`.  Now copy the password provided into mainsite.com's External Connections `Password` field.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ You can define a constant `DISTRIBUTOR_DEBUG` to `true` to increase the ease of 
 
 Enabling this will also provide more debugging information in your error log for image side loading issues. The specific logging method may change in the future.
 
+### Application Passwords and WordPress 5.6
+
+In WordPress 5.6, Application Passwords is merged into the WordPress core with some limitations. From 5.6, Application Passwords is enabled by default only for live sites with HTTPS. To enable Application Passwords for development sites, you will need the following snippet:
+
+```php
+add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+add_action('wp_authorize_application_password_request_errors', function( $error ) {
+    $error->remove( 'invalid_redirect_scheme' );
+});
+```
+
 ## Changelog
 
 A complete listing of all notable changes to Distributor are documented in [CHANGELOG.md](https://github.com/10up/distributor/blob/develop/CHANGELOG.md).

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -135,6 +135,11 @@ jQuery( authorizeConnectionButton ).on( 'click', ( event ) => {
 			return;
 		}
 
+		if( 'core_application_passwords_available' in response.data && ! response.data.core_application_passwords_available ) {
+			jQuery( wizardError[0] ).text( dt.application_passwords_not_available );
+			return;
+		}
+
 		const successURL = addQueryArgs( document.location.href,
 			{
 				setupStatus: 'success',
@@ -150,7 +155,7 @@ jQuery( authorizeConnectionButton ).on( 'click', ( event ) => {
 			}
 		);
 
-		const auth_page = 'core_has_application_password' in response.data && response.data.core_has_application_password ? 'authorize-application.php' : 'admin.php?page=auth_app';
+		const auth_page = 'core_has_application_passwords' in response.data && response.data.core_has_application_passwords ? 'authorize-application.php' : 'admin.php?page=auth_app';
 
 		const authURL = addQueryArgs(
 			`${ siteURL }wp-admin/${ auth_page }`,
@@ -300,11 +305,7 @@ function checkConnections() {
 // Initialize after load.
 setTimeout( () => {
 	// Repopulate fields on wizard flow.
-	const { wizard_return, wizard_available } = dt;
-
-	if ( ! wizard_available ) {
-		jQuery( manualSetupButton ).trigger( 'click' );
-	}
+	const { wizard_return } = dt;
 
 	if ( wizard_return ) {
 		if ( '' === titleField.value ) {

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -150,8 +150,10 @@ jQuery( authorizeConnectionButton ).on( 'click', ( event ) => {
 			}
 		);
 
+		const auth_page = 'core_has_application_password' in response.data && response.data.core_has_application_password ? 'authorize-application.php' : 'admin.php?page=auth_app';
+
 		const authURL = addQueryArgs(
-			`${ siteURL }wp-admin/${ dt.auth_page }`,
+			`${ siteURL }wp-admin/${ auth_page }`,
 			{
 				app_name: dt.distributor_from, /*eslint camelcase: 0*/
 				success_url: encodeURI( successURL ), /*eslint camelcase: 0*/

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -151,9 +151,8 @@ jQuery( authorizeConnectionButton ).on( 'click', ( event ) => {
 		);
 
 		const authURL = addQueryArgs(
-			`${ siteURL }wp-admin/admin.php`,
+			`${ siteURL }wp-admin/${ dt.auth_page }`,
 			{
-				page: 'auth_app',
 				app_name: dt.distributor_from, /*eslint camelcase: 0*/
 				success_url: encodeURI( successURL ), /*eslint camelcase: 0*/
 				reject_url:  encodeURI( failureURL ), /*eslint camelcase: 0*/

--- a/distributor.php
+++ b/distributor.php
@@ -127,9 +127,9 @@ add_action(
 								<?php
 								echo wp_kses_post(
 									sprintf(
-										/* translators: %s is the URL to the guide to enable Application Password for non HTTPS sites. */
-										__( 'Your site is not using HTTPS or is a local environment. Follow this <a href="%s">guide</a> to enable Application Password.', 'distributor' ),
-										'https://github.com/10up/distributor/'
+										/* translators: %s is the URL to the guide to enable Application Passwords for non HTTPS sites. */
+										__( 'Your site is not using HTTPS or is a local environment. Follow this <a href="%s">guide</a> to enable Application Passwords.', 'distributor' ),
+										'https://github.com/10up/distributor#application-passwords-and-wordpress-56'
 									)
 								);
 								?>

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -305,7 +305,6 @@ function admin_enqueue_scripts( $hook ) {
 				'distributor_from'          => sprintf( esc_html__( 'Distributor on %1$s (%2$s)', 'distributor' ), $blog_name, esc_url( home_url() ) ),
 				'wizard_return'             => $wizard_return,
 				'wizard_available'          => $wizard_available,
-				'auth_page'                 => function_exists( 'wp_is_application_passwords_available' ) ? 'authorize-application.php' : 'admin.php?page=auth_app',
 			)
 		);
 

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -305,6 +305,7 @@ function admin_enqueue_scripts( $hook ) {
 				'distributor_from'          => sprintf( esc_html__( 'Distributor on %1$s (%2$s)', 'distributor' ), $blog_name, esc_url( home_url() ) ),
 				'wizard_return'             => $wizard_return,
 				'wizard_available'          => $wizard_available,
+				'auth_page'                 => function_exists( 'wp_is_application_passwords_available' ) ? 'authorize-application.php' : 'admin.php?page=auth_app',
 			)
 		);
 

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -272,39 +272,34 @@ function admin_enqueue_scripts( $hook ) {
 
 		$blog_name        = get_bloginfo( 'name ' );
 		$wizard_return    = get_wizard_return_data();
-		$wizard_available = true;
-
-		if ( function_exists( 'wp_is_application_passwords_available' ) && ! wp_is_application_passwords_available() ) {
-			$wizard_available = false;
-		}
 
 		wp_localize_script(
 			'dt-admin-external-connection',
 			'dt',
 			array(
-				'nonce'                     => wp_create_nonce( 'dt-verify-ext-conn' ),
-				'bad_connection'            => esc_html__( 'No connection found.', 'distributor' ),
-				'good_connection'           => esc_html__( 'Connection established.', 'distributor' ),
-				'limited_connection'        => esc_html__( 'Limited connection established.', 'distributor' ),
-				'no_push'                   => esc_html__( 'Push distribution unavailable.', 'distributor' ),
-				'no_permissions'            => esc_html__( 'Authentication succeeded but your account does not have permissions to create posts on the external site.', 'distributor' ),
-				'pull_limited'              => esc_html__( 'Pull distribution limited to basic content, i.e. title and content body.', 'distributor' ),
-				'endpoint_suggestion'       => esc_html__( 'Did you mean: ', 'distributor' ),
-				'endpoint_checking_message' => esc_html__( 'Checking endpoint...', 'distributor' ),
-				'bad_auth'                  => esc_html__( 'Authentication failed due to invalid credentials.', 'distributor' ),
-				'change'                    => esc_html__( 'Change', 'distributor' ),
-				'cancel'                    => esc_html__( 'Cancel', 'distributor' ),
-				'invalid_url'               => esc_html__( 'Please enter a valid URL, including the HTTP(S).', 'distributor' ),
-				'norest'                    => esc_html__( 'No REST API endpoint was located for this site.', 'distributor' ),
-				'noconnection'              => esc_html__( 'Unable to connect to site.', 'distributor' ),
-				'minversion'                => esc_html__( 'Remote site requires Distributor version 1.6.0 or greater. Upgrade Distributor on the remote site to use the Authentication Wizard.', 'distributor' ),
-				'no_distributor'            => esc_html__( 'Distributor not installed on remote site.', 'distributor' ),
-				'roles_warning'             => esc_html__( 'Be careful assigning less trusted roles push privileges as they will inherit the capabilities of the user on the remote site.', 'distributor' ),
-				'admin_url'                 => admin_url(),
+				'nonce'                               => wp_create_nonce( 'dt-verify-ext-conn' ),
+				'bad_connection'                      => esc_html__( 'No connection found.', 'distributor' ),
+				'good_connection'                     => esc_html__( 'Connection established.', 'distributor' ),
+				'limited_connection'                  => esc_html__( 'Limited connection established.', 'distributor' ),
+				'no_push'                             => esc_html__( 'Push distribution unavailable.', 'distributor' ),
+				'no_permissions'                      => esc_html__( 'Authentication succeeded but your account does not have permissions to create posts on the external site.', 'distributor' ),
+				'pull_limited'                        => esc_html__( 'Pull distribution limited to basic content, i.e. title and content body.', 'distributor' ),
+				'endpoint_suggestion'                 => esc_html__( 'Did you mean: ', 'distributor' ),
+				'endpoint_checking_message'           => esc_html__( 'Checking endpoint...', 'distributor' ),
+				'bad_auth'                            => esc_html__( 'Authentication failed due to invalid credentials.', 'distributor' ),
+				'change'                              => esc_html__( 'Change', 'distributor' ),
+				'cancel'                              => esc_html__( 'Cancel', 'distributor' ),
+				'invalid_url'                         => esc_html__( 'Please enter a valid URL, including the HTTP(S).', 'distributor' ),
+				'norest'                              => esc_html__( 'No REST API endpoint was located for this site.', 'distributor' ),
+				'noconnection'                        => esc_html__( 'Unable to connect to site.', 'distributor' ),
+				'minversion'                          => esc_html__( 'Remote site requires Distributor version 1.6.0 or greater. Upgrade Distributor on the remote site to use the Authentication Wizard.', 'distributor' ),
+				'no_distributor'                      => esc_html__( 'Distributor not installed on remote site.', 'distributor' ),
+				'roles_warning'                       => esc_html__( 'Be careful assigning less trusted roles push privileges as they will inherit the capabilities of the user on the remote site.', 'distributor' ),
+				'admin_url'                           => admin_url(),
 				/* translators: %1$s: site name, %2$s: site URL */
-				'distributor_from'          => sprintf( esc_html__( 'Distributor on %1$s (%2$s)', 'distributor' ), $blog_name, esc_url( home_url() ) ),
-				'wizard_return'             => $wizard_return,
-				'wizard_available'          => $wizard_available,
+				'distributor_from'                    => sprintf( esc_html__( 'Distributor on %1$s (%2$s)', 'distributor' ), $blog_name, esc_url( home_url() ) ),
+				'wizard_return'                       => $wizard_return,
+				'application_passwords_not_available' => __( 'Application Passwords is not available on the remote site. Please set up connection manually!', 'distributor' ),
 			)
 		);
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -291,7 +291,8 @@ function register_endpoints() {
  */
 function distributor_meta() {
 	return array(
-		'version' => DT_VERSION,
+		'version'                       => DT_VERSION,
+ 		'core_has_application_password' => function_exists( 'wp_is_application_passwords_available' ),
 	);
 }
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -291,8 +291,9 @@ function register_endpoints() {
  */
 function distributor_meta() {
 	return array(
-		'version'                       => DT_VERSION,
- 		'core_has_application_password' => function_exists( 'wp_is_application_passwords_available' ),
+		'version'                             => DT_VERSION,
+		'core_has_application_passwords'       => function_exists( 'wp_is_application_passwords_available' ),
+		'core_application_passwords_available' => function_exists( 'wp_is_application_passwords_available' ) && ! wp_is_application_passwords_available() ? false : true,
 	);
 }
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds a new section for Application Passwords and 5.6 debug guide. This also updates the auth page URL to make the Auth Wizard work on 5.6.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process
- Update a distributor development site without HTTPS to 5.6.
- Notice the Application Passwords section disappears on the user edit page.
- Add a new external connection, don't see the wizard.
- Follow the guide in this PR to enable Application Passwords.
- See the Application Passwords section on the user edit page.
- Add a new external connection, see the wizard working.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
