### PR TITLE
Prevent fatal caused by filter name clash.

### DIFF
--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -559,7 +559,8 @@ class WordPressExternalConnection extends ExternalConnection {
 			 *
 			 * @return {array} The post data to be inserted.
 			 */
-			$new_post = wp_insert_post( apply_filters( 'dt_pull_post_args', $post_array, $item_array['remote_post_id'], $post, $this ) );
+			$new_post_args = Utils\post_args_allow_list( apply_filters( 'dt_pull_post_args', $post_array, $item_array['remote_post_id'], $post, $this ) );
+			$new_post      = wp_insert_post( $new_post_args );
 
 			update_post_meta( $new_post, 'dt_original_post_id', (int) $item_array['remote_post_id'] );
 			update_post_meta( $new_post, 'dt_original_source_id', (int) $this->id );

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -111,7 +111,8 @@ class NetworkSiteConnection extends Connection {
 
 		add_filter( 'wp_insert_post_data', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'maybe_set_modified_date' ), 10, 2 );
 		// Filter documented in includes/classes/ExternalConnections/WordPressExternalConnection.php
-		$new_post_id = wp_insert_post( apply_filters( 'dt_push_post_args', $new_post_args, $post, $args, $this ) );
+		$new_post_args = Utils\post_args_allow_list( apply_filters( 'dt_push_post_args', $new_post_args, $post, $args, $this ) );
+		$new_post_id   = wp_insert_post( $new_post_args );
 
 		remove_filter( 'wp_insert_post_data', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'maybe_set_modified_date' ), 10, 2 );
 
@@ -267,7 +268,8 @@ class NetworkSiteConnection extends Connection {
 			add_filter( 'wp_insert_post_data', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'maybe_set_modified_date' ), 10, 2 );
 
 			// Filter documented in includes/classes/ExternalConnections/WordPressExternalConnection.php
-			$new_post_id = wp_insert_post( apply_filters( 'dt_pull_post_args', $post_array, $item_array['remote_post_id'], $post, $this ) );
+			$new_post_args = Utils\post_args_allow_list( apply_filters( 'dt_pull_post_args', $post_array, $item_array['remote_post_id'], $post, $this ) );
+			$new_post_id   = wp_insert_post( $new_post_args );
 
 			remove_filter( 'wp_insert_post_data', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'maybe_set_modified_date' ), 10, 2 );
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1071,3 +1071,43 @@ function set_media_errors( $post_id, $data ) {
 
 	set_transient( "dt_media_errors_$post_id", $errors, HOUR_IN_SECONDS );
 }
+
+/**
+ * Reduce arguments passed to wp_insert_post to approved arguments only.
+ *
+ * @link http://developer.wordpress.org/reference/functions/wp_insert_post/ wp_insert_post() documentation.
+ *
+ * @param array $post_args Arguments used for wp_insert_post() or wp_update_post().
+ *
+ * @return array Arguments cleaned of any not expected by the core function.
+ */
+function post_args_allow_list( $post_args ) {
+	$allowed_post_keys = array(
+		'ID',
+		'post_author',
+		'post_date',
+		'post_date_gmt',
+		'post_content',
+		'post_content_filtered',
+		'post_title',
+		'post_excerpt',
+		'post_status',
+		'post_password',
+		'post_name',
+		'to_ping',
+		'pinged',
+		'post_modified',
+		'post_modified_gmt',
+		'post_parent',
+		'menu_order',
+		'post_mime_type',
+		'guid',
+		'import_id',
+		'post_category',
+		'tags_input',
+		'tax_input',
+		'meta_input',
+	);
+
+	return array_intersect_key( $post_args, array_flip( $allowed_post_keys ) );
+}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1075,6 +1075,8 @@ function set_media_errors( $post_id, $data ) {
 /**
  * Reduce arguments passed to wp_insert_post to approved arguments only.
  *
+ * @since x.x.x
+ *
  * @link http://developer.wordpress.org/reference/functions/wp_insert_post/ wp_insert_post() documentation.
  *
  * @param array $post_args Arguments used for wp_insert_post() or wp_update_post().

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -838,4 +838,27 @@ class UtilsTest extends TestCase {
 	 * Todo finish process_media
 	 */
 
+	 /**
+	  * Test post_args_allow_list
+	  *
+	  * @since x.x.x
+	  */
+	function test_post_args_allow_list() {
+		$post_args = [
+			'post_title'   => 'Test Title',
+			'post_content' => 'Test Content',
+			'post_excerpt' => 'Test Excerpt',
+			'link'         => 'https://github.com/10up/distributor/issues/879',
+			'dt_source'    => 'https://github.com/10up/distributor/pull/895',
+		];
+
+		$expected = [
+			'post_title'   => 'Test Title',
+			'post_content' => 'Test Content',
+			'post_excerpt' => 'Test Excerpt',
+		];
+
+		$actual = Utils\post_args_allow_list( $post_args );
+		$this->assertSame( $expected, $actual );
+	}
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This change ensures only arguments accepted by `wp_insert_post()` are passed to the function during a push or pull distribution of content.

This addresses a bug in which the dynamic hooks fired within the function call were clashing with other WP hooks and causing a fatal error. 

<!-- Enter any applicable Issues here. Example: -->
Closes #879

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

I considered using the hooks `dt_pull_post_args` and `dt_push_post_args` to reduce the items to the allow list but discovered the latter filter is also used for making an HTTP request when pushing a post so could not be used in this fashion.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Breaks plugins expecting _unofficial_ parameters be passed to `wp_insert_post()`. I've done a review of the function to see if there are any hooks that pass both the post ID and the unmodified `$postarr` and can't see anything.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

WIP

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

Fixed: Prevent conflict with `pre_post_link` filter.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @jeremyfelt, @peterwilsoncc 
