### PR TITLE
Add ability to Unskip or Pull items from the Skipped tab on the Pull screen

### DIFF
--- a/includes/classes/Connection.php
+++ b/includes/classes/Connection.php
@@ -43,11 +43,19 @@ abstract class Connection {
 	/**
 	 * Log a sync
 	 *
-	 * @param array $item_id_mappings Mapping to store; key = origin post ID, value = new post ID.
-	 * @param int   $id Blog or Connection ID. Optional.
+	 * @param array   $item_id_mappings Mapping to store; key = origin post ID, value = new post ID.
+	 * @param int     $id Blog or Connection ID. Optional.
+	 * @param boolean $overwrite Whether to overwrite the sync log. Optional.
 	 * @since 0.8
 	 */
-	abstract public function log_sync( array $item_id_mappings, $id );
+	abstract public function log_sync( array $item_id_mappings, $id, bool $overwrite );
+
+	/**
+	 * Get the sync log
+	 *
+	 * @param int $id Blog or Connection ID. Optional.
+	 */
+	abstract public function get_sync_log( $id );
 
 	/**
 	 * Get available post types from a connection

--- a/includes/classes/ExternalConnection.php
+++ b/includes/classes/ExternalConnection.php
@@ -77,9 +77,9 @@ abstract class ExternalConnection extends Connection {
 	public function log_sync( array $item_id_mappings, $connection_id = 0, $overwrite = false ) {
 		$connection_id = 0 === $connection_id ? $this->id : $connection_id;
 
-		$sync_log = get_post_meta( $connection_id, 'dt_sync_log', true );
+		$sync_log = $this->get_sync_log( $connection_id );
 
-		if ( empty( $sync_log ) || true === $overwrite ) {
+		if ( true === $overwrite ) {
 			$sync_log = array();
 		}
 

--- a/includes/classes/ExternalConnection.php
+++ b/includes/classes/ExternalConnection.php
@@ -69,16 +69,17 @@ abstract class ExternalConnection extends Connection {
 	 *
 	 * This let's us grab all the IDs of posts we've PULLED from a given connection
 	 *
-	 * @param array $item_id_mappings Mapping array to store; key = origin post ID, value = new post ID.
-	 * @param int   $connection_id Connection ID.
+	 * @param array   $item_id_mappings Mapping array to store; key = origin post ID, value = new post ID.
+	 * @param int     $connection_id Connection ID.
+	 * @param boolean $overwrite Whether to overwrite the sync log for this connection. Default false.
 	 * @since 0.8
 	 */
-	public function log_sync( array $item_id_mappings, $connection_id = 0 ) {
+	public function log_sync( array $item_id_mappings, $connection_id = 0, $overwrite = false ) {
 		$connection_id = 0 === $connection_id ? $this->id : $connection_id;
 
 		$sync_log = get_post_meta( $connection_id, 'dt_sync_log', true );
 
-		if ( empty( $sync_log ) ) {
+		if ( empty( $sync_log ) || true === $overwrite ) {
 			$sync_log = array();
 		}
 
@@ -103,6 +104,24 @@ abstract class ExternalConnection extends Connection {
 		 * @param {object} $this The current connection class.
 		 */
 		do_action( 'dt_log_sync', $item_id_mappings, $sync_log, $this );
+	}
+
+	/**
+	 * Return the sync log for a specific connection
+	 *
+	 * @param int $connection_id Connection ID.
+	 * @return array
+	 */
+	public function get_sync_log( $connection_id = 0 ) {
+		$connection_id = 0 === $connection_id ? $this->id : $connection_id;
+
+		$sync_log = get_post_meta( $connection_id, 'dt_sync_log', true );
+
+		if ( empty( $sync_log ) ) {
+			$sync_log = [];
+		}
+
+		return $sync_log;
 	}
 
 	/**

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -346,12 +346,7 @@ class NetworkSiteConnection extends Connection {
 	public function log_sync( array $item_id_mappings, $blog_id = 0, $overwrite = false ) {
 		$blog_id = 0 === $blog_id ? $this->site->blog_id : $blog_id;
 
-		$sync_log = get_option( 'dt_sync_log', array() );
-
-		$current_site_log = [];
-		if ( ! empty( $sync_log[ $blog_id ] ) && false === $overwrite ) {
-			$current_site_log = $sync_log[ $blog_id ];
-		}
+		$current_site_log = $this->get_sync_log( $blog_id );
 
 		foreach ( $item_id_mappings as $old_item_id => $new_item_id ) {
 			if ( empty( $new_item_id ) || is_wp_error( $new_item_id ) ) {

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -338,17 +338,18 @@ class NetworkSiteConnection extends Connection {
 	 *
 	 * This let's us grab all the IDs of posts we've PULLED from a given site
 	 *
-	 * @param array $item_id_mappings Mapping to log; key = origin post ID, value = new post ID.
-	 * @param int   $blog_id Blog ID
+	 * @param array   $item_id_mappings Mapping to log; key = origin post ID, value = new post ID.
+	 * @param int     $blog_id Blog ID
+	 * @param boolean $overwrite Whether to overwrite the sync log for this site. Default false.
 	 * @since 0.8
 	 */
-	public function log_sync( array $item_id_mappings, $blog_id = 0 ) {
+	public function log_sync( array $item_id_mappings, $blog_id = 0, $overwrite = false ) {
 		$blog_id = 0 === $blog_id ? $this->site->blog_id : $blog_id;
 
 		$sync_log = get_option( 'dt_sync_log', array() );
 
 		$current_site_log = [];
-		if ( ! empty( $sync_log[ $blog_id ] ) ) {
+		if ( ! empty( $sync_log[ $blog_id ] ) && false === $overwrite ) {
 			$current_site_log = $sync_log[ $blog_id ];
 		}
 
@@ -366,6 +367,25 @@ class NetworkSiteConnection extends Connection {
 
 		// Action documented in includes/classes/ExternalConnection.php.
 		do_action( 'dt_log_sync', $item_id_mappings, $sync_log, $this );
+	}
+
+	/**
+	 * Return the sync log for a specific site
+	 *
+	 * @param int $blog_id Blog ID
+	 * @return array
+	 */
+	public function get_sync_log( $blog_id = 0 ) {
+		$blog_id = 0 === $blog_id ? $this->site->blog_id : $blog_id;
+
+		$sync_log = get_option( 'dt_sync_log', [] );
+
+		$current_site_log = [];
+		if ( ! empty( $sync_log[ $blog_id ] ) ) {
+			$current_site_log = $sync_log[ $blog_id ];
+		}
+
+		return $current_site_log;
 	}
 
 	/**

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -344,9 +344,12 @@ class NetworkSiteConnection extends Connection {
 	 * @since 0.8
 	 */
 	public function log_sync( array $item_id_mappings, $blog_id = 0, $overwrite = false ) {
-		$blog_id = 0 === $blog_id ? $this->site->blog_id : $blog_id;
+		$blog_id          = 0 === $blog_id ? $this->site->blog_id : $blog_id;
+		$current_site_log = [];
 
-		$current_site_log = $this->get_sync_log( $blog_id );
+		if ( false === $overwrite ) {
+			$current_site_log = $this->get_sync_log( $blog_id );
+		}
 
 		foreach ( $item_id_mappings as $old_item_id => $new_item_id ) {
 			if ( empty( $new_item_id ) || is_wp_error( $new_item_id ) ) {


### PR DESCRIPTION
### Description of the Change

At the moment, if you Skip an item from the Pull screen, that item goes to a Skipped tab. From here, the only option a user has is to view that item. So if someone were to accidentally Skip an item or change their mind later, there isn't an easy way for them to later pull that item.

This PR adds the same Pull options to the Skipped tab, both in the bulk actions and in the inline row options. This allows someone to directly Pull an item from the Skipped tab.

In addition, it adds a new Unskip option, both in the bulk actions and in an inline row option. If this Unskip option is used, the Skipped item is sent back to the New screen and can then be Pulled from there later (or Skipped again if desired).

Note: by default, we show the 10 most recent items on the new screen. If someone were to Unskip an item that doesn't belong to one of those 10 items, this item will still be Unskipped but won't show up on the first page of results. Pagination will have to be used to find this item.

### Alternate Designs

None

### Benefits

Users can now Unskip or directly Pull previously Skipped items

### Possible Drawbacks

None

### Verification Process

1. Go to the Pull screen and from the New tab, Skip an item
2. Go to the Skipped tab and find this Skipped item
3. Test using the inline row option and Unskip this item
4. Verify that item now shows back up in the New tab
5. Repeat using the Bulk option
6. In addition, test if the Pull option works as expected from the Skipped tab following the same directions as above but using the Pull option instead of the Unskip option

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Addresses part of #392