### PR TITLE
Hiding registration notice when it's registered

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -238,9 +238,9 @@ function license_key_callback() {
 	</div>
 
 	<?php if ( false === $settings['valid_license'] ) : ?>
-	<p class="description">
-		<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
-	</p>
+		<p class="description">
+			<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
+		</p>
 	<?php
 	endif;
 }
@@ -366,9 +366,9 @@ function network_settings_screen() {
 						</div>
 
 						<?php if ( false === $settings['valid_license'] ) : ?>
-						<p class="description">
-							<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
-						</p>
+							<p class="description">
+								<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
+							</p>
 						<?php endif; ?>
 					</td>
 				</tr>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -237,7 +237,7 @@ function license_key_callback() {
 		<input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>" id="dt_settings_license_key">
 	</div>
 
-	<?php if ( false === $settings['valid_license'] ) : ?>
+	<?php if ( true !== $settings['valid_license'] ) : ?>
 		<p class="description">
 			<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
 		</p>
@@ -365,7 +365,7 @@ function network_settings_screen() {
 							<input name="dt_settings[email]" type="email" placeholder="<?php esc_html_e( 'Email', 'distributor' ); ?>" value="<?php echo esc_attr( $email ); ?>"> <input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>">
 						</div>
 
-						<?php if ( false === $settings['valid_license'] ) : ?>
+						<?php if ( true !== $settings['valid_license'] ) : ?>
 							<p class="description">
 								<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
 							</p>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -237,10 +237,12 @@ function license_key_callback() {
 		<input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>" id="dt_settings_license_key">
 	</div>
 
+	<?php if ( false === $settings['valid_license'] ) : ?>
 	<p class="description">
 		<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
 	</p>
 	<?php
+	endif;
 }
 
 /**
@@ -363,9 +365,11 @@ function network_settings_screen() {
 							<input name="dt_settings[email]" type="email" placeholder="<?php esc_html_e( 'Email', 'distributor' ); ?>" value="<?php echo esc_attr( $email ); ?>"> <input name="dt_settings[license_key]" type="text" placeholder="<?php esc_html_e( 'Registration Key', 'distributor' ); ?>" value="<?php echo esc_attr( $license_key ); ?>">
 						</div>
 
+						<?php if ( false === $settings['valid_license'] ) : ?>
 						<p class="description">
 							<?php echo wp_kses_post( __( 'Registration is 100% free and provides update notifications and upgrades inside the dashboard. <a href="https://distributorplugin.com/#cta">Register for your key</a>.', 'distributor' ) ); ?>
 						</p>
+						<?php endif; ?>
 					</td>
 				</tr>
 			</tbody>


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/10up/distributor/issues/501. This change hides the registration notice when the valid registration key is added.

### Alternate Designs

N/A

### Benefits

This change will help to avoid the confusion of seeing the registration notice even after adding the valid key.

### Possible Drawbacks

N/A

### Verification Process

- Message should be shown when the fields are empty
- Message should be shown when invalid licence key is added
- Message should be hidden when there is a valid licence key

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/distributor/issues/501

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
