### PR TITLE
Fix: Post author uses API user instead of author

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -265,7 +265,7 @@ function register_endpoints() {
 		array(
 			'get_callback'    => function( $post_array ) {
 				$site_url = get_post_meta( $post_array['id'], 'dt_original_site_url', true );
-				return empty( $site_url ) ? home_url() : esc_html( $site_url );
+				return empty( $site_url ) ? home_url() : esc_url_raw( $site_url );
 			},
 			'update_callback' => function( $value, $post ) { },
 			'schema'          => array(

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -248,7 +248,8 @@ function register_endpoints() {
 		'distributor_original_site_name',
 		array(
 			'get_callback'    => function( $post_array ) {
-				return esc_html( get_post_meta( $post_array['id'], 'dt_original_site_name', true ) );
+				$site_name = get_post_meta( $post_array['id'], 'dt_original_site_name', true );
+				return empty( $site_name ) ? get_bloginfo( 'name' ) : esc_html( $site_name );
 			},
 			'update_callback' => function( $value, $post ) { },
 			'schema'          => array(
@@ -263,7 +264,8 @@ function register_endpoints() {
 		'distributor_original_site_url',
 		array(
 			'get_callback'    => function( $post_array ) {
-				return esc_url_raw( get_post_meta( $post_array['id'], 'dt_original_site_url', true ) );
+				$site_url = get_post_meta( $post_array['id'], 'dt_original_site_url', true );
+				return empty( $site_url ) ? home_url() : esc_html( $site_url );
 			},
 			'update_callback' => function( $value, $post ) { },
 			'schema'          => array(

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -371,6 +371,15 @@ function prepare_meta( $post_id ) {
 	$meta          = get_post_meta( $post_id );
 	$prepared_meta = array();
 
+
+	$author_id                 = get_post_field( 'post_author', $post_id );
+	$meta['dt_original_author'] = array(
+		array(
+			'name' => get_the_author_meta( 'display_name', $author_id ),
+			'url'  => get_author_posts_url( $author_id ),
+		)
+	);
+
 	$blacklisted_meta = blacklisted_meta();
 
 	// Transfer all meta

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -371,13 +371,12 @@ function prepare_meta( $post_id ) {
 	$meta          = get_post_meta( $post_id );
 	$prepared_meta = array();
 
-
 	$author_id                 = get_post_field( 'post_author', $post_id );
 	$meta['dt_original_author'] = array(
 		array(
 			'name' => get_the_author_meta( 'display_name', $author_id ),
 			'url'  => get_author_posts_url( $author_id ),
-		)
+		),
 	);
 
 	$blacklisted_meta = blacklisted_meta();


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Originally, when `override_author_byline` is false, Distributor uses the user of the remote site (which is used for authorizing the connection) as the post author.

This PR adds the ability to display the original author for distributed posts. This is enabled by default and can be turned off by a filter to restore the original behavior. I decided to make it default because using the original author makes more sense to me.

This PR also fixes the issue where the original site name and URL are `null` when pulling external posts.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
n/a
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
As mentioned above.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
This PR will cause inconsistent behavior for the old posts which don't have the original author data.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Switch to this PR on both original and remote sites.
2. Make sure `override_author_byline` isn't checked on both sites.
3. On the remote site, create a post with a unique author, which is not the current logged-in user or has the same username as any user on the remote site.
4. Push the post to the remote site.
5. See the author name and URL of the distributed post on the frontend set to the original author.
6. Do the similar for pull, see the original author used on the front end.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #751
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Fixed: prepare correct original site name and URL for pull action.
Added: show the original author as the author of distributed posts.