### PR TITLE
Ensure pulling content from an external connection sets all meta properly

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -248,7 +248,13 @@ function register_endpoints() {
 		'distributor_original_site_name',
 		array(
 			'get_callback'    => function( $post_array ) {
-				return esc_html( get_post_meta( $post_array['id'], 'dt_original_site_name', true ) );
+				$site_name = get_post_meta( $post_array['id'], 'dt_original_site_name', true );
+
+				if ( ! $site_name ) {
+					$site_name = get_bloginfo( 'name' );
+				}
+
+				return esc_html( $site_name );
 			},
 			'update_callback' => function( $value, $post ) { },
 			'schema'          => array(
@@ -263,7 +269,13 @@ function register_endpoints() {
 		'distributor_original_site_url',
 		array(
 			'get_callback'    => function( $post_array ) {
-				return esc_url_raw( get_post_meta( $post_array['id'], 'dt_original_site_url', true ) );
+				$site_url = get_post_meta( $post_array['id'], 'dt_original_site_url', true );
+
+				if ( ! $site_url ) {
+					$site_url = home_url();
+				}
+
+				return esc_url_raw( $site_url );
 			},
 			'update_callback' => function( $value, $post ) { },
 			'schema'          => array(


### PR DESCRIPTION
### Description of the Change

Currently, if you pull in content from an external connection, there are two meta fields that are empty: `dt_original_site_name` and `dt_original_site_url`.

The issue here is those fields are added to the REST API response but they pull their values from post meta. Those meta values will only exist if the content itself was originally distributed. But for original content, those fields will always be blank and thus that meta will never get properly set on content that is pulled in.

This PR fixes that by updating the callback function for both of those fields to use a proper fallback if the meta fields are empty.

### Alternate Designs

It seems like the way those fields are set up in the API is to support content that has already been distributed. Adding a fallback value fixes the use case here but could also add separate fields just for these original site values if we wanted to decouple that logic.

### Benefits

Pulled external content will have the original site meta set properly

### Possible Drawbacks

None

### Verification Process

1. Check out these changes
2. Create an external connection if needed
3. Pull content from that external connection
4. Verify the `dt_original_site_name` and `dt_original_site_url` have a proper value set

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #769 

### Changelog Entry

> Fix - Ensure original site information is set properly on content Pulled from external connections