### PR TITLE
Fix undefined variable localizing `gutenberg-syndicated-post`.

### DIFF
--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -632,7 +632,6 @@ function enqueue_gutenberg_edit_scripts() {
 		'dt-gutenberg-syndicated-post',
 		'dtGutenberg',
 		[
-			'i18n'                 => $i18n_locale,
 			'originalBlogId'       => (int) $original_blog_id,
 			'originalPostId'       => (int) $original_post_id,
 			'originalSourceId'     => (int) $original_source_id,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Fixes a bug introduced during requirement bump causing an undefined variable notice while enqueuing `gutenberg-syndicated-post.js`.

During the switch to wp-scripts, the use of the variable was replaced with the `wp.i18n` package so can be removed 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
See #905.
Follow up to 7be02372ebd64e9fb5478cf2723a6c29e8c4cb2d in #917.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Undefined variable notice.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
