### PR TITLE
Add option to set post_status of pulled content

### DIFF
--- a/assets/css/admin-pull-table.css
+++ b/assets/css/admin-pull-table.css
@@ -9,6 +9,15 @@
 			cursor: default;
 		}
 	}
+
+	& .dt-pull-post-type {
+		display: flex;
+		align-items: center;
+
+		& .dt-as-draft {
+			padding-left: 10px;
+		}
+	}
 }
 
 .wp-list-table .disabled {

--- a/assets/js/admin-pull.js
+++ b/assets/js/admin-pull.js
@@ -1,4 +1,5 @@
 import jQuery from 'jquery';
+import { addQueryArgs } from '@wordpress/url';
 
 const chooseConnection = document.getElementById( 'pull_connections' );
 const choosePostType = document.getElementById( 'pull_post_type' );
@@ -6,6 +7,8 @@ const choosePostTypeBtn = document.getElementById( 'pull_post_type_submit' );
 const searchField = document.getElementById( 'post-search-input' );
 const searchBtn = document.getElementById( 'search-submit' );
 const form = document.getElementById( 'posts-filter' );
+const asDraftCheckboxes = document.querySelectorAll( '[name=dt_as_draft]' );
+const pullLinks = document.querySelectorAll( '.distributor_page_pull .pull a' );
 
 jQuery( chooseConnection ).on( 'change', ( event ) => {
 
@@ -36,6 +39,36 @@ if ( chooseConnection && choosePostType && form ) {
 			document.location = `${ getURL() }&s=${ search }`;
 
 			document.body.className += ' dt-loading';
+		} );
+	}
+
+	if ( asDraftCheckboxes && pullLinks ) {
+		jQuery( asDraftCheckboxes ).on( 'change', ( event ) => {
+			if ( event.currentTarget.checked ) {
+				for ( let i = 0; i < asDraftCheckboxes.length; ++i ) {
+					asDraftCheckboxes[i].checked = true;
+				}
+
+				for ( let i = 0; i < pullLinks.length; ++i ) {
+					pullLinks[i].href = addQueryArgs( pullLinks[i].href,
+						{
+							dt_as_draft: 'draft', /*eslint camelcase: 0*/
+						}
+					);
+				}
+			} else {
+				for ( let i = 0; i < asDraftCheckboxes.length; ++i ) {
+					asDraftCheckboxes[i].checked = false;
+				}
+
+				for ( let i = 0; i < pullLinks.length; ++i ) {
+					pullLinks[i].href = addQueryArgs( pullLinks[i].href,
+						{
+							dt_as_draft: '', /*eslint camelcase: 0*/
+						}
+					);
+				}
+			}
 		} );
 	}
 }

--- a/assets/js/admin-pull.js
+++ b/assets/js/admin-pull.js
@@ -1,5 +1,6 @@
 import jQuery from 'jquery';
 import { addQueryArgs } from '@wordpress/url';
+import { dt } from 'window';
 
 const chooseConnection = document.getElementById( 'pull_connections' );
 const choosePostType = document.getElementById( 'pull_post_type' );
@@ -9,6 +10,7 @@ const searchBtn = document.getElementById( 'search-submit' );
 const form = document.getElementById( 'posts-filter' );
 const asDraftCheckboxes = document.querySelectorAll( '[name=dt_as_draft]' );
 const pullLinks = document.querySelectorAll( '.distributor_page_pull .pull a' );
+const { pull: pullText, as_draft: pullAsDraftText } = dt;
 
 jQuery( chooseConnection ).on( 'change', ( event ) => {
 
@@ -55,6 +57,7 @@ if ( chooseConnection && choosePostType && form ) {
 							dt_as_draft: 'draft', /*eslint camelcase: 0*/
 						}
 					);
+					pullLinks[i].text = pullAsDraftText;
 				}
 			} else {
 				for ( let i = 0; i < asDraftCheckboxes.length; ++i ) {
@@ -67,6 +70,7 @@ if ( chooseConnection && choosePostType && form ) {
 							dt_as_draft: '', /*eslint camelcase: 0*/
 						}
 					);
+					pullLinks[i].text = pullText;
 				}
 			}
 		} );

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -411,6 +411,10 @@ class WordPressExternalConnection extends ExternalConnection {
 				unset( $post_array['post_parent'] );
 			}
 
+			if ( ! empty( $item_array['post_status'] ) ) {
+				$post_array['post_status'] = $item_array['post_status'];
+			}
+
 			// Remove date stuff
 			unset( $post_array['post_date'] );
 			unset( $post_array['post_date_gmt'] );

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -227,6 +227,10 @@ class NetworkSiteConnection extends Connection {
 				unset( $post_array['post_parent'] );
 			}
 
+			if ( ! empty( $item_array['post_status'] ) ) {
+				$post_array['post_status'] = $item_array['post_status'];
+			}
+
 			add_filter( 'wp_insert_post_data', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'maybe_set_modified_date' ), 10, 2 );
 
 			// Filter documented in includes/classes/ExternalConnections/WordPressExternalConnection.php

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -327,7 +327,7 @@ class PullListTable extends \WP_List_Table {
 				}
 
 				$actions = [
-					'pull' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=syndicate&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id . '&pull_post_type=' . $item->post_type . '&dt_as_draft=' . $draft ), 'bulk-distributor_page_pull' ) ), esc_html__( 'Pull', 'distributor' ) ),
+					'pull' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=syndicate&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id . '&pull_post_type=' . $item->post_type . '&dt_as_draft=' . $draft ), 'bulk-distributor_page_pull' ) ), $draft ? esc_html__( 'Pull as draft', 'distributor' ) : esc_html__( 'Pull', 'distributor' ) ),
 					'view' => '<a href="' . esc_url( $item->link ) . '">' . esc_html__( 'View', 'distributor' ) . '</a>',
 					'skip' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=skip&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id ), 'dt_skip' ) ), esc_html__( 'Skip', 'distributor' ) ),
 				];
@@ -552,7 +552,7 @@ class PullListTable extends \WP_List_Table {
 		if ( $connection_now && $connection_now->pull_post_types && $connection_now->pull_post_type ) :
 			?>
 
-			<div class="alignleft actions">
+			<div class="alignleft actions dt-pull-post-type">
 				<label for="pull_post_type" class="screen-reader-text">Content to Pull</label>
 				<select id="pull_post_type" name="pull_post_type">
 					<?php foreach ( $connection_now->pull_post_types as $post_type ) : ?>
@@ -569,7 +569,7 @@ class PullListTable extends \WP_List_Table {
 					$as_draft = apply_filters( 'dt_pull_as_draft', true, $connection_now );
 				?>
 
-					<label class="as-draft" for="dt-as-draft-<?php echo esc_attr( $which ); ?>">
+					<label class="dt-as-draft" for="dt-as-draft-<?php echo esc_attr( $which ); ?>">
 						<input type="checkbox" id="dt-as-draft-<?php echo esc_attr( $which ); ?>" name="dt_as_draft" value="draft" <?php checked( $as_draft ); ?>> <?php esc_html_e( 'Pull in as draft', 'distributor' ); ?>
 					</label>
 				<?php endif; ?>

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -309,8 +309,25 @@ class PullListTable extends \WP_List_Table {
 				$actions = [];
 				$disable = true;
 			} else {
+				/**
+				 * Filter the default value of the 'Pull in as draft' option in the pull ui
+				 *
+				 * @hook dt_pull_as_draft
+				 *
+				 * @param {bool}   $as_draft   Whether the 'Pull in as draft' option should be checked.
+				 * @param {object} $connection The connection being used to pull from.
+				 *
+				 * @return {bool}
+				 */
+				$as_draft = apply_filters( 'dt_pull_as_draft', true, $connection_now );
+
+				$draft = 'draft';
+				if ( ! $as_draft ) {
+					$draft = '';
+				}
+
 				$actions = [
-					'pull' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=syndicate&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id . '&pull_post_type=' . $item->post_type ), 'bulk-distributor_page_pull' ) ), esc_html__( 'Pull', 'distributor' ) ),
+					'pull' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=syndicate&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id . '&pull_post_type=' . $item->post_type . '&dt_as_draft=' . $draft ), 'bulk-distributor_page_pull' ) ), esc_html__( 'Pull', 'distributor' ) ),
 					'view' => '<a href="' . esc_url( $item->link ) . '">' . esc_html__( 'View', 'distributor' ) . '</a>',
 					'skip' => sprintf( '<a href="%s">%s</a>', esc_url( wp_nonce_url( admin_url( 'admin.php?page=pull&action=skip&_wp_http_referer=' . rawurlencode( $_SERVER['REQUEST_URI'] ) . '&post=' . $item->ID . '&connection_type=' . $connection_type . '&connection_id=' . $connection_id ), 'dt_skip' ) ), esc_html__( 'Skip', 'distributor' ) ),
 				];
@@ -545,6 +562,17 @@ class PullListTable extends \WP_List_Table {
 					<?php endforeach; ?>
 				</select>
 				<input type="submit" name="filter_action" id="pull_post_type_submit" class="button" value="<?php esc_attr_e( 'Filter', 'distributor' ); ?>">
+
+				<?php
+				if ( empty( $_GET['status'] ) || 'pulled' !== $_GET['status']  ) :
+					// Filter documented above.
+					$as_draft = apply_filters( 'dt_pull_as_draft', true, $connection_now );
+				?>
+
+					<label class="as-draft" for="dt-as-draft-<?php echo esc_attr( $which ); ?>">
+						<input type="checkbox" id="dt-as-draft-<?php echo esc_attr( $which ); ?>" name="dt_as_draft" value="draft" <?php checked( $as_draft ); ?>> <?php esc_html_e( 'Pull in as draft', 'distributor' ); ?>
+					</label>
+				<?php endif; ?>
 			</div>
 
 			<?php

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -213,6 +213,7 @@ function process_actions() {
 						return [
 							'remote_post_id' => $remote_post_id,
 							'post_type'      => $post_type,
+							'post_status'    => 'draft',
 						];
 				},
 				$posts

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -205,15 +205,16 @@ function process_actions() {
 				break;
 			}
 
-			$posts     = (array) $_GET['post'];
-			$post_type = sanitize_text_field( $_GET['pull_post_type'] );
+			$posts       = (array) $_GET['post'];
+			$post_type   = sanitize_text_field( $_GET['pull_post_type'] );
+			$post_status = ! empty( $_GET['dt_as_draft'] ) && 'draft' === $_GET['dt_as_draft'] ? 'draft' : '';
 
 			$posts = array_map(
-				function( $remote_post_id ) use ( $post_type ) {
+				function( $remote_post_id ) use ( $post_type, $post_status ) {
 						return [
 							'remote_post_id' => $remote_post_id,
 							'post_type'      => $post_type,
-							'post_status'    => 'draft',
+							'post_status'    => $post_status,
 						];
 				},
 				$posts

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -116,6 +116,15 @@ function admin_enqueue_scripts( $hook ) {
 
 	wp_enqueue_script( 'dt-admin-pull', plugins_url( '/dist/js/admin-pull.min.js', __DIR__ ), array( 'jquery' ), DT_VERSION, true );
 	wp_enqueue_style( 'dt-admin-pull', plugins_url( '/dist/css/admin-pull-table.min.css', __DIR__ ), array(), DT_VERSION );
+
+	wp_localize_script(
+		'dt-admin-pull',
+		'dt',
+		[
+			'pull'     => __( 'Pull', 'distributor' ),
+			'as_draft' => __( 'Pull as draft', 'distributor' ),
+		]
+	);
 }
 
 /**


### PR DESCRIPTION
### Description of the Change

When pushing content, you have the ability to choose if that content should be sent in a draft state or not (draft is the default). But when pulling content, you don't have that option and items will come over with whatever `post_status` they have (typically published).

Having content automatically be published is probably not the ideal workflow, so this PR adds a new `Pull in as draft` checkbox to the Pull Content screen. This checkbox is checked by default and if checked, if content is pulled in, either individually or in bulk, the `post_status` will be set as draft on those items.

There is a filter around this value so if someone wants the default to be unchecked, they can use that filter to accomplish this.

<img width="421" alt="Screen Shot 2021-01-21 at 4 12 31 PM" src="https://user-images.githubusercontent.com/916738/105423839-7efb7c80-5c03-11eb-94c1-94a58369efef.png">

### Alternate Designs

We could just force pulled in content to be set as draft, rather than introducing a new checkbox control

### Benefits

Gives users the ability to choose whether pulled in content should be set in a draft state (which will now be the default) or if they want pulled content to inherit the `post_status` of the original item (which is the state if this new checkbox is unchecked).

### Possible Drawbacks

None

### Verification Process

Go to the Pull Content screen and see if the new `Pull in as draft` checkbox shows. Try pulling content individually and in bulk to ensure they come over as draft. Now uncheck that box and run the same tests again, ensuring items come over with their original `post_status`.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #695 