### PR TITLE
Hide manual connection when switching to WP.COM

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -451,6 +451,12 @@ jQuery( externalConnectionTypeField ).on( 'change', () => {
 	const slug = externalConnectionTypeField.value;
 
 	wpbody.className = slug;
+
+	if ( 'wp' === slug ) {
+		jQuery( '.external-connection-setup, .hide-until-authed' ).show();
+	} else {
+		jQuery( '.external-connection-setup, .hide-until-authed' ).hide();
+	}
 } );
 
 

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -453,7 +453,7 @@ jQuery( externalConnectionTypeField ).on( 'change', () => {
 	wpbody.className = slug;
 
 	if ( 'wp' === slug ) {
-		jQuery( '.external-connection-setup, .hide-until-authed' ).show();
+		jQuery( '.external-connection-wizard' ).show();
 	} else {
 		jQuery( '.external-connection-setup, .hide-until-authed' ).hide();
 	}


### PR DESCRIPTION
### Description of the Change

Hiding manual connection setup fields when switching to wp.com connection mode.


### Verification Process

- Checkout to this branch
- Run `npm run watch`
- Create new external connection
- Try to change the connection type

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/distributor/issues/583
