### PR TITLE
Ensure translator comments are consistent.

### DIFF
--- a/includes/distributed-post-ui.php
+++ b/includes/distributed-post-ui.php
@@ -89,7 +89,7 @@ function distributed_to( $post ) {
 			<?php
 			echo wp_kses_post(
 				sprintf(
-					/* translators: %d: number of connections */
+					/* translators: 1: Number of connections content distributed to. */
 					_n(
 						'Distributed to %1$s connection.',
 						'Distributed to %1$s connections.',

--- a/includes/distributed-post-ui.php
+++ b/includes/distributed-post-ui.php
@@ -54,7 +54,7 @@ function add_help_tab() {
 		array(
 			'id'      => 'distributer',
 			'title'   => esc_html__( 'Distributor', 'distributor' ),
-			/* translators: %1$s: Post type singular name, %2$s: Post type singular name, %3$s: Pos type name */
+			/* translators: %1$s: Post type singular name, %2$s: Post type singular name, %3$s: Post type name */
 			'content' => '<p>' . sprintf( esc_html__( 'The number of connections this %1$s has been distributed to is shown in the publish meta box. If this %2$s is deleted, it could have ramifications across all those %3$s.', 'distributor' ), esc_html( strtolower( $post_type_object->labels->singular_name ) ), esc_html( strtolower( $post_type_object->labels->singular_name ) ), esc_html( strtolower( $post_type_object->labels->name ) ) ) . '</p>',
 		)
 	);

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -439,7 +439,7 @@ function syndicated_message( $post ) {
 		restore_current_blog();
 
 		if ( empty( $original_location_name ) ) {
-			/* translators: %d: the blog ID */
+			/* translators: %d: The site ID */
 			$original_location_name = sprintf( esc_html__( 'Blog #%d', 'distributor' ), $original_blog_id );
 		}
 	} else {
@@ -594,7 +594,7 @@ function enqueue_gutenberg_edit_scripts() {
 		restore_current_blog();
 
 		if ( empty( $original_location_name ) ) {
-			/* translators: %d: the original blog id */
+			/* translators: %d: The site ID */
 			$original_location_name = sprintf( esc_html__( 'Blog #%d', 'distributor' ), $original_blog_id );
 		}
 	} else {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Replaces a few translator comments to ensure they are consistent in each location they are used.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #948

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Other - Unified translator comments.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
