### PR TITLE
Ensure the tutorial snippets have a proper height

### DIFF
--- a/.github/hookdoc-tmpl/static/styles-10up.css
+++ b/.github/hookdoc-tmpl/static/styles-10up.css
@@ -94,5 +94,6 @@ footer {
 .prettyprint code {
 	padding: 2px 10px;
 	line-height: 16px;
-	height: 16px;
+	min-height: 16px;
+	height: auto;
 }


### PR DESCRIPTION
### Description of the Change

We have some tutorial snippets that were added to our automated doc site a [few months back](https://github.com/10up/distributor/pull/817) but there's currently a styling issue there where the [full snippet](https://10up.github.io/distributor/tutorial-snippets.html) doesn't show. The issue is with some CSS that is forcing a height of 16px, so if the code container needs to be bigger than that, the text gets cut off.

This PR fixes that by changing the height style to a min-height style. As far as I can tell, this has no impact on the other sections of that doc site but unsure why that style was added in the first place.

**Before:**

<img width="947" alt="before" src="https://user-images.githubusercontent.com/916738/150601704-06bf2f32-a56c-4cd8-aa98-56470a300080.png">

**After:**

<img width="937" alt="after" src="https://user-images.githubusercontent.com/916738/150601716-5bd3b251-853d-40d9-954f-7e39cb1b7ed2.png">

### Alternate Designs

None

### Possible Drawbacks

Potential that other places on the docs site relies on that style and could be negatively impacted

### Verification Process

1. Checkout this PR locally
2. Run `npm install`
3. Run `npm run build:docs`
4. In the resulting `docs-built` directory, find the `tutorial-snippets.html` file and open in a browser. Ensure the snippets fully display (can compare to [this](https://10up.github.io/distributor/tutorial-snippets.html))

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
