### PR TITLE
Add proper error `<ul>` so errors can be properly shown

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -594,6 +594,7 @@ function menu_content() {
 				<div class="loader-messages messages">
 					<div class="dt-error">
 						<?php esc_html_e( 'There was an issue loading connections.', 'distributor' ); ?>
+						<ul class="details"></ul>
 					</div>
 				</div>
 			</div>

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -82,6 +82,7 @@
 			</div>
 			<div class="dt-error">
 				<?php esc_html_e( 'There were some issues distributing the post.', 'distributor' ); ?>
+				<ul class="details"></ul>
 			</div>
 		</div>
 

--- a/templates/show-connections.php
+++ b/templates/show-connections.php
@@ -80,6 +80,7 @@
 			</div>
 			<div class="dt-error">
 				<?php esc_html_e( 'There were some issues distributing the post.', 'distributor' ); ?>
+				<ul class="details"></ul>
 			</div>
 		</div>
 


### PR DESCRIPTION
### Description of the Change

In our templates that output the connection dropdown, used when Pushing content, we were missing an unordered list element that we look for when outputting error messages. It appears this accidentally got removed when changes were made to better support [AMP](https://github.com/10up/distributor/pull/665).

Without this element, if an error occurs during pushing, that error message will not be shown and a console error will happen (as reported in #795). This PR fixes this by adding that error element back to each template that needs it.

### Alternate Designs

None

### Benefits

Error messages will properly show and no console errors will happen

### Possible Drawbacks

None

### Verification Process

Easy way to create an error during push is to modify the [`ajax_push`](https://github.com/10up/distributor/blob/1.6.5/includes/push-ui.php#L224) function and at the top of that, temporarily add a `wp_send_json_error`. Then go and try pushing some content. An error message should show and it should match whatever message as manually added.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #795

### Changelog Entry

> Fixed - ensure error messages are shown properly if an error happens during a push
