### PR TITLE
Introduce 'View all' post type filter on pull screen

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -248,32 +248,21 @@ class PullListTable extends \WP_List_Table {
 	}
 
 	/**
-	 * Output standard table columns (not name)
+	 * Output standard table columns.
 	 *
 	 * @param  array|\WP_Post $item Item to output.
 	 * @param  string         $column_name Column name.
 	 *
-	 * @return string Url, post title, or empty string.
+	 * @return string.
 	 * @since  0.8
 	 */
 	public function column_default( $item, $column_name ) {
-		switch ( $column_name ) {
-			case 'name':
-				return $item->post_title;
-			case 'url':
-				$url = get_post_meta( $item->ID, 'dt_external_connection_url', true );
+		if ( 'post_type' === $column_name ) {
+			$post_type = get_post_type_object( $item->post_type );
 
-				if ( empty( $url ) ) {
-					$url = esc_html__( 'None', 'distributor' );
-				}
-
-				return $url;
-			case 'post_type':
-				$post_type = get_post_type_object( $item->post_type );
-
-				if ( $post_type && isset( $post_type->labels->singular_name ) ) {
-					return $post_type->labels->singular_name;
-				}
+			if ( $post_type && isset( $post_type->labels->singular_name ) ) {
+				return $post_type->labels->singular_name;
+			}
 		}
 
 		/**

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -422,10 +422,10 @@ function dashboard() {
 				<?php
 				$connection_now->pull_post_types = \Distributor\Utils\available_pull_post_types( $connection_now, $connection_type );
 
-				// Ensure we have at least one post type to pull
+				// Ensure we have at least one post type to pull.
 				$connection_now->pull_post_type = '';
 				if ( ! empty( $connection_now->pull_post_types ) ) {
-					$connection_now->pull_post_type = 'all';
+					$connection_now->pull_post_type = ( 'internal' === $connection_type ) ? 'all' : $connection_now->pull_post_types[0]['slug'];
 				}
 
 				// Set the post type we want to pull (if any)
@@ -433,6 +433,11 @@ function dashboard() {
 				foreach ( $connection_now->pull_post_types as $post_type ) {
 					if ( isset( $_GET['pull_post_type'] ) ) { // @codingStandardsIgnoreLine No nonce needed here.
 						if ( $_GET['pull_post_type'] === $post_type['slug'] ) { // @codingStandardsIgnoreLine Comparing values, no nonce needed.
+							$connection_now->pull_post_type = $post_type['slug'];
+							break;
+						}
+					} else {
+						if ( 'post' === $post_type['slug'] && 'external' === $connection_type ) {
 							$connection_now->pull_post_type = $post_type['slug'];
 							break;
 						}

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -425,7 +425,7 @@ function dashboard() {
 				// Ensure we have at least one post type to pull
 				$connection_now->pull_post_type = '';
 				if ( ! empty( $connection_now->pull_post_types ) ) {
-					$connection_now->pull_post_type = $connection_now->pull_post_types[0]['slug'];
+					$connection_now->pull_post_type = 'all';
 				}
 
 				// Set the post type we want to pull (if any)
@@ -433,11 +433,6 @@ function dashboard() {
 				foreach ( $connection_now->pull_post_types as $post_type ) {
 					if ( isset( $_GET['pull_post_type'] ) ) { // @codingStandardsIgnoreLine No nonce needed here.
 						if ( $_GET['pull_post_type'] === $post_type['slug'] ) { // @codingStandardsIgnoreLine Comparing values, no nonce needed.
-							$connection_now->pull_post_type = $post_type['slug'];
-							break;
-						}
-					} else {
-						if ( 'post' === $post_type['slug'] ) {
 							$connection_now->pull_post_type = $post_type['slug'];
 							break;
 						}


### PR DESCRIPTION
### Description of the Change

Introduce a 'View all' filter on the pull screen to allow users to view all post types by default instead of filtering manually. Also added a new column to the pull screen table to show which post type is currently in view - useful for when all are being displayed.

This handles one of the planned changes outlined in #392.

### Alternate Designs
N/A

### Benefits
Allows users to view all available post types on the pull screen without having to filter separately.

### Possible Drawbacks


### Verification Process

1. Visit the pull screen and verify that "View all" is selected by default - all post types should be viewable
2. Test filtering various post types
3. Ensure correct post type is visible within the added "Post Type" column

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x]  My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#392 

### Changelog Entry
