### PR TITLE
Fix some Pull UI errors

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -358,7 +358,7 @@ class PullListTable extends \WP_List_Table {
 	public function prepare_items() {
 		global $connection_now;
 
-		if ( empty( $connection_now ) ) {
+		if ( empty( $connection_now ) || empty( $connection_now->pull_post_type ) ) {
 			return;
 		}
 

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -409,9 +409,14 @@ function dashboard() {
 				<?php
 				$connection_now->pull_post_types = \Distributor\Utils\available_pull_post_types( $connection_now, $connection_type );
 
-				// Set the post type we want to pull
+				// Ensure we have at least one post type to pull
+				$connection_now->pull_post_type = '';
+				if ( ! empty( $connection_now->pull_post_types ) ) {
+					$connection_now->pull_post_type = $connection_now->pull_post_types[0]['slug'];
+				}
+
+				// Set the post type we want to pull (if any)
 				// This is either from a query param, "post" post type, or the first in the list
-				$connection_now->pull_post_type = $connection_now->pull_post_types[0]['slug'];
 				foreach ( $connection_now->pull_post_types as $post_type ) {
 					if ( isset( $_GET['pull_post_type'] ) ) { // @codingStandardsIgnoreLine No nonce needed here.
 						if ( $_GET['pull_post_type'] === $post_type['slug'] ) { // @codingStandardsIgnoreLine Comparing values, no nonce needed.


### PR DESCRIPTION
### Description of the Change

As reported in #402, if a connection has no supported post types for pulling, a PHP notice is shown (if debug is turned on). Fixing this, I also realized that if a connection has no post types available, we default to still showing content from the `post` post type, which seems non-ideal. So this PR fixes that as well, so if there are no post types available for pulling, we show the `No items found` message.

Also in addition, while testing this, I was able to reproduce another PHP notice on this screen. We have a helper function to output any pull error messages and this only accounted for external connections, so when using an internal connection, a PHP notice is shown. And finally, it's possible for internal and external connections to have the same ID and the way we were storing these error messages wasn't accounting for that. So I've made a change so transient key we use now is different for both internal and external connections, to avoid any potential overlap.

### Alternate Designs

None

### Benefits

No more PHP notices will be shown and this fixes a few additional bugs.

### Possible Drawbacks

None

### Verification Process

1. Add this filter to your current theme: `add_filter( 'dt_available_pull_post_types', '__return_empty_array' );`
2. Go to the Pull screen and ensure that 1) no PHP notice is shown and 2) no posts are shown as available for pulling
3. Remove that filter and go back to the Pull screen and ensure posts are now showing

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #402 