### PR TITLE
Don't discard the `post_type` argument, as this will force all items to be the type `post`

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1140,6 +1140,8 @@ function post_args_allow_list( $post_args ) {
 		'post_excerpt',
 		'post_status',
 		'post_type',
+		'comment_status',
+		'ping_status',
 		'post_password',
 		'post_name',
 		'to_ping',

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1139,6 +1139,7 @@ function post_args_allow_list( $post_args ) {
 		'post_title',
 		'post_excerpt',
 		'post_status',
+		'post_type',
 		'post_password',
 		'post_name',
 		'to_ping',

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -874,6 +874,7 @@ class UtilsTest extends TestCase {
 	function test_post_args_allow_list() {
 		$post_args = [
 			'post_title'   => 'Test Title',
+			'post_type'    => 'post',
 			'post_content' => 'Test Content',
 			'post_excerpt' => 'Test Excerpt',
 			'link'         => 'https://github.com/10up/distributor/issues/879',
@@ -882,6 +883,7 @@ class UtilsTest extends TestCase {
 
 		$expected = [
 			'post_title'   => 'Test Title',
+			'post_type'    => 'post',
 			'post_content' => 'Test Content',
 			'post_excerpt' => 'Test Excerpt',
 		];


### PR DESCRIPTION
### Description of the Change

In #895 we added some code to ensure only the arguments we want are allowed to be passed in to `wp_insert_post`. The `post_type` argument was left off that list, which now means that argument isn't set and `wp_insert_post` will default to using `post` as the argument there. This means any non-post `post_type` will be imported as a post.

This is a simple fix of just adding `post_type` to the list of approved arguments, so that value won't be lost.

Closes #919, #921

### How to test the Change

Test pulling in a non-post `post_type` item (Page or CPT) from both an internal and external connection. Ensure in both instances the proper `post_type` is retained.

Test pushing a non-post `post_type` item (Page or CPT) from both an internal and external connection. Ensure in both instances the proper `post_type` is retained.

### Changelog Entry
> Fixed - Ensure we don't lose the `post_type` value when pushing or pulling content.

### Credits
Props @dkotter, @pdewouters, @andygagnon, @jmstew3


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
