### PR TITLE
Fix a PHP fatal error when updating a distributed item that uses the block editor

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -949,8 +949,24 @@ function dt_use_block_editor_for_post_type( $post_type ) {
 		return false;
 	}
 
-	// Filter documented in WordPress core.
-	return apply_filters( 'use_block_editor_for_post_type', true, $post_type );
+	// In some contexts this function doesn't exist so we can't reliably use the filter.
+	if ( function_exists( 'use_block_editor_for_post_type' ) ) {
+		// Filter documented in WordPress core.
+		return apply_filters( 'use_block_editor_for_post_type', true, $post_type );
+	}
+
+	/**
+	 * Filters whether an item is able to be edited in the block editor.
+	 *
+	 * @since 1.6.9
+	 * @hook dt_use_block_editor_for_post_type
+	 *
+	 * @param bool   $use_block_editor Whether the post type uses the block editor. Default true.
+	 * @param string $post_type        The post type being checked.
+	 *
+	 * @return bool Whether the post type uses the block editor.
+	 */
+	return apply_filters( 'dt_use_block_editor_for_post_type', true, $post_type );
 }
 
 /**


### PR DESCRIPTION
### Description of the Change

As described in #844, WordPress 5.9 added a new function hooked to the `use_block_editor_for_post_type` filter. We run this filter in our `dt_use_block_editor_for_post_type` function, which runs when an item that has already been distributed is saved (among other places). If this item uses the block editor, saves happen via a REST API request and the new function WP 5.9 hooks doesn't exist in that context.

This PR fixes that by checking if the `use_block_editor_for_post_type` function exists (which is in the same file as the newly hooked function, `_disable_block_editor_for_navigation_post_type `. If it does exist, we apply the `use_block_editor_for_post_type`. If it doesn't exist, we apply a newly added filter, `dt_use_block_editor_for_post_type`. This ensures this response can be filtered no matter the context.

Closes #844 

### Alternate Designs

Instead of doing `function_exists( 'use_block_editor_for_post_type' )`, we could just `remove_action( 'use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type' );`. My concern with this approach is while it solves the immediate issue, there could be other functions in the future hooked up that cause the same problem and we would have to remove those hooks individually as well.

Another approach I considered is using `function_exists` but if it doesn't exist, just return `true` instead of passing `true` through a new filter. I figured having a new filter gives developers the most flexibility.

### Possible Drawbacks

Any code that is hooked to the `use_block_editor_for_post_type` will no longer run when the `dt_use_block_editor_for_post_type` function is called during a REST API request. This can be solved by instead using the new `dt_use_block_editor_for_post_type` filter

### Verification Process

1. Be on a WP 5.9 install
2. Create a new post using the block editor
3. Distribute that post to at least one connection
4. Try updating that post
5. No errors should happen and updates should be syndicated

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Ensure content updates work for distributed items that use the block editor in WordPress 5.9+

### Credits

Props @dkotter
