### PR TITLE
Fix the Gutenberg check for posts that have no `post_content` set

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -49,27 +49,27 @@ function is_using_gutenberg( $post ) {
 		return false;
 	}
 
-	if ( ! empty( $post->post_content ) ) {
-		// This duplicates the check from `use_block_editor_for_post()` as of WP 5.0.
-		// We duplicate this here to remove the $_GET['meta-box-loader'] check
-		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
-			// The posts page can't be edited in the block editor.
-			if ( absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
-				return false;
-			}
-
-			// Make sure this post type supports Gutenberg
-			$use_block_editor = use_block_editor_for_post_type( $post->post_type );
-
-			/** This filter is documented in wp-admin/includes/post.php */
-			return apply_filters( 'use_block_editor_for_post', $use_block_editor, $post );
+	// This duplicates the check from `use_block_editor_for_post()` as of WP 5.0.
+	// We duplicate this here to remove the $_GET['meta-box-loader'] check
+	if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+		// The posts page can't be edited in the block editor.
+		if ( absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
+			return false;
 		}
 
-		// This duplicates the check from `has_blocks()` as of WP 5.2.
+		// Make sure this post type supports Gutenberg
+		$use_block_editor = use_block_editor_for_post_type( $post->post_type );
+
+		/** This filter is documented in wp-admin/includes/post.php */
+		return apply_filters( 'use_block_editor_for_post', $use_block_editor, $post );
+	}
+
+	// This duplicates the check from `has_blocks()` as of WP 5.2.
+	if ( ! empty( $post->post_content ) ) {
 		return false !== strpos( (string) $post->post_content, '<!-- wp:' );
 	}
 
-	$use_block_editor = true;
+	$use_block_editor = false;
 
 	if ( ! function_exists( 'is_plugin_active' ) ) {
 		require_once ABSPATH . '/wp-admin/includes/plugin.php';


### PR DESCRIPTION
### Description of the Change

We have a Gutenberg check that tries to determine if a content type utilizes Gutenberg, both on the origin site and the site being distributed to. If both sites are using Gutenberg for that content type, we distribute the raw content instead of the rendered content, to ensure individual block markup isn't lost.

A bug was found where if the item you are trying to distribute has no `post_content` (either intentionally left blank or a content type that just uses meta), our Gutenberg check would always return `true`, though in most circumstances, this content type isn't actually using Gutenberg.

This doesn't cause any issues when initially distributing content, as the raw content in these circumstances will typically mirror the rendered content, but when pushing updates to internal connections, those updates fail. The issue here is when pushing updates, we check if the item in question uses Gutenberg and if so, we add a hook to `rest_after_insert_{$post->post_type}` to fire off updates. This ensures that all data is saved before we push updates.

So in circumstances where our Gutenberg check returns `true` when it shouldn't, we utilize the `rest_after_insert_{$post->post_type}` hook, but that hook will never fire if the item doesn't actually use Gutenberg, resulting in updates never getting pushed out.

To fix this, this PR updates our Gutenberg check to do a few things:
1. The main code that runs in that check is currently behind a check that ensures we have `post_content`. There's no real reason we need that code behind that check, so this PR moves it out of that. This ensures this check runs irregardless of if the post has content or not
2. In situations where these checks get bypassed (which would only be someone using WordPress <5.0, plus the Gutenberg plugin, plus a post that has no content), we set our default to `false` instead of `true`, as it's more likely they aren't using Gutenberg and even if they are, we don't really care since we have no content to distribute 

### Alternate Designs

Instead of making both of the above changes, we could make just one or the other. I think it makes the most sense to change both but if we want less potential impact, we could just change the default value to `false` and leave our first check as-is

### Benefits

Better check to determine if something uses Gutenberg

### Possible Drawbacks

None that I've seen but because this does change our Gutenberg check, there is potential that this could negatively impact other scenarios I haven't though of

### Verification Process

1. Register a new post type that doesn't support the editor but does have `show_in_rest` set to `true`
2. Without this code change in place, create a new item in that post type and distribute it to an internal connection. Ensure this distribution worked
3. Make an update to the title of the original and note that update did not come over
4. Add this code change in and try an update again. That update should come over 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #659 