### PR TITLE
Minor fixes to the `remote_post` method used by External Connections 

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -395,6 +395,22 @@ class WordPressExternalConnection extends ExternalConnection {
 			return new \WP_Error( 'endpoint-error', esc_html__( 'Endpoint URL must be set', 'distributor' ) );
 		}
 
+		/**
+		* Filter the remote_post query arguments
+		*
+		* @since 1.6.7
+		* @hook dt_remote_post_query_args
+		*
+		* @param {array}  $args The request arguments.
+		* @param {WordPressExternalConnection} $this The current connection object.
+		*
+		* @return {array} The query arguments.
+		*/
+		$body = apply_filters( 'dt_remote_post_query_args', $args, $this );
+
+		// Add request parameter to specify Distributor request
+		$body['distributor_request'] = '1';
+
 		$request = wp_remote_post(
 			$url,
 			$this->auth_handler->format_post_args(
@@ -411,18 +427,7 @@ class WordPressExternalConnection extends ExternalConnection {
 					 * @return int The timeout to use for the remote_post call.
 					 */
 					'timeout' => apply_filters( 'dt_remote_post_timeout', 45, $args ),
-					/**
-					 * Filter the remote_post query arguments
-					 *
-					 * @since 1.6.7
-					 * @hook dt_remote_post_query_args
-					 *
-					 * @param {array}  $args The request arguments.
-					 * @param {WordPressExternalConnection} $this The current connection object.
-					 *
-					 * @return {array} The query arguments.
-					 */
-					'body'    => apply_filters( 'dt_remote_post_query_args', $args, $this ),
+					'body'    => $body,
 				)
 			)
 		);

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -419,7 +419,7 @@ function get_pull_content( $request ) {
 	];
 
 	if ( ! empty( $request['search'] ) ) {
-		$args['s'] = urldecode( $request['search'] );
+		$args['s'] = rawurldecode( $request['search'] );
 	}
 
 	if ( ! empty( $request['exclude'] ) ) {
@@ -440,7 +440,7 @@ function get_pull_content( $request ) {
 	 */
 	$args = apply_filters( 'dt_get_pull_content_rest_query_args', $args, $request );
 
-	$query = new \WP_Query( $args, $request );
+	$query = new \WP_Query( $args );
 
 	if ( empty( $query->posts ) ) {
 		return rest_ensure_response( array() );


### PR DESCRIPTION
### Description of the Change

While researching/testing out an issue around the Pull UI for external connections, I found a few minor things that could be cleaned up (though these did not appear to be causing any issues in the tests I ran).

1. For the `remote_get` method, we add a `distributor_request` param to the request. Figured we should probably add this to the newly added `remote_post` method as well to ensure those have as much parity as possible. This required moving a filter up a bit so we could run the filter first and then add this new data, but the filter is not changed in any way
2. We currently run a `rawurlencode` on the search param of our Pull requests but we were using `urldecode` to decode that value. In order to match, switched that to use `rawurldecode` instead
3. There was an extra parameter being passed to the `WP_Query` object that gets the content available for pulling. Not sure why that was there (which was originally added by me and I can't remember why) and doesn't seem to serve any purpose (if you look at the [constructor](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-query.php#L3651) for `WP_Query`, it only supports a single argument), so that should be removed 

### Alternate Designs

None

### Possible Drawbacks

Should be none

### Verification Process

Set up an external connection and verify the Pull UI screen shows content as expected, that pulling content works, that skipping content works and that searching for content works

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Changed - minor changes to the `remote_post` method 


### Credits

Props @dkotter
