### PR TITLE
Remove the limit of 100 `posts_per_page` on the Pull screen

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -167,8 +167,8 @@ class WordPressExternalConnection extends ExternalConnection {
 
 		// When running a query for the Pull screen with excluded items, make a POST request instead
 		if ( empty( $id ) && isset( $args['post__not_in'] ) && isset( $args['dt_pull_list'] ) ) {
-			$query_args['post_type'] = isset( $post_type ) ? $post_type : 'post';
-			$query_args['per_page']  = isset( $posts_per_page ) ? $posts_per_page : 20;
+			$query_args['post_type']      = isset( $post_type ) ? $post_type : 'post';
+			$query_args['posts_per_page'] = isset( $posts_per_page ) ? $posts_per_page : 20;
 
 			$posts_response = $this->remote_post(
 				untrailingslashit( $this->base_url ) . '/' . self::$namespace . '/distributor/list-pull-content',

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -514,7 +514,7 @@ class PullListTable extends \WP_List_Table {
 		$remote_get = $connection_now->remote_get( $remote_get_args );
 
 		if ( is_wp_error( $remote_get ) ) {
-			$this->pull_error = true;
+			$this->pull_error = $remote_get->get_error_messages();
 
 			return;
 		}

--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -528,6 +528,15 @@ function dashboard() {
 
 		<?php if ( ! empty( $connection_list_table->pull_error ) ) : ?>
 			<p><?php esc_html_e( 'Could not pull content from connection due to error.', 'distributor' ); ?></p>
+			<ul>
+				<?php foreach ( $connection_list_table->pull_error as $error ) : ?>
+				<li>
+					<ul>
+						<li><?php echo esc_html( $error ); ?></li>
+					</ul>
+				</li>
+				<?php endforeach; ?>
+			</ul>
 		<?php else : ?>
 			<?php $connection_list_table->views(); ?>
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -163,7 +163,7 @@ function register_rest_routes() {
  */
 function get_pull_content_list_args() {
 	return array(
-		'exclude'     => array(
+		'exclude'        => array(
 			'description' => esc_html__( 'Ensure result set excludes specific IDs.', 'distributor' ),
 			'type'        => 'array',
 			'items'       => array(
@@ -171,7 +171,7 @@ function get_pull_content_list_args() {
 			),
 			'default'     => array(),
 		),
-		'page'        => array(
+		'page'           => array(
 			'description'       => esc_html__( 'Current page of the collection.', 'distributor' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -179,28 +179,27 @@ function get_pull_content_list_args() {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		),
-		'per_page'    => array(
+		'posts_per_page' => array(
 			'description'       => esc_html__( 'Maximum number of items to be returned in result set.', 'distributor' ),
 			'type'              => 'integer',
-			'default'           => 10,
+			'default'           => 20,
 			'minimum'           => 1,
-			'maximum'           => 100,
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		),
-		'post_type'   => array(
+		'post_type'      => array(
 			'description'       => esc_html__( 'Limit results to content matching a certain type.', 'distributor' ),
 			'type'              => 'string',
 			'default'           => 'post',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		),
-		'search'      => array(
+		'search'         => array(
 			'description'       => esc_html__( 'Limit results to those matching a string.', 'distributor' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		),
-		'post_status' => array(
+		'post_status'    => array(
 			'default'     => 'publish',
 			'description' => esc_html__( 'Limit result set to content assigned one or more statuses.', 'distributor' ),
 			'type'        => 'array',
@@ -413,7 +412,7 @@ function check_post_types_permissions() {
  */
 function get_pull_content( $request ) {
 	$args = [
-		'posts_per_page' => isset( $request['per_page'] ) ? $request['per_page'] : 10,
+		'posts_per_page' => isset( $request['posts_per_page'] ) ? $request['posts_per_page'] : 20,
 		'paged'          => isset( $request['page'] ) ? $request['page'] : 1,
 		'post_type'      => isset( $request['post_type'] ) ? $request['post_type'] : 'post',
 		'post_status'    => isset( $request['post_status'] ) ? $request['post_status'] : array( 'any' ),


### PR DESCRIPTION
### Description of the Change

In #811 we changed how the initial content on the Pull screen for external connections is fetched, in order to address some performance concerns. Ultimately we have a new REST endpoint that is used to fetch data. We had a limit of 100 items per page, which WordPress also enforces itself behind the scenes on any REST endpoint that utilizes the `per_page` argument. But we still allow users to put in a per page argument that is greater than 100, it just isn't reflected in the results.

To fix this, I've removed that upper limit and changed our argument to be `posts_per_page`, to avoid having WordPress core add the limit back. In addition, I noticed we don't output the actual error message on that Pull screen, making it harder to debug these types of issues, so that is also fixed here.

### Alternate Designs

Instead of removing the limit all together, we could raise the limit to something above 100.

Could also leave the limit at 100 and make sure we force the user entered argument to never be more than 100.

### Benefits

Results will now match what a user enters, if they are entering more than 100

### Possible Drawbacks

Since we aren't enforcing an upper limit, if you enter a high number here, you will see performance impacts

### Verification Process

Follow the steps as outlined on #826

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #826

### Changelog Entry

> Fix - ensure users can enter a per page limit of greater than 100 and have that properly used on the Pull screen for external connections
