### PR TITLE
Ensure we are on a multisite before using `switch_to_blog`

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -542,7 +542,7 @@ function menu_content() {
 	$original_blog_id = get_post_meta( $post->ID, 'dt_original_blog_id', true );
 	$original_post_id = get_post_meta( $post->ID, 'dt_original_post_id', true );
 
-	if ( ! empty( $original_blog_id ) && ! empty( $original_post_id ) && ! $unlinked ) {
+	if ( ! empty( $original_blog_id ) && ! empty( $original_post_id ) && ! $unlinked && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 		$post_url  = get_permalink( $original_post_id );
 		$site_url  = home_url();

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -344,7 +344,7 @@ function link() {
 	/**
 	 * For external connections we use a saved update since we might not have access to sync from original
 	 */
-	if ( empty( $original_source_id ) ) {
+	if ( empty( $original_source_id ) && is_multisite() ) {
 		$original_post_id = get_post_meta( $post_id, 'dt_original_post_id', true );
 		$original_blog_id = get_post_meta( $post_id, 'dt_original_blog_id', true );
 
@@ -423,7 +423,7 @@ function syndicated_message( $post ) {
 	$post_url           = get_post_meta( $post->ID, 'dt_original_post_url', true );
 	$original_site_name = get_post_meta( $post->ID, 'dt_original_site_name', true );
 
-	if ( ! empty( $original_blog_id ) ) {
+	if ( ! empty( $original_blog_id ) && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 		$original_location_name = get_bloginfo( 'name' );
 		restore_current_blog();
@@ -537,7 +537,7 @@ function enqueue_gutenberg_edit_scripts() {
 		$total_connections = count( $connection_map['internal'] ) + count( $connection_map['external'] );
 	}
 
-	if ( ! empty( $original_blog_id ) ) {
+	if ( ! empty( $original_blog_id ) && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 		$original_location_name = get_bloginfo( 'name' );
 		restore_current_blog();

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -43,7 +43,7 @@ function distributor_get_original_post_link( $post_id = null ) {
 	$original_site_name = get_post_meta( $post_id, 'dt_original_site_name', true );
 	$original_post_url  = get_post_meta( $post_id, 'dt_original_post_url', true );
 
-	if ( ! empty( $original_blog_id ) && ! empty( $original_post_id ) ) {
+	if ( ! empty( $original_blog_id ) && ! empty( $original_post_id ) && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 
 		$link = get_permalink( $original_post_id );
@@ -85,7 +85,7 @@ function distributor_get_original_site_name( $post_id = null ) {
 	$original_blog_id   = get_post_meta( $post_id, 'dt_original_blog_id', true );
 	$original_site_name = get_post_meta( $post_id, 'dt_original_site_name', true );
 
-	if ( ! empty( $original_blog_id ) ) {
+	if ( ! empty( $original_blog_id ) && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 
 		$text = get_bloginfo( 'name' );
@@ -127,7 +127,7 @@ function distributor_get_original_site_url( $post_id = null ) {
 	$original_blog_id  = get_post_meta( $post_id, 'dt_original_blog_id', true );
 	$original_site_url = get_post_meta( $post_id, 'dt_original_site_url', true );
 
-	if ( ! empty( $original_blog_id ) ) {
+	if ( ! empty( $original_blog_id ) && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
 
 		$url = home_url();

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -982,6 +982,9 @@ function get_processed_content( $post_content ) {
  * @return string
  */
 function get_rest_url( $blog_id, $post_id ) {
+	if ( ! is_multisite() ) {
+		return apply_filters( 'dt_get_rest_url', false, $blog_id, $post_id );
+	}
 
 	switch_to_blog( $blog_id );
 


### PR DESCRIPTION
### Description of the Change

As detailed in #773, if you use Distributor on a multisite and then convert some of those sites into single install sites, you can run into PHP fatal errors. The issue here is around our usage of `switch_to_blog`. We had checks in place to ensure we only used that if the proper Distributor meta was in place but in the above scenario, you can have that meta but actually not be on a multisite.

This PR fixes that by adding `is_multisite()` checks to any function that uses `switch_to_blog` after checking for the existence of Distributor meta. This should prevent fatal errors from occurring in the above detailed scenario.

### Alternate Designs

None

### Benefits

No PHP fatal errors will happen when using Distributor on sites that used to be part of a multisite

### Possible Drawbacks

None

### Verification Process

1. Create a WordPress multisite with two sites
2. Distribute some content from site A to site B
3. Convert site B to a stand-alone site
4. Edit one of the items that was distributed and see that no errors occur

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

#773 

### Changelog Entry

> Fixed - ensure we are on a multisite before using `switch_to_blog`
