### PR TITLE
Better support for showing the FE Distributor admin bar

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -55,7 +55,7 @@ function syndicatable() {
 			return false;
 		}
 	} else {
-		if ( ! is_single() ) {
+		if ( ! is_singular( \Distributor\Utils\distributable_post_types() ) ) {
 			return false;
 		}
 	}


### PR DESCRIPTION
### Description of the Change

We currently have some checks in place to determine when we should show the Distributor admin bar. There is a bug in there that when we are on the front-end, we only show that bar if the item being viewed is a post or custom post type. This means this admin bar is never shown for pages.

This PR fixes this by switching from the `is_single` check to the `is_singular` check, as well as passing in our approved list of accepted post types. This ensure the admin bar shows properly on the front-end for Pages but will also ensure we return earlier if we're on a single view of a post type that isn't approved.

### Alternate Designs

None

### Benefits

Distributor admin bar will now show on the front-end for Pages

### Possible Drawbacks

None

### Verification Process

With Distributor active and without these changes in place, log in, go to the front-end view of a Page and notice the Distributor admin bar doesn't show.

With these changes in place, take the same actions but notice the admin bar now shows.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #483 