### PR TITLE
Adds slashes to a string or recursively adds slashes to strings within an array for the JSON value while migrating metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 screenshots/
 lang/
 docs-built
+.phpunit.result.cache

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -202,7 +202,7 @@ function set_meta( $post_id, $meta ) {
 			json_decode( $meta_value );
 			// Adds slashes to a string or recursively adds slashes to strings within an array for the JSON
 			if ( json_last_error() === JSON_ERROR_NONE || '_elementor_data' === $meta_key ) {
-				$meta_value = \wp_slash( $meta_value );
+				$meta_value = wp_slash( $meta_value );
 			}
 
 			if ( $has_prev_value ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -199,13 +199,10 @@ function set_meta( $post_id, $meta ) {
 				$meta_value = maybe_unserialize( $meta_value );
 			}
 
-			// Adds slashes to a string or recursively adds slashes to strings within an array to avoid JSON decode failure while migrating metadata
-			$meta_value = wp_slash( $meta_value );
-
 			if ( $has_prev_value ) {
-				update_post_meta( $post_id, $meta_key, $meta_value, $prev_value );
+				update_post_meta( $post_id, wp_slash( $meta_key ), wp_slash( $meta_value ), $prev_value );
 			} else {
-				add_post_meta( $post_id, $meta_key, $meta_value );
+				add_post_meta( $post_id, wp_slash( $meta_key ), wp_slash( $meta_value ) );
 			}
 		}
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -199,6 +199,12 @@ function set_meta( $post_id, $meta ) {
 				$meta_value = maybe_unserialize( $meta_value );
 			}
 
+			json_decode( $meta_value );
+			// Adds slashes to a string or recursively adds slashes to strings within an array for the JSON
+			if ( json_last_error() === JSON_ERROR_NONE || '_elementor_data' === $meta_key ) {
+				$meta_value = \wp_slash( $meta_value );
+			}
+
 			if ( $has_prev_value ) {
 				update_post_meta( $post_id, $meta_key, $meta_value, $prev_value );
 			} else {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -195,18 +195,12 @@ function set_meta( $post_id, $meta ) {
 				$prev_value = maybe_unserialize( $existing_meta[ $meta_key ][ $meta_placement ] );
 			}
 
-			$is_json = false;
-
 			if ( ! is_array( $meta_value ) ) {
-				json_decode( $meta_value );
-				$is_json    = json_last_error() === 0 ? true : false;
 				$meta_value = maybe_unserialize( $meta_value );
 			}
 
-			// Adds slashes to a string or recursively adds slashes to strings within an array for the JSON
-			if ( function_exists( 'wp_slash' ) && ( $is_json || '_elementor_data' === $meta_key ) ) {
-				$meta_value = wp_slash( $meta_value );
-			}
+			// Adds slashes to a string or recursively adds slashes to strings within an array to avoid JSON decode failure while migrating metadata
+			$meta_value = wp_slash( $meta_value );
 
 			if ( $has_prev_value ) {
 				update_post_meta( $post_id, $meta_key, $meta_value, $prev_value );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -195,13 +195,16 @@ function set_meta( $post_id, $meta ) {
 				$prev_value = maybe_unserialize( $existing_meta[ $meta_key ][ $meta_placement ] );
 			}
 
+			$is_json = false;
+
 			if ( ! is_array( $meta_value ) ) {
+				json_decode( $meta_value );
+				$is_json    = json_last_error() === 0 ? true : false;
 				$meta_value = maybe_unserialize( $meta_value );
 			}
 
-			json_decode( $meta_value );
 			// Adds slashes to a string or recursively adds slashes to strings within an array for the JSON
-			if ( json_last_error() === JSON_ERROR_NONE || '_elementor_data' === $meta_key ) {
+			if ( function_exists( 'wp_slash' ) && ( $is_json || '_elementor_data' === $meta_key ) ) {
 				$meta_value = wp_slash( $meta_value );
 			}
 

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -46,6 +46,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'wp_slash', [
+				'times'  => 2,
+				'return_arg' => 0,
+			]
+		);
+
 		\WP_Mock::expectAction( 'dt_after_set_meta', [ 'key' => [ 'value' ] ], [], 1 );
 
 		\WP_Mock::expectAction( 'dt_after_set_meta', [ 'key' => [ [ 'value' ] ] ], [ 'key' => [ 'value' ] ], 1 );
@@ -129,6 +136,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'wp_slash', [
+				'times'  => 5,
+				'return_arg' => 0,
+			]
+		);
+
 		Utils\set_meta(
 			1, [
 				'key'  => [ 'value' ],
@@ -178,6 +192,13 @@ class UtilsTest extends TestCase {
 				'times'  => 1,
 				'args'   => [ 1, 'key2', [ 0 => 'test' ], [ 0 => 'test' ] ],
 				'return' => [],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_slash', [
+				'times'  => 2,
+				'return_arg' => 0,
 			]
 		);
 
@@ -824,6 +845,13 @@ class UtilsTest extends TestCase {
 						'post_excerpt' => $attached_media_post->post_excerpt,
 					],
 				],
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'wp_slash', [
+				'times'  => 2,
+				'return_arg' => 0,
 			]
 		);
 

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -48,7 +48,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 4,
+				'times'      => 4,
 				'return_arg' => 0,
 			]
 		);
@@ -138,7 +138,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 10,
+				'times'      => 10,
 				'return_arg' => 0,
 			]
 		);
@@ -197,7 +197,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 4,
+				'times'      => 4,
 				'return_arg' => 0,
 			]
 		);
@@ -850,7 +850,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 4,
+				'times'      => 4,
 				'return_arg' => 0,
 			]
 		);

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -48,7 +48,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 2,
+				'times'  => 4,
 				'return_arg' => 0,
 			]
 		);
@@ -138,7 +138,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 5,
+				'times'  => 10,
 				'return_arg' => 0,
 			]
 		);
@@ -197,7 +197,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 2,
+				'times'  => 4,
 				'return_arg' => 0,
 			]
 		);
@@ -850,7 +850,7 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'wp_slash', [
-				'times'  => 2,
+				'times'  => 4,
 				'return_arg' => 0,
 			]
 		);


### PR DESCRIPTION
### Description of the Change

Adds slashes to a string or recursively adds slashes to strings within an array for the JSON value while migrating metadata

This PR fixes the issues https://github.com/10up/distributor/issues/738 and https://github.com/10up/distributor/issues/724

### Verification Process

- After checking out this branch, try to migrate a post that included JSON metadata and try to migrate Elementor Post

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
