### PR TITLE
Add snippet.md to documention

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Deploy to GH Pages
       uses: maxheld83/ghpages@v0.2.1
       env:
-        BUILD_DIR: 'docs/'
+        BUILD_DIR: 'docs-built/'
         GH_PAT: ${{ secrets.GH_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ release/*
 dist/*
 screenshots/
 lang/
+docs-built

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -1,0 +1,57 @@
+## Snippets
+
+### Limit to certain post types
+
+```php
+add_filter( 'distributable_post_types', 'client_prefix_filter_post_types' );
+/**
+ * Filter the post types we can distribute.
+ * 
+ * @see https://10up.github.io/distributor/distributable_post_types.html
+ *
+ * @return array
+ */
+function client_prefix_filter_post_types() : array {
+	return array( 'post', 'page' );
+}
+```
+
+### Limit to certain user capabilities
+
+```php
+add_filter( 'dt_syndicatable_capabilities', 'client_prefix_filter_user_capabilities' );
+/**
+ * Filter the user capabilities that are allowed to distribute content.
+ * 
+ * @see https://10up.github.io/distributor/dt_syndicatable_capabilities.html
+ *
+ * @return string
+ */
+function client_prefix_filter_user_capabilities() : string {
+	return 'manage_options';
+}
+```
+
+### Limit to certain sites on the network
+
+```php
+add_filter( 'dt_authorized_sites', 'client_prefix_filter_authorized_sites', 10, 2 );
+/**
+ * Filter certain sites from the authorized sites list.
+ * 
+ * @see https://10up.github.io/distributor/dt_authorized_sites.html
+ *
+ * @param array  $authorized_sites Authorized sites.
+ * @param string $context Push or pull.
+ *
+ * @return array
+ */
+function client_prefix_filter_authorized_sites( array $authorized_sites, string $context ) : array {
+	return array_filter(
+		$authorized_sites,
+		function( $site ) {
+			return '/' === $site['site']->path;
+		}
+	);
+}
+```

--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -1,9 +1,10 @@
 {
   "opts": {
-      "destination": "docs",
+      "destination": "docs-built",
       "template": "node_modules/wp-hookdoc/template",
       "recurse": true,
-      "readme": "./.github/hookdoc-tmpl/README.md"
+      "readme": "./.github/hookdoc-tmpl/README.md",
+	  "tutorials": "./docs"
   },
   "source": {
       "includePattern": ".+\\.(php|inc)?$"


### PR DESCRIPTION
### Description of the Change
This PR address #816 by adding a `snippet.md` file and sharing helpful filters and their associated callbacks. To do this I am changing the `/docs` directory to be `/docs-built` and then version controlling the `/docs` directory. These code changes bring Distributor in line with how Elasticpress is building its documentation.

### Benefits

With this change, we can now add more tutorial-based documentation to the site.

### Possible Drawbacks

This is hard to test because we are relying on GitHub actions to perform on pushing to the `trunk` branch.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Added `snippets.md` to documentation with helpful filters and callbacks
Changed directory where we build the documentation from `docs` to `docs-built`
