### PR TITLE
Ensure we have a `WP_Site` object before creating a `NetworkSiteConnection` class

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -637,7 +637,12 @@ class NetworkSiteConnection extends Connection {
 		}
 
 		foreach ( $connection_map['internal'] as $blog_id => $post_array ) {
-			$connection = new self( get_site( $blog_id ) );
+			$site = get_site( $blog_id );
+			if ( ! $site || ! is_a( $site, '\WP_Site' ) ) {
+				continue;
+			}
+
+			$connection = new self( $site );
 
 			switch_to_blog( $blog_id );
 


### PR DESCRIPTION
### Description of the Change

When a post that has been distributed internally is deleted, we try and find all places this has been sent and update the connection information (basically severing the connection between the two). But if you happened to distribute something to a site that no longer exists, this can cause a fatal error and prevent you from deleting the original item.

This PR fixes that by ensuring we have a proper `WP_Site` object before we use that to delete the connection.

### Alternate Designs

None

### Benefits

Avoid fatal errors on deletion

### Possible Drawbacks

None

### Verification Process

1. Distribute an item to one or more sites
2. Delete one of the sites that item was distributed to
3. Go back to the original item and delete it, ensuring it gets deleted appropriately

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #821 

### Changelog Entry

> Fix - ensure the connection information we have is valid prior to using that for deletion
