### PR TITLE
Reset the `last_changed_sites` option when a new site is created

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -496,6 +496,7 @@ class NetworkSiteConnection extends Connection {
 		add_action( 'wp_trash_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'separate_syndicated_on_delete' ) );
 		add_action( 'untrash_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'connect_syndicated_on_untrash' ) );
 		add_action( 'clean_site_cache', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'set_sites_last_changed_time' ) );
+		add_action( 'wp_insert_site', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'set_sites_last_changed_time' ) );
 		add_action( 'add_user_to_blog', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'rebuild_user_authorized_sites_cache' ) );
 		add_action( 'remove_user_from_blog', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'rebuild_user_authorized_sites_cache' ) );
 	}


### PR DESCRIPTION
### Description of the Change

We currently have some caching around our internal sites list that should be updated anytime a new site is created. An issue was reported where if a site was created using WP-CLI, no connections would show until that site was manually saved in the network settings. This seems to point to a caching issue.

Looking through the code that fires when a new site is created via WP-CLI, there is a possibility that the current way we update our cache may not fire correctly, under certain circumstances.

This PR adds a new hook onto `wp_insert_site` that fires our same cache clearing function we currently use that is hooked to `clean_site_cache`. In theory, this second hook _should_ always fire, while the first one may not fire in certain circumstances. For most circumstances though, both of these hooks will probably end up firing.

### Alternate Designs

None

### Benefits

The internal connections list should be more accurate now when a new site is created

### Possible Drawbacks

For most setups, I think we'll end up with both hooks firing, which isn't a huge deal but we'll basically clear the cache twice.

### Verification Process

Within an existing multisite, create a new site, go to that site and go to the Pull screen. Ensure connections show on that screen. Run this test both with manually creating a site and using WP-CLI.

Can also test from the perspective of an existing site. So create a new site, go to an existing site, go to the Pull screen and ensure the newly created site shows in the list. 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#639