### PR TITLE
Simplify how we show/hide the overlay

### DIFF
--- a/assets/css/push.css
+++ b/assets/css/push.css
@@ -48,20 +48,14 @@
 	display: block;
 }
 
-#distributor-overlay {
-	display: none;
+#wp-admin-bar-distributor.hover + #distributor-overlay,
+#wp-admin-bar-distributor.syncing + #distributor-overlay  {
 	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
 	background: rgba(0, 0, 0, 0.6);
-	z-index: 10000;
-
-	&.show,
-	&.syncing {
-		display: block;
-	}
 }
 
 #wpadminbar #distributor-push-wrapper .inner {


### PR DESCRIPTION
### Description of the Change

In #750, we added support for Gutenberg's full screen mode and in the process of that, changed up how the overlay on the distribution menu is used. Main goal there was to be able to capture clicks on the overlay and use that to close the overlay (as well as retain the hover in/out showing and hiding).

After thinking about it a bit more, I thought of a few ways this could be simplified and the results of that are this PR.

This overlay div is now added right after the distributor menu item, so we can use just CSS to show and hide that. This means the overlay should never show unless it's needed, while the current approach can result in the overlay showing if you hover over/out really quickly on the menu item. This also means a lot of code can be removed as it is no longer needed.

We still have one use of `hoverintent` that I would love to get rid of but I couldn't come up with a better approach there. Basically we need to know when someone hovers out of the menu so we can hide the admin bar if in fullscreen mode. Open to thoughts on that piece.

### Alternate Designs

None

### Benefits

Simpler logic around the showing and hiding of the overlay

### Possible Drawbacks

None

### Verification Process

Same process as described on #750

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

### Changelog Entry

> Fix - simplify how we show and hide the Distributor overlay when the Distributor menu is shown