### PR TITLE
test for _wp_attachment_metadata blacklist

### DIFF
--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -659,8 +659,8 @@ class UtilsTest extends TestCase {
 				'times'  => 1,
 				'args'   => [ $media_post->ID ],
 				'return' => [
-					'meta1' => [ true ],
-					'meta2' => [ false ],
+					'meta1'                   => [ true ],
+					'meta2'                   => [ false ],
 					'_wp_attachment_metadata' => [ true ],
 				],
 			]

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -592,6 +592,94 @@ class UtilsTest extends TestCase {
 	}
 
 	/**
+	 * Test format media with no `_wp_attachment_metadata`
+	 *
+	 * @group Utils
+	 * @runInSeparateProcess
+	 */
+	public function test_format_media_no_attachment_meta() {
+		$media_post                 = new \stdClass();
+		$media_post->ID             = 1;
+		$media_post->post_parent    = 10;
+		$media_post->post_title     = 'title';
+		$media_post->post_content   = 'content';
+		$media_post->post_excerpt   = 'excerpt';
+		$media_post->post_mime_type = 'image/png';
+
+		\WP_Mock::userFunction(
+			'get_post_thumbnail_id', [
+				'times'  => 1,
+				'args'   => [ $media_post->post_parent ],
+				'return' => 0,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'get_post_meta', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID, '_wp_attachment_image_alt', true ],
+				'return' => 'alt',
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_attachment_is_image', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => true,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_attachment_metadata', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => [ 'test' => 1 ],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_get_attachment_url', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => 'http://mediaitem.com',
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'get_attached_file', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => '/var/www/html/wp-content/uploads/mediaitem.jpg',
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'get_post_meta', [
+				'times'  => 1,
+				'args'   => [ $media_post->ID ],
+				'return' => [
+					'meta1' => [ true ],
+					'meta2' => [ false ],
+					'_wp_attachment_metadata' => [ true ],
+				],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'remove_filter', [
+				'times' => 1,
+			]
+		);
+
+		$formatted_media = Utils\format_media_post( $media_post );
+
+		$this->assertFalse( array_key_exists( '_wp_attachment_metadata', $formatted_media['meta'] ) );
+
+		return $formatted_media;
+	}
+
+	/**
 	 * Test set media
 	 *
 	 * @since 1.0


### PR DESCRIPTION
### Description of the Change

PHPUnit test for https://github.com/10up/distributor/pull/289
Issue: https://github.com/10up/distributor/issues/306

### Benefits

Ensures `_wp_attachment_metadata` is not distributed to other sites.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

 https://github.com/10up/distributor/issues/306

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
