### PR TITLE
Set empty action in bulk action dropdown

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -527,6 +527,7 @@ class PullListTable extends \WP_List_Table {
 	public function get_bulk_actions() {
 		if ( empty( $_GET['status'] ) || 'new' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
 			$actions = [
+				'-1'             => esc_html__( 'Bulk Action', 'distributor' ),
 				'bulk-syndicate' => esc_html__( 'Pull', 'distributor' ),
 				'bulk-skip'      => esc_html__( 'Skip', 'distributor' ),
 			];

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -527,7 +527,7 @@ class PullListTable extends \WP_List_Table {
 	public function get_bulk_actions() {
 		if ( empty( $_GET['status'] ) || 'new' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
 			$actions = [
-				'-1'             => esc_html__( 'Bulk Action', 'distributor' ),
+				'-1'             => esc_html__( 'Bulk Actions', 'distributor' ),
 				'bulk-syndicate' => esc_html__( 'Pull', 'distributor' ),
 				'bulk-skip'      => esc_html__( 'Skip', 'distributor' ),
 			];


### PR DESCRIPTION
### Description of the Change
We have the `Pull` action as the default action on the bulk dropdown, whenever we click the `Apply` button the page sends both top and bottom form to the server irrespective of the button we clicked. Since both `action` and `action2` has values, WP always takes the value of `action'. Now I have added a empty option as like the post list page to fix this issue. 


### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.


### Applicable Issues

https://github.com/10up/distributor/issues/610
