### PR TITLE
Fix/906 Distributable post types made consistent

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -464,7 +464,7 @@ class NetworkSiteConnection extends Connection {
 	 */
 	public function get_post_types() {
 		switch_to_blog( $this->site->blog_id );
-		$post_types = get_post_types( [ 'public' => true ], 'objects' );
+		$post_types = Utils\distributable_post_types( 'objects' );
 		restore_current_blog();
 
 		return $post_types;

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -454,7 +454,7 @@ function meta_box_external_connection_details( $post ) {
 
 	$external_connection_status = get_post_meta( $post->ID, 'dt_external_connections', true );
 
-	$post_types = \Distributor\Utils\distributable_post_types( 'is_post_type_viewable' );
+	$post_types = \Distributor\Utils\distributable_post_types( 'objects' );
 
 	$registered_external_connection_types = \Distributor\Connections::factory()->get_registered();
 

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -454,12 +454,7 @@ function meta_box_external_connection_details( $post ) {
 
 	$external_connection_status = get_post_meta( $post->ID, 'dt_external_connections', true );
 
-	$post_types = get_post_types(
-		array(
-			'show_in_rest' => true,
-		),
-		'objects'
-	);
+	$post_types = \Distributor\Utils\distributable_post_types( 'is_post_type_viewable' );
 
 	$registered_external_connection_types = \Distributor\Connections::factory()->get_registered();
 
@@ -544,20 +539,13 @@ function meta_box_external_connection_details( $post ) {
 					<th><?php esc_html_e( 'Can push?', 'distributor' ); ?></th>
 				</thead>
 				<tbody>
-					<?php
-					$hide_from_list = \Distributor\Utils\get_excluded_post_types_from_permission_list();
-
-					foreach ( $post_types as $post_type ) :
-						if ( in_array( $post_type->name, $hide_from_list, true ) ) {
-							continue;
-						}
-						?>
-						<tr>
-							<td><?php echo esc_html( $post_type->label ); ?></td>
-							<td><?php echo in_array( $post_type->name, $external_connection_status['can_get'] ) ? esc_html__( 'Yes', 'distributor' ) : esc_html__( 'No', 'distributor' ); ?></td>
-							<td><?php echo in_array( $post_type->name, $external_connection_status['can_post'] ) ? esc_html__( 'Yes', 'distributor' ) : esc_html__( 'No', 'distributor' ); ?></td>
-						</tr>
-					<?php endforeach; ?>
+				<?php foreach ( $post_types as $post_type ) : ?>
+					<tr>
+						<td><?php echo esc_html( $post_type->label ); ?></td>
+						<td><?php echo in_array( $post_type->name, $external_connection_status['can_get'] ) ? esc_html__( 'Yes', 'distributor' ) : esc_html__( 'No', 'distributor' ); ?></td>
+						<td><?php echo in_array( $post_type->name, $external_connection_status['can_post'] ) ? esc_html__( 'Yes', 'distributor' ) : esc_html__( 'No', 'distributor' ); ?></td>
+					</tr>
+				<?php endforeach; ?>
 				</tbody>
 			</table>
 		</div>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -307,15 +307,10 @@ function available_pull_post_types( $connection, $type ) {
  * @return array
  */
 function distributable_post_types( $output = 'names' ) {
-	$post_types = get_post_types( [ 'show_in_rest' => true ], $output );
+	$post_types = array_filter( get_post_types(), 'is_post_type_viewable' );
 
 	$exclude_post_types = [
 		'attachment',
-		'nav_menu_item',
-		'wp_block',
-		'wp_navigation',
-		'wp_template',
-		'wp_template_part',
 		'dt_ext_connection',
 		'dt_subscription',
 	];
@@ -331,11 +326,20 @@ function distributable_post_types( $output = 'names' ) {
 	 * @hook distributable_post_types
 	 *
 	 * @param {array} Post types that are distributable.
-	 * @param {string} The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
 	 *
 	 * @return {array} Post types that are distributable.
 	 */
-	return apply_filters( 'distributable_post_types', $post_types, $output );
+	$post_types = apply_filters( 'distributable_post_types', $post_types );
+
+	// Remove unregistered post types added via the filter.
+	$post_types = array_filter( $post_types, 'post_type_exists' );
+
+	if ( 'objects' === $output ) {
+		// Convert to objects.
+		$post_types = array_map( 'get_post_type_object', $post_types );
+	}
+
+	return $post_types;
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -304,6 +304,7 @@ function available_pull_post_types( $connection, $type ) {
  *                       Accepts post type 'names' or 'objects'. Default 'names'.
  *
  * @since  1.0
+ * @since  x.x.x $output parameter introduced.
  * @return array
  */
 function distributable_post_types( $output = 'names' ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -285,14 +285,28 @@ function available_pull_post_types( $connection, $type ) {
 /**
  * Return post types that are allowed to be distributed
  *
+ * @param string $output Optional. The type of output to return.
+ *                       Accepts post type 'names' or 'objects'. Default 'names'.
+ *
  * @since  1.0
  * @return array
  */
-function distributable_post_types() {
-	$post_types = get_post_types( [ 'public' => true ] );
+function distributable_post_types( $output = 'names' ) {
+	$post_types = get_post_types( [ 'show_in_rest' => true ] , $output );
 
-	if ( ! empty( $post_types['attachment'] ) ) {
-		unset( $post_types['attachment'] );
+	$exclude_post_types = [
+		'attachment',
+		'nav_menu_item',
+		'wp_block',
+		'wp_navigation',
+		'wp_template',
+		'wp_template_part',
+		'dt_ext_connection',
+		'dt_subscription'
+	];
+
+	foreach ( $exclude_post_types as $exclude_post_type ) {
+		unset( $post_types[ $exclude_post_type ] );
 	}
 
 	/**
@@ -302,47 +316,11 @@ function distributable_post_types() {
 	 * @hook distributable_post_types
 	 *
 	 * @param {array} Post types that are distributable. Default all post types except `dt_ext_connection` and `dt_subscription`.
+	 * @param {string} The type of output to return. Accepts post type 'names' or 'objects'. Default 'names'.
 	 *
 	 * @return {array} Post types that are distributable.
 	 */
-	return apply_filters( 'distributable_post_types', array_diff( $post_types, [ 'dt_ext_connection', 'dt_subscription' ] ) );
-}
-
-/**
- * Return post types that should be excluded from the permission list.
- *
- * @since  1.7.0
- * @return array
- */
-function get_excluded_post_types_from_permission_list() {
-	// Hide the built-in post types except 'post' and 'page'.
-	$hide_from_list = get_post_types(
-		array(
-			'_builtin'     => true,
-			'show_in_rest' => true,
-		)
-	);
-	unset( $hide_from_list['post'], $hide_from_list['page'] );
-
-	// Default is keyed by the post type 'post' => 'post', etc; hence using `array_values`.
-	$hide_from_list = array_values( $hide_from_list );
-
-	/**
-	 * Filter to update the list of post types that should be hidden from the "Post types permissions" list.
-	 *
-	 * @since 1.7.0
-	 * @hook dt_excluded_post_types_from_permission_list
-	 *
-	 * @param {array} The list of hidden post types.
-	 *
-	 * @return {bool} The updated array with the list of post types that should be hidden.
-	 */
-	$hide_from_list = apply_filters( 'dt_excluded_post_types_from_permission_list', $hide_from_list );
-
-	// Strict Hide 'dt_subscription' post type.
-	$hide_from_list[] = 'dt_subscription';
-
-	return $hide_from_list;
+	return apply_filters( 'distributable_post_types', $post_types, $output );
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -292,7 +292,7 @@ function available_pull_post_types( $connection, $type ) {
  * @return array
  */
 function distributable_post_types( $output = 'names' ) {
-	$post_types = get_post_types( [ 'show_in_rest' => true ] , $output );
+	$post_types = get_post_types( [ 'show_in_rest' => true ], $output );
 
 	$exclude_post_types = [
 		'attachment',
@@ -302,7 +302,7 @@ function distributable_post_types( $output = 'names' ) {
 		'wp_template',
 		'wp_template_part',
 		'dt_ext_connection',
-		'dt_subscription'
+		'dt_subscription',
 	];
 
 	foreach ( $exclude_post_types as $exclude_post_type ) {


### PR DESCRIPTION
### Description of the Change

* This PR reverts the changes made in #898.
* Removes the function `get_excluded_post_types_from_permission_list`.
* Removes a filter `dt_excluded_post_types_from_permission_list`.
* Modifies the `distributable_post_types` function. Added a new parameter `$output`, which supports returning the result as per the given type of output.
* In that function, the following post types are excluded from the result by default.
```
                 'attachment',
		'nav_menu_item',
		'wp_block',
		'wp_navigation',
		'wp_template',
		'wp_template_part',
		'dt_ext_connection',
		'dt_subscription'
```


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #906

### How to test the Change

1. Create a new connection or edit an existing one.
2. See the list under the “Post types permissions” title.
3. You won’t find any of these:
    1. Media
    2. Navigation Menu Items
    3. Reusable blocks
    4. Templates
    5. Templates Parts
    6. Navigation Menus

### Changelog Entry
> Added - Distributable post types made consistent
> Removed - The filter `dt_excluded_post_types_from_permission_list` is removed.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
