### PR TITLE
Standardize Distributed Alert Copy

### DIFF
--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -11,7 +11,7 @@ if ( '0' !== dtGutenberg.originalSourceId || '0' !== dtGutenberg.originalBlogId 
 	if ( parseInt( dtGutenberg.originalDelete ) ) {
 		message = wp.i18n.sprintf( wp.i18n.__( 'This %1$s was distributed from %2$s. However, the original has been deleted.' ), dtGutenberg.postTypeSingular, dtGutenberg.originalLocationName );
 	} else if ( ! parseInt( dtGutenberg.unlinked ) ) {
-		message = wp.i18n.sprintf( wp.i18n.__( 'Distributed from %s. The original will update this unless you', 'distributor' ), dtGutenberg.originalLocationName );
+		message = wp.i18n.sprintf( wp.i18n.__( 'Distributed from %s. The original will update this version unless you', 'distributor' ), dtGutenberg.originalLocationName );
 
 		actions.push( {
 			label: wp.i18n. __( 'unlink from original.', 'distributor' ),

--- a/tests/wpacceptance/DistributedPostTest.php
+++ b/tests/wpacceptance/DistributedPostTest.php
@@ -75,7 +75,7 @@ class DistributedPost extends \TestCase {
 
 		// Make sure we see distributed status admin notice and that it shows as linked
 		if ( $editor_has_blocks ) {
-			$I->seeText( 'Distributed from Site One. The original will update this unless youunlink from original.View Original', '.components-notice__content' );
+			$I->seeText( 'Distributed from Site One. The original will update this version unless you unlink from original.View Original', '.components-notice__content' );
 			$element = $I->getElement( '.components-notice__action' );
 			$I->seeText( 'unlink from original.', '.components-notice__action' );
 		} else {


### PR DESCRIPTION
Partially addresses #611 

### Description of the Change

Per #611, the notification copy between the classic and Gutenberg editors was inconsistent. This PR simply updates said verbiage for consistency between Gutenberg and Classic.

### Alternate Designs

The original spec called for an inline link to the original post as opposed to the "View Original" action in the Gutenberg notification. As outlined in a comment in #611, the notification architecture might have to be altered to account for this, so this PR will only address the verbiage.

### Benefits

Verbiage for the notifications will be more consistent across editors.

### Possible Drawbacks

None.

### Verification Process

1) Visit a distributed post in the Gutenberg editor, and ensure that the verbiage matches that of the Classic editor.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change. | WPAcceptance test changed accordingly.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

The inline link still needs to be added to the Gutenberg notification so as to match the Classic

### Changelog Entry

Changed some notification text for added consistency.
