### PR TITLE
Change how the `New` tab is generated on the Pull screen for external connections

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -165,20 +165,6 @@ class WordPressExternalConnection extends ExternalConnection {
 			}
 		}
 
-		/**
-		 * Filter the remote_get query arguments
-		 *
-		 * @since 1.0
-		 * @hook dt_remote_get_query_args
-		 *
-		 * @param  {array}  $query_args The existing query arguments.
-		 * @param  {array}  $args       The arguments originally passed to `remote_get`.
-		 * @param  {object} $this       The authentication class.
-		 *
-		 * @return {array} The existing query arguments.
-		 */
-		$query_args = apply_filters( 'dt_remote_get_query_args', $query_args, $args, $this );
-
 		// When running a query for the Pull screen with excluded items, make a POST request instead
 		if ( empty( $id ) && isset( $args['post__not_in'] ) && isset( $args['dt_pull_list'] ) ) {
 			$query_args['post_type'] = isset( $post_type ) ? $post_type : 'post';
@@ -256,6 +242,20 @@ class WordPressExternalConnection extends ExternalConnection {
 		if ( ! empty( $posts_per_page ) ) {
 			$args_str .= 'per_page=' . (int) $posts_per_page;
 		}
+
+		/**
+		 * Filter the remote_get query arguments
+		 *
+		 * @since 1.0
+		 * @hook dt_remote_get_query_args
+		 *
+		 * @param  {array}  $query_args The existing query arguments.
+		 * @param  {array}  $args       The arguments originally passed to `remote_get`.
+		 * @param  {object} $this       The authentication class.
+		 *
+		 * @return {array} The existing query arguments.
+		 */
+		$query_args = apply_filters( 'dt_remote_get_query_args', $query_args, $args, $this );
 
 		foreach ( $query_args as $arg_key => $arg_value ) {
 			if ( is_array( $arg_value ) ) {
@@ -402,6 +402,7 @@ class WordPressExternalConnection extends ExternalConnection {
 					/**
 					 * Filter the timeout used when calling `remote_post`
 					 *
+					 * @since 1.6.7
 					 * @hook dt_remote_post_timeout
 					 *
 					 * @param int $timeout The timeout to use for the remote post. Default `45`.
@@ -410,7 +411,18 @@ class WordPressExternalConnection extends ExternalConnection {
 					 * @return int The timeout to use for the remote_post call.
 					 */
 					'timeout' => apply_filters( 'dt_remote_post_timeout', 45, $args ),
-					'body'    => $args,
+					/**
+					 * Filter the remote_post query arguments
+					 *
+					 * @since 1.6.7
+					 * @hook dt_remote_post_query_args
+					 *
+					 * @param {array}  $args The request arguments.
+					 * @param {WordPressExternalConnection} $this The current connection object.
+					 *
+					 * @return {array} The query arguments.
+					 */
+					'body'    => apply_filters( 'dt_remote_post_query_args', $args, $this ),
 				)
 			)
 		);

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -452,6 +452,18 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		$total_posts = ! empty( $response_headers['X-WP-Total'] ) ? $response_headers['X-WP-Total'] : count( $formatted_posts );
 
+		/**
+		 * Filter the items returned when using `WordPressExternalConnection::remote_post`
+		 *
+		 * @since 1.6.7
+		 * @hook dt_remote_post
+		 *
+		 * @param {array} $items The items returned from the POST request.
+		 * @param {array} $args The arguments used in the POST request.
+		 * @param {WordPressExternalConnection} $this The current connection object.
+		 *
+		 * @return {array} The items returned from a remote POST request.
+		 */
 		return apply_filters(
 			'dt_remote_post',
 			[

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -441,8 +441,7 @@ class PullListTable extends \WP_List_Table {
 			'posts_per_page' => $per_page,
 			'paged'          => $current_page,
 			'post_type'      => $post_type,
-			'orderby'        => 'ID', // this is because of include/exclude truncation
-			'order'          => 'DESC', // default but specifying to be safe
+			'dt_pull_list'   => true, // custom argument used to only run code on this screen
 		];
 
 		if ( ! empty( $_GET['s'] ) ) { // @codingStandardsIgnoreLine Nonce isn't required.
@@ -478,15 +477,11 @@ class PullListTable extends \WP_List_Table {
 		}
 
 		if ( empty( $_GET['status'] ) || 'new' === $_GET['status'] ) { // @codingStandardsIgnoreLine Nonce not required.
-			// Sort from highest ID (newest) to low so the slice only affects later pagination.
-			rsort( $skipped, SORT_NUMERIC );
-			rsort( $syndicated, SORT_NUMERIC );
+			$post_ids = array_merge( $skipped, $syndicated );
 
-			// This is somewhat arbitrarily set to 200 and should probably be made filterable eventually.
-			// IDs can get rather large and 400 easily exceeds typical header size limits.
-			$post_ids = array_slice( array_merge( $skipped, $syndicated ), 0, 200, true );
-
-			$remote_get_args['post__not_in'] = $post_ids;
+			if ( ! empty( $post_ids ) ) {
+				$remote_get_args['post__not_in'] = $post_ids;
+			}
 
 			$remote_get_args['meta_query'] = [
 				[

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -143,6 +143,74 @@ function register_rest_routes() {
 			'permission_callback' => '__return_true',
 		)
 	);
+
+	register_rest_route(
+		'wp/v2',
+		'distributor/list-pull-content',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\get_pull_content',
+			'permission_callback' => '__return_true',
+			'args'                => get_pull_content_list_args(),
+		)
+	);
+}
+
+/**
+ * Set the accepted arguments for the pull content list endpoint
+ *
+ * @return array
+ */
+function get_pull_content_list_args() {
+	return array(
+		'exclude'     => array(
+			'description' => esc_html__( 'Ensure result set excludes specific IDs.', 'distributor' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		),
+		'page'        => array(
+			'description'       => esc_html__( 'Current page of the collection.', 'distributor' ),
+			'type'              => 'integer',
+			'default'           => 1,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		),
+		'per_page'    => array(
+			'description'       => esc_html__( 'Maximum number of items to be returned in result set.', 'distributor' ),
+			'type'              => 'integer',
+			'default'           => 10,
+			'minimum'           => 1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		),
+		'post_type'   => array(
+			'description'       => esc_html__( 'Limit results to content matching a certain type.', 'distributor' ),
+			'type'              => 'string',
+			'default'           => 'post',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		),
+		'search'      => array(
+			'description'       => esc_html__( 'Limit results to those matching a string.', 'distributor' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		),
+		'post_status' => array(
+			'default'     => 'publish',
+			'description' => esc_html__( 'Limit result set to content assigned one or more statuses.', 'distributor' ),
+			'type'        => 'array',
+			'items'       => array(
+				'enum' => array_merge( array_keys( get_post_stati() ), array( 'any' ) ),
+				'type' => 'string',
+			),
+		),
+	);
 }
 
 /**
@@ -336,6 +404,125 @@ function check_post_types_permissions() {
 	}
 
 	return $response;
+}
+
+/**
+ * Get a list of content to show on the Pull screen
+ *
+ * @param \WP_Rest_Request $request API request arguments
+ * @return \WP_REST_Response|\WP_Error
+ */
+function get_pull_content( $request ) {
+	$args = [
+		'posts_per_page' => isset( $request['per_page'] ) ? $request['per_page'] : 10,
+		'paged'          => isset( $request['page'] ) ? $request['page'] : 1,
+		'post_type'      => isset( $request['post_type'] ) ? $request['post_type'] : 'post',
+		'post_status'    => isset( $request['post_status'] ) ? $request['post_status'] : array( 'any' ),
+	];
+
+	if ( ! empty( $request['search'] ) ) {
+		$args['s'] = urldecode( $request['search'] );
+	}
+
+	if ( ! empty( $request['exclude'] ) ) {
+		$args['post__not_in'] = $request['exclude'];
+	}
+
+	// Filter documented in includes/classes/ExternalConnections/WordPressExternalConnection.php
+	$query = new \WP_Query( apply_filters( 'dt_remote_get_query_args', $args, $request ) );
+
+	if ( empty( $query->posts ) ) {
+		return rest_ensure_response( array() );
+	}
+
+	$page        = (int) $args['paged'];
+	$total_posts = $query->found_posts;
+
+	$max_pages = ceil( $total_posts / (int) $query->query_vars['posts_per_page'] );
+
+	if ( $page > $max_pages && $total_posts > 0 ) {
+		return new \WP_Error(
+			'rest_post_invalid_page_number',
+			esc_html__( 'The page number requested is larger than the number of pages available.', 'distributor' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$formatted_posts = array();
+	foreach ( $query->posts as $post ) {
+		if ( ! check_read_permission( $post ) ) {
+			continue;
+		}
+
+		$formatted_posts[] = array(
+			'id'             => $post->ID,
+			'title'          => array( 'rendered' => $post->post_title ),
+			'excerpt'        => array( 'rendered' => $post->post_excerpt ),
+			'content'        => array( 'raw' => $post->post_content ),
+			'password'       => $post->post_password,
+			'date'           => $post->post_date,
+			'date_gmt'       => $post->post_date_gmt,
+			'guid'           => array( 'rendered' => $post->guid ),
+			'modified'       => $post->post_modified,
+			'modified_gmt'   => $post->post_modified_gmt,
+			'type'           => $post->post_type,
+			'link'           => get_the_permalink( $post ),
+			'comment_status' => $post->comment_status,
+			'ping_status'    => $post->ping_status,
+		);
+	}
+
+	$response = rest_ensure_response( $formatted_posts );
+
+	$response->header( 'X-WP-Total', (int) $total_posts );
+	$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+	return $response;
+}
+
+/**
+ * Checks if a post can be read.
+ *
+ * Copied from WordPress core.
+ *
+ * @param \WP_Post $post Post object.
+ * @return bool
+ */
+function check_read_permission( $post ) {
+	// Validate the post type.
+	$post_type = \get_post_type_object( $post->post_type );
+
+	if ( empty( $post_type ) || empty( $post_type->show_in_rest ) ) {
+		return false;
+	}
+
+	// Is the post readable?
+	if ( 'publish' === $post->post_status || \current_user_can( 'read_post', $post->ID ) ) {
+		return true;
+	}
+
+	$post_status_obj = \get_post_status_object( $post->post_status );
+	if ( $post_status_obj && $post_status_obj->public ) {
+		return true;
+	}
+
+	// Can we read the parent if we're inheriting?
+	if ( 'inherit' === $post->post_status && $post->post_parent > 0 ) {
+		$parent = \get_post( $post->post_parent );
+		if ( $parent ) {
+			return check_read_permission( $parent );
+		}
+	}
+
+	/*
+	* If there isn't a parent, but the status is set to inherit, assume
+	* it's published (as per get_post_status()).
+	*/
+	if ( 'inherit' === $post->post_status ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -198,7 +198,6 @@ function get_pull_content_list_args() {
 		'search'      => array(
 			'description'       => esc_html__( 'Limit results to those matching a string.', 'distributor' ),
 			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		),
 		'post_status' => array(

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -150,7 +150,7 @@ function register_rest_routes() {
 		array(
 			'methods'             => 'POST',
 			'callback'            => __NAMESPACE__ . '\get_pull_content',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'is_user_logged_in',
 			'args'                => get_pull_content_list_args(),
 		)
 	);

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -427,8 +427,7 @@ function get_pull_content( $request ) {
 		$args['post__not_in'] = $request['exclude'];
 	}
 
-	// Filter documented in includes/classes/ExternalConnections/WordPressExternalConnection.php
-	$query = new \WP_Query( apply_filters( 'dt_remote_get_query_args', $args, $request ) );
+	$query = new \WP_Query( $args, $request );
 
 	if ( empty( $query->posts ) ) {
 		return rest_ensure_response( array() );


### PR DESCRIPTION
### Description of the Change

When building the content that shows on the `New` tab of the Pull screen, we determine what content has already been pulled and what content has already been skipped. This is then trimmed down to 200 items and used in a `post__not_in` query.

This can cause two different problems:
1. Since we limit this to 200 items, if you have more than 200 items, you could end up seeing already pulled or skipped items on the `New` tab
2. You might see performance problems if you have lots of items that need excluded. This will mostly impact external connections and even more so, WordPress.com VIP sites, since we use a lower timeout value in those requests

This PR attempts to fix both of those problems in the following ways:
1. Create a new custom endpoint that is used to generate the content for the `New` tab on the Pull screen
2. Utilize this endpoint if we are on the Pull screen of an external connection and we have no previously pulled or skipped items
3. Make a `POST` request to this endpoint (instead of `GET`), which allows us to pass data via the `body` parameter instead of in the URL
4. Remove the 200 item limit on excluded items, since those are now passed in the `body`

Because we remove that 200 item limit, we won't run into issues with previously pulled or skipped items showing on the `New` tab. Fixes #808 

Because we are using a custom endpoint with a `POST` request, fixes potential timeout issues when on a WordPress.com VIP site because we no longer have the strict 3 second timeout limit. Fixes #809 

### Alternate Designs

Ultimately we are still running a `post__not_in` query, which may not be the most performant. Other approaches were considered but ultimately rejected:

1. Instead of using `post__not_in`, increase our `posts_per_page` value and then remove excluded items after. This can still cause performance issues and causes pagination issues
2. To get around the performance issues of a large `posts_per_page`, could set an upper limit and break out into new queries once that limit is reached. Still have pagination problems and could still have performance issues because we are running more queries
3. To fix pagination issues, would have to potentially run multiple extra queries to determine proper offset. For instance, if someone wants page 10 of the results, we can't assume page 10 of the query matches what we want. We would have to run queries for each page leading up to page 10 to determine what offset we need. This would have performance implications for higher paginated pages
4. Instead of excluding items based on their post ID, have a piece of meta associated with all external pulled items that we can use to exclude. This would fix things going forward but isn't backwards compatible

### Benefits

All excluded items are properly excluded from the `New` tab. Better performance in certain situations

### Possible Drawbacks

I can't think of any but maybe some drawback around switching from a `GET` request to a `POST` request?

### Verification Process

1. Set up a site with at least one internal connection and one external connection
2. Ensure the Pull screen works for both
3. Try pulling and skipping content from both
4. Ensure things still work. Be sure to test pagination, search, skipping, pulling, etc.
5. Ideal is to test with a large amount of content pulled in, though this can be tedious to do

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#808 
#809 

### Changelog Entry

> Fixed - change how the Pull screen `New` tab is populated for external connections
