### PR TITLE
Fix/862 Search form moved outside of the filter form

### DIFF
--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -540,6 +540,8 @@ function dashboard() {
 		<?php else : ?>
 			<?php $connection_list_table->views(); ?>
 
+			<?php $connection_list_table->search_box( esc_html__( 'Search', 'distributor' ), 'post' ); ?>
+
 			<form id="posts-filter" class="status-<?php echo ( ! empty( $_GET['status'] ) ) ? esc_attr( $_GET['status'] ) : 'new'; // @codingStandardsIgnoreLine Nonce not needed. ?>" method="get">
 				<?php if ( ! empty( $connection_list_table->connection_objects ) ) : ?>
 					<input type="hidden" name="connection_type" value="<?php echo esc_attr( $connection_type ); ?>">
@@ -547,8 +549,6 @@ function dashboard() {
 				<?php endif; ?>
 
 				<input type="hidden" name="page" value="pull">
-
-				<?php $connection_list_table->search_box( esc_html__( 'Search', 'distributor' ), 'post' ); ?>
 
 				<?php $connection_list_table->display(); ?>
 			</form>


### PR DESCRIPTION
### Description of the Change

- This PR moves the search form outside of the filter form.
- Earlier hitting the `enter` key while the cursor is on the page number input field, the search form was being submitted instead of the filter form.

<!-- Enter any applicable Issues here. Example: -->
Closes #862

### Verification Process

1. Go to the Pull Content screen.
2. Ensure you're on a connection that has multiple pages of results. If not, create at least 2 posts/pages and set `Posts per page` to 2 in the `Screen Options`.
3. Manually enter any page other than 1.
4. Hit enter and see the requested page is loaded.
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Manually entering a page number doesn't work on the Pull screen

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @faisal-alvi  @dkotter 
