### PR TITLE
Add hook to filter WP_Query args for get_pull_content REST endpoint

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -426,6 +426,20 @@ function get_pull_content( $request ) {
 		$args['post__not_in'] = $request['exclude'];
 	}
 
+	/**
+	 * Filters WP_Query arguments when querying posts via the REST API.
+	 *
+	 * Enables adding extra arguments or setting defaults for a post collection request.
+	 *
+	 * @hook dt_get_pull_content_rest_query_args
+	 *
+	 * @param {array}           $args    Array of arguments for WP_Query.
+	 * @param {WP_REST_Request} $request The REST API request.
+	 *
+	 * @return {array} The array of arguments for WP_Query.
+	 */
+	$args = apply_filters( 'dt_get_pull_content_rest_query_args', $args, $request );
+
 	$query = new \WP_Query( $args, $request );
 
 	if ( empty( $query->posts ) ) {


### PR DESCRIPTION
### Description of the Change

This PR introduces a new hook which can be used to filter the arguments used by `WP_Query` in the `distributor/list-pull-content` REST API endpoint (based on existing hook provided by WP core, see [rest_this-post_type_query](https://developer.wordpress.org/reference/hooks/rest_this-post_type_query/)).

This can be useful to filter down the content when users have already pulled content from a connection.

### Alternate Designs

N/A

### Possible Drawbacks

I guess there could be a possible negative performance impact if a developer doesn't use the filter properly (e.g. setting `posts_per_page` to -1).

### Verification Process

I did add a custom mu-plugin plugin to my WP install with the following code and was able to change the results for the WP_Query.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Added - New hook to filter WP_Query args for the `list-pull-content` REST endpoint