### PR TITLE
Update distributions after post terms and meta is saved.

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -579,7 +579,7 @@ class NetworkSiteConnection extends Connection {
 	 */
 	public static function bootstrap() {
 		add_action( 'template_redirect', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'canonicalize_front_end' ) );
-		add_action( 'save_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'update_syndicated' ), 99 );
+		add_action( 'wp_after_insert_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'update_syndicated' ), 99 );
 		add_action( 'before_delete_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'separate_syndicated_on_delete' ) );
 		add_action( 'before_delete_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'remove_distributor_post_from_original' ) );
 		add_action( 'wp_trash_post', array( '\Distributor\InternalConnections\NetworkSiteConnection', 'separate_syndicated_on_delete' ) );

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -704,12 +704,6 @@ class NetworkSiteConnection extends Connection {
 			return;
 		}
 
-		// If using Gutenberg, short circuit early and run this method later to make sure terms and meta are saved before syndicating.
-		if ( \Distributor\Utils\is_using_gutenberg( $post ) && doing_action( 'save_post' ) && ! isset( $_GET['meta-box-loader'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			add_action( "rest_after_insert_{$post->post_type}", array( '\Distributor\InternalConnections\NetworkSiteConnection', 'update_syndicated' ) );
-			return;
-		}
-
 		$connection_map = get_post_meta( $post_id, 'dt_connection_map', true );
 
 		if ( empty( $connection_map ) || ! is_array( $connection_map ) || empty( $connection_map['internal'] ) ) {

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -244,12 +244,6 @@ function send_notifications( $post ) {
 		return;
 	}
 
-	// If using Gutenberg, short circuit early and run this method later to make sure terms and meta are saved before syndicating.
-	if ( \Distributor\Utils\is_using_gutenberg( $post ) && doing_action( 'save_post' ) && ! isset( $_GET['meta-box-loader'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-		add_action( "rest_after_insert_{$post->post_type}", __NAMESPACE__ . '\send_notifications' );
-		return;
-	}
-
 	$subscriptions = get_post_meta( $post_id, 'dt_subscriptions', true );
 
 	if ( empty( $subscriptions ) ) {

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -20,7 +20,7 @@ function setup() {
 		'plugins_loaded',
 		function() {
 			add_action( 'init', __NAMESPACE__ . '\register_cpt' );
-			add_action( 'save_post', __NAMESPACE__ . '\send_notifications', 99 );
+			add_action( 'wp_after_insert_post', __NAMESPACE__ . '\send_notifications', 99 );
 			add_action( 'before_delete_post', __NAMESPACE__ . '\delete_subscriptions' );
 		}
 	);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This moves the updating of distributions during edits from the `save_post` hook to the `wp_after_insert_post` hook.

In updates via both the classic and REST API, WordPress fires this hook after all terms and post meta is updated. This prevents the distribution of legacy data described in the issue.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #399 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install this mini-plugin that [updates post meta with each save](https://gist.github.com/peterwilsoncc/61eeb5f2337cdf4976608a5123acbb1d) 
2. On the main `develop` branch
    a) Create and distribute a post via the block editor
    b) Update the post
    c) Check the database -- observe the value of the post meta differs between source and distribution (one less)
4. Switch to this branch
5. Resave the post in the block editor
6. observe the post meta matches in both the source and distributed material.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensure post meta and terms have saved prior to distribution.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @dinhtungdu, @dkotter, @timstl, @faisal-alvi.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
