### PR TITLE
Change GH Action used for deploy to GH Pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         CI: true
     - name: Deploy to GH Pages
-      uses: maxheld83/ghpages@v0.2.1
-      env:
-        BUILD_DIR: 'docs-built/'
-        GH_PAT: ${{ secrets.GH_PAT }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: './docs'


### PR DESCRIPTION
### Description of the Change

Following the failure in deploy to GH Pages in **Classifai** and **ElasticPress**, this PR has been raised to replace the broken GH action used for deploy to GH Pages.

This PR changes the GH Action used to publish to the GH Pages. Previously, we were using https://github.com/maxheld83/ghpages, and this PR changes to use https://github.com/peaceiris/actions-gh-pages

ClassifAI PR: https://github.com/10up/classifai/pull/345
ElasticPress PR: https://github.com/10up/ElasticPress/pull/2803

### Alternate Designs

Maybe debug an issue in the existing action and fix it or choose any other GH action to deploy to GH pages.

### Possible Drawbacks

### Verification Process
Hook Docs should deploy correctly once this is merged to the trunk. We will need to merge this one to the trunk to see if it works.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Changelog Entry

> Changed: GH Action used for deploy to GH Pages

### Credits

Props @iamdharmesh 
