### PR TITLE
Fix Gutenberg sniff

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -36,7 +36,7 @@ function is_vip_com() {
 function is_using_gutenberg( $post ) {
 	global $wp_version;
 
-	$gutenberg_available = function_exists( 'the_gutenberg_project' );
+	$gutenberg_available = function_exists( 'gutenberg_pre_init' );
 	$version_5_plus      = version_compare( $wp_version, '5', '>=' );
 
 	if ( ! $gutenberg_available && ! $version_5_plus ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -74,14 +74,14 @@ function is_using_gutenberg( $post ) {
 	if ( class_exists( 'Classic_Editor' ) && is_callable( array( 'Classic_Editor', 'init_actions' ) ) ) {
 		$allow_site_override = true;
 		if ( is_multisite() ) {
-			$use_block_editor    = ( get_site_option( 'classic-editor-replace' ) === 'no-replace' );
-			$allow_site_override = ( get_site_option( 'classic-editor-allow-sites' ) === 'allow' );
+			$use_block_editor    = ( get_site_option( 'classic-editor-replace', 'no-replace' ) === 'no-replace' );
+			$allow_site_override = ( get_site_option( 'classic-editor-allow-sites', 'allow' ) === 'allow' );
 		}
 		if (
 			$allow_site_override &&
 			get_option( 'classic-editor-replace' )
 		) {
-			$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+			$use_block_editor = ( get_option( 'classic-editor-replace', 'no-replace' ) === 'no-replace' );
 		}
 	}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -76,14 +76,14 @@ function is_using_gutenberg( $post ) {
 	if ( class_exists( 'Classic_Editor' ) && is_callable( array( 'Classic_Editor', 'init_actions' ) ) ) {
 		$allow_site_override = true;
 		if ( is_multisite() ) {
-			$use_block_editor    = ( get_site_option( 'classic-editor-replace', 'no-replace' ) === 'no-replace' );
+			$use_block_editor    = in_array( get_site_option( 'classic-editor-replace', 'block' ), array( 'no-replace', 'block' ), true );
 			$allow_site_override = ( get_site_option( 'classic-editor-allow-sites', 'allow' ) === 'allow' );
 		}
 		if (
 			$allow_site_override &&
 			get_option( 'classic-editor-replace' )
 		) {
-			$use_block_editor = ( get_option( 'classic-editor-replace', 'no-replace' ) === 'no-replace' );
+			$use_block_editor = in_array( get_option( 'classic-editor-replace', 'block' ), array( 'no-replace', 'block' ), true );
 		}
 	}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -29,6 +29,8 @@ function is_vip_com() {
  *  - WordPress 5.0, Classic editor plugin active, using the block editor.
  *
  * @since  1.2
+ * @since  1.7 Update Gutenberg plugin sniff to avoid deprecated function.
+ *             Update Classic Editor sniff to account for mu-plugins.
  *
  * @param object $post The post object.
  * @return boolean

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -71,12 +71,18 @@ function is_using_gutenberg( $post ) {
 
 	$use_block_editor = false;
 
-	if ( ! function_exists( 'is_plugin_active' ) ) {
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
-	}
-
-	if ( is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
-		$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+	if ( class_exists( 'Classic_Editor' ) && is_callable( array( 'Classic_Editor', 'init_actions' ) ) ) {
+		$allow_site_override = true;
+		if ( is_multisite() ) {
+			$use_block_editor    = ( get_site_option( 'classic-editor-replace' ) === 'no-replace' );
+			$allow_site_override = ( get_site_option( 'classic-editor-allow-sites' ) === 'allow' );
+		}
+		if (
+			$allow_site_override &&
+			get_option( 'classic-editor-replace' )
+		) {
+			$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+		}
 	}
 
 	if ( $use_block_editor && is_a( $post, '\WP_Post' ) && class_exists( '\Gutenberg_Ramp' ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This modifies the `is_using_gutenberg()` test in a number of ways:

* Replaces the gutenberg plugin test with a new function, `the_gutenberg_project` was deprecated some time ago
* Tests for the Classic_Editor class and a callable to determine if the classic editor plugin is installed. This is mainly to account for the plugin being installed as an `mu-plugin`.
* When getting the classic editor options, if they haven't been set then assumes the default - block editor - options.
* Tests for both network and site options according to classic editor settings.
* At some point the classic editor plugin changed it's value to `block` or `classic`, test for that too.

<!-- Enter any applicable Issues here. Example: -->
Closes #893.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I'vee broken the sniff. I don't think so but I'll probably get a couple of people to review this so I can be sure.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

- installed and enabled classic editor (set to allow switching to block editor)
- created a post using the classic editor (post ID 7)
- created a post using the block editor (post ID 9)
- checked the function reported correctly
   ```
   wp> \Distributor\Utils\is_using_gutenberg( 7 );
   => phar:///usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
   bool(false)
   wp> \Distributor\Utils\is_using_gutenberg( 9 );
   => phar:///usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
   bool(true)
   ```
- configure the classic editor as an mu-plugin
- re-run the commands above to ensure it works as expected.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

Fix: Account for plugin changes in test to determine editor type (classic or block).

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 
