### PR TITLE
Create release PR automatically when a release branch is pushed to GitHub

### DIFF
--- a/.github/release-pull-request-template.md
+++ b/.github/release-pull-request-template.md
@@ -1,0 +1,16 @@
+- [x] Branch: Starting from `develop`, create a release branch named `release/X.Y.Z` for your changes.
+- [ ] Version bump: Bump the version number in `distributor.php`, `package.json`, and `readme.txt` if it does not already reflect the version being released.  In `distributor.php` update both the plugin "Version:" property and the plugin `DT_VERSION` constant.
+- [ ] New files: Ensure any new files, especially in the vendor folder, are correctly included in `webpack.config.release.js`.
+- [ ] Changelog: Add/update the changelog in `CHANGELOG.md`.
+- [ ] Props: Update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
+- [ ] Readme updates: Make any other readme changes as necessary.  `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
+- [ ] Since tag updates: ensure `@since` tags indicate the new version, replacing `x.x.x`, `n.e.x.t` and other placeholders.
+- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the Pull Request), then do the same for `develop` into `trunk` (`git checkout trunk && git merge --no-ff develop`).  `trunk` contains the stable development version.
+- [ ] Build: Wait for the [Build Stable Release Action](https://github.com/10up/distributor/actions?query=workflow%3A%22Build+Stable+Release%22) to finish running.
+- [ ] Update this pull request's status from `draft` to `ready to merge`.
+- [ ] Review: Do a review of the commit to the `stable` branch to ensure the contents of the diffs are as expected.
+- [ ] Test: Check out the `stable` branch and test it locally to ensure everything works as expected.  It is recommended that you rename the existing `distributor` directory and check out `stable` fresh because switching branches does not delete files.  This can be done with `git clone --single-branch --branch stable git@github.com:10up/distributor.git`
+- [ ] Release: Create a [new release](https://github.com/10up/distributor/releases/new), naming the tag and the release with the new version number, and **targeting the `stable` branch**.  Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/10up/distributor/milestone/#?closed=1).  The release should now appear under [releases](https://github.com/10up/distributor/releases).
+- [ ] Check release: Wait for the [Publish Release Action](https://github.com/10up/distributor/actions?query=workflow%3A%22Publish+Release%22) to complete, and then check the latest release to ensure that the ZIP has been attached as an asset.  Download the ZIP and inspect the contents to be sure they match the contents of the `stable` branch.
+- [ ] Close milestone: Edit the [milestone](https://github.com/10up/distributor/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
+- [ ] Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0`, or `Future Release`.

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -1,0 +1,22 @@
+name: Release Pull Request Automation
+
+on:
+  create:
+jobs:
+  release-pull-request-automation:
+    if: ${{ github.event.ref_type == 'branch' && contains( github.ref, 'release/' ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Generate title
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo $BRANCH
+          VERSION=${BRANCH#'release/'}
+          echo ::set-output name=result::"Release: ${VERSION}"
+        id: title
+      - name: Create Pull Request
+        run: gh pr create --draft --title "${{ steps.title.outputs.result }}" --body-file ./.github/release-pull-request-template.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,17 +29,6 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Branch: Starting from `develop`, create a release branch named `release/X.Y.Z` for your changes.
-1. Version bump: Bump the version number in `distributor.php`, `package.json`, and `readme.txt` if it does not already reflect the version being released.  In `distributor.php` update both the plugin "Version:" property and the plugin `DT_VERSION` constant.
-1. New files: Ensure any new files, especially in the vendor folder, are correctly included in `webpack.config.release.js`.
-1. Changelog: Add/update the changelog in `CHANGELOG.md`.
-1. Props: Update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
-1. Readme updates: Make any other readme changes as necessary.  `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
-1. Since tag updates: ensure `@since` tags indicate the new version, replacing `x.x.x`, `n.e.x.t` and other placeholders.
-1. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the Pull Request), then do the same for `develop` into `trunk` (`git checkout trunk && git merge --no-ff develop`).  `trunk` contains the stable development version.
-1. Build: Wait for the [Build Stable Release Action](https://github.com/10up/distributor/actions?query=workflow%3A%22Build+Stable+Release%22) to finish running.
-1. Review: Do a review of the commit to the `stable` branch to ensure the contents of the diffs are as expected.
-1. Test: Check out the `stable` branch and test it locally to ensure everything works as expected.  It is recommended that you rename the existing `distributor` directory and check out `stable` fresh because switching branches does not delete files.  This can be done with `git clone --single-branch --branch stable git@github.com:10up/distributor.git`
-1. Release: Create a [new release](https://github.com/10up/distributor/releases/new), naming the tag and the release with the new version number, and **targeting the `stable` branch**.  Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/10up/distributor/milestone/#?closed=1).  The release should now appear under [releases](https://github.com/10up/distributor/releases).
-1. Check release: Wait for the [Publish Release Action](https://github.com/10up/distributor/actions?query=workflow%3A%22Publish+Release%22) to complete, and then check the latest release to ensure that the ZIP has been attached as an asset.  Download the ZIP and inspect the contents to be sure they match the contents of the `stable` branch.
-1. Close milestone: Edit the [milestone](https://github.com/10up/distributor/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
-1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0`, or `Future Release`.
+2. Follow pull request checklist: A draft release pull request will be created once you push your branch to Github. Follow the steps in the pull request.
+
+Should the pull request fail to be created, a pull request can be manually created using the [template file](https://github.com/10up/distributor/blob/develop/.github/release-pull-request-template.md) containing each of the steps.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds a new workflow that creates a release PR automatically when a release branch is pushed to GitHub.

Pushing release/2.1.1 to GitHub for the first time:

- A PR named Release: 2.1.1 is created.
- The PR content is taken from `./.github/release-pull-request-template.md.`


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #939

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

See ~peterwilsoncc#1~ _(fork since deleted)_

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Other - Automated creation of release pull requests.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dinhtungdu, @peterwilsoncc, @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
