### PR TITLE
Sync empty taxonomies to distributed posts.

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -248,6 +248,11 @@ class SubscriptionsController extends \WP_REST_Controller {
 				'media'        => ( isset( $request['post_data']['distributor_media'] ) ) ? $request['post_data']['distributor_media'] : [],
 			];
 
+			// Limit taxonomy updates to those shown in the REST API.
+			$rest_taxonomies = get_taxonomies( [ 'show_in_rest' => true ] );
+			$rest_taxonomies = array_fill_keys( $rest_taxonomies, true );
+			$update['terms'] = array_intersect_key( $update['terms'], $rest_taxonomies );
+
 			update_post_meta( (int) $request['post_id'], 'dt_subscription_update', $update );
 
 			$unlinked = (bool) get_post_meta( $request['post_id'], 'dt_unlinked', true );

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -284,33 +284,42 @@ function send_notifications( $post ) {
 			}
 		}
 
+		/**
+		 * Filter the timeout used when calling `\Distributor\Subscriptions\send_notifications`
+		 *
+		 * @hook dt_subscription_post_timeout
+		 *
+		 * @param {int}     $timeout The timeout to use for the remote post. Default `5`.
+		 * @param {WP_Post} $post    The post object
+		 *
+		 * @return {int} The timeout to use for the remote post.
+		 */
+		$request_timeout = apply_filters( 'dt_subscription_post_timeout', 5, $post );
+
+		/**
+		 * Filter the arguments sent to the remote server during a subscription update.
+		 *
+		 * @since 1.3.0
+		 * @hook dt_subscription_post_args
+		 *
+		 * @param  {array}   $post_body The request body to send.
+		 * @param  {WP_Post} $post      The WP_Post that is being pushed.
+		 *
+		 * @return {array} The request body to send.
+		 */
+		$post_body = apply_filters( 'dt_subscription_post_args', $post_body, $post );
+
+		$post_arguments = [
+			'timeout' => $request_timeout,
+			'body'    => wp_json_encode( $post_body ),
+			'headers' => [
+				'Content-Type' => 'application/json',
+			],
+		];
+
 		$request = wp_remote_post(
 			untrailingslashit( $target_url ) . '/wp/v2/dt_subscription/receive',
-			[
-				/**
-				 * Filter the timeout used when calling `\Distributor\Subscriptions\send_notifications`
-				 *
-				 * @hook dt_subscription_post_timeout
-				 *
-				 * @param {int}     $timeout The timeout to use for the remote post. Default `5`.
-				 * @param {WP_Post} $post    The post object
-				 *
-				 * @return {int} The timeout to use for the remote post.
-				 */
-				'timeout' => apply_filters( 'dt_subscription_post_timeout', 5, $post ),
-				/**
-				 * Filter the arguments sent to the remote server during a subscription update.
-				 *
-				 * @since 1.3.0
-				 * @hook dt_subscription_post_args
-				 *
-				 * @param  {array}   $post_body The request body to send.
-				 * @param  {WP_Post} $post      The WP_Post that is being pushed.
-				 *
-				 * @return {array} The request body to send.
-				 */
-				'body'    => apply_filters( 'dt_subscription_post_args', $post_body, $post ),
-			]
+			$post_arguments
 		);
 
 		if ( ! is_wp_error( $request ) ) {

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -273,7 +273,7 @@ function send_notifications( $post ) {
 				'content'           => Utils\get_processed_content( $post->post_content ),
 				'excerpt'           => $post->post_excerpt,
 				'distributor_media' => \Distributor\Utils\prepare_media( $post_id ),
-				'distributor_terms' => \Distributor\Utils\prepare_taxonomy_terms( $post_id ),
+				'distributor_terms' => \Distributor\Utils\prepare_taxonomy_terms( $post_id, array( 'show_in_rest' => true ) ),
 				'distributor_meta'  => \Distributor\Utils\prepare_meta( $post_id ),
 			],
 		];

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -438,15 +438,21 @@ function prepare_media( $post_id ) {
 /**
  * Format taxonomy terms for consumption
  *
- * @param  int $post_id Post ID.
  * @since  1.0
- * @return array
+ *
+ * @param  int   $post_id Post ID.
+ * @param  array $args    Taxonomy query arguments. See get_taxonomies().
+ * @return array[] Array of taxonomy terms.
  */
-function prepare_taxonomy_terms( $post_id ) {
+function prepare_taxonomy_terms( $post_id, $args = array() ) {
 	$post = get_post( $post_id );
 
+	if ( empty( $args ) ) {
+		$args = array( 'publicly_queryable' => true );
+	}
+
 	$taxonomy_terms = [];
-	$taxonomies     = get_object_taxonomies( $post );
+	$taxonomies     = get_taxonomies( $args );
 
 	/**
 	 * Filters the taxonomies that should be synced.

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -547,7 +547,7 @@ class SubscriptionsTest extends TestCase {
 					$target_url . '/wp/v2/dt_subscription/receive',
 					[
 						'timeout' => 5,
-						'body'    => [
+						'body'    => wp_json_encode( [
 							'post_id'   => $remote_post_id,
 							'signature' => $signature,
 							'post_data' => [
@@ -560,7 +560,10 @@ class SubscriptionsTest extends TestCase {
 								'distributor_terms' => [],
 								'distributor_meta'  => [],
 							],
-						],
+						] ),
+						'headers' => [
+							'Content-Type' => 'application/json',
+						]
 					],
 				],
 			]

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -359,19 +359,22 @@ class SubscriptionsTest extends TestCase {
 					$target_url . '/wp/v2/dt_subscription/receive',
 					[
 						'timeout' => 5,
-						'body'    => [
+						'body'    => wp_json_encode( [
 							'post_id'   => $remote_post_id,
 							'signature' => $signature,
 							'post_data' => [
 								'title'             => 'title',
+								'slug'              => 'slug',
+								'post_type'         => 'post',
 								'content'           => 'content',
 								'excerpt'           => 'excerpt',
-								'post_type'         => 'post',
-								'slug'              => 'slug',
 								'distributor_media' => [],
 								'distributor_terms' => [],
 								'distributor_meta'  => [],
-							],
+							]
+						] ),
+						'headers' => [
+							'Content-Type' => 'application/json',
 						],
 					],
 				],
@@ -553,9 +556,9 @@ class SubscriptionsTest extends TestCase {
 							'post_data' => [
 								'title'             => 'title',
 								'slug'              => 'slug',
+								'post_type'         => 'post',
 								'content'           => 'content',
 								'excerpt'           => 'excerpt',
-								'post_type'         => 'post',
 								'distributor_media' => [],
 								'distributor_terms' => [],
 								'distributor_meta'  => [],

--- a/tests/php/SubscriptionsTest.php
+++ b/tests/php/SubscriptionsTest.php
@@ -368,9 +368,9 @@ class SubscriptionsTest extends TestCase {
 								'post_type'         => 'post',
 								'content'           => 'content',
 								'excerpt'           => 'excerpt',
-								'distributor_media' => [],
-								'distributor_terms' => [],
-								'distributor_meta'  => [],
+								'distributor_media' => null, // Accounts for https://github.com/10up/wp_mock/issues/173
+								'distributor_terms' => null, // Accounts for https://github.com/10up/wp_mock/issues/173
+								'distributor_meta'  => null, // Accounts for https://github.com/10up/wp_mock/issues/173
 							]
 						] ),
 						'headers' => [
@@ -559,9 +559,9 @@ class SubscriptionsTest extends TestCase {
 								'post_type'         => 'post',
 								'content'           => 'content',
 								'excerpt'           => 'excerpt',
-								'distributor_media' => [],
-								'distributor_terms' => [],
-								'distributor_meta'  => [],
+								'distributor_media' => null, // Accounts for https://github.com/10up/wp_mock/issues/173
+								'distributor_terms' => null, // Accounts for https://github.com/10up/wp_mock/issues/173
+								'distributor_meta'  => null, // Accounts for https://github.com/10up/wp_mock/issues/173
 							],
 						] ),
 						'headers' => [

--- a/tests/php/includes/common.php
+++ b/tests/php/includes/common.php
@@ -250,6 +250,20 @@ function get_allowed_mime_types() {
 }
 
 /**
+ * Mock wp_json_encode() function.
+ *
+ * @since x.x.x
+ *
+ * @param mixed $data Data to encode.
+ * @param int   $options Optional. Options to be passed to json_encode(). Default 0.
+ * @param int   $depth Optional. Maximum depth to walk through $data.
+ * @return string|false The JSON encoded string, or false if it cannot be encoded.
+ */
+function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+	return json_encode( $data, $options, $depth );
+}
+
+/**
  * Stub for remove_filter to avoid failure in test_remote_get()
  *
  * @return void


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This modifies `prepare_taxonomy_terms()` to include both populated and unpopulated taxonomies when distributing sites.

This allows for the situation in which an original post is updated to remove all terms within a shared taxonomy.

To account for empty arrays being stripped from `$_POST` data (I've not been able to determine where this happens), update notifications are now sent as JSON encoded data to the remote sites REST API.  _This may be a backward compatibility issue for sites using hooks and getting POSTed data rather than using the `$request` object._

Taxonomy updates are limited to those shown in the REST API. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #625

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Check out the `develop` branch.
2. Create a post and assign it two or more tags.
3. Distribute the post
4. Observe distributed version of post has two tags
5. Delete one tag on original post, update it.
6. Observe distributed version of post has one tag.
7. Delete all tags on original post, update it.
8. Observe distributed version of post has one tag (error).
9. Check out this branch and repeat
10. After deleting tags on the original post, the distributed version should have no tags.

#### Notes

1. E2E tests are failing for trunk due to a bug in `@wordpress/env` -- it was fixed five days ago but is still to be released https://github.com/WordPress/gutenberg/commit/3983fee52b8fa0b9336d6202e8b92d407b99187c 
2. I've had to change some of the tests to work around an issue in wp_mocks. I've created an issue and linked to that within the comments.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Distribute empty taxonomies to external sites.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @manolobevia, @jeffpaul, @cadic

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
