### PR TITLE
Change from using the term `blacklist` to `excluded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,7 +288,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Add `dt_allowed_media_extensions` and `dt_media_processing_filename` filters so that different media types or specific files can be detected and targeted.
 
 ### Fixed
-- Ensure media meta is passed through `prepare_meta()` to apply the blacklist. This completes the generated image size info fix from 1.3.3.
+- Ensure media meta is passed through `prepare_meta()` to apply the exclusion. This completes the generated image size info fix from 1.3.3.
 - Avoid a PHP notice when only using the block editor on the receiving site.
 - Avoid a jQuery Migrate notice.
 
@@ -370,7 +370,7 @@ This adds a post type selector when viewing the Pull Content list for both exter
 
 ### Changed
 - Don’t set Distributor meta data on REST API post creation unless post was created by Distributor
-- Blacklist the `_wp_old_slug` and `_wp_old_date` meta
+- Exclude the `_wp_old_slug` and `_wp_old_date` meta
 - Disable pull UI while switching between pull connections
 
 ### Fixed

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -330,7 +330,7 @@ function distributable_post_statuses() {
  */
 function blacklisted_meta() {
 	_deprecated_function( __FUNCTION__, 'X.X.X', '\Distributor\Utils\excluded_meta()' );
-	excluded_meta();
+	return excluded_meta();
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -137,17 +137,17 @@ function is_dt_debug() {
 /**
  * Given an array of meta, set meta to another post.
  *
- * Don't copy in blacklisted (Distributor) meta.
+ * Don't copy in excluded (Distributor) meta.
  *
  * @param int   $post_id Post ID.
  * @param array $meta Array of meta as key => value
  */
 function set_meta( $post_id, $meta ) {
-	$existing_meta    = get_post_meta( $post_id );
-	$blacklisted_meta = blacklisted_meta();
+	$existing_meta = get_post_meta( $post_id );
+	$excluded_meta = excluded_meta();
 
 	foreach ( $meta as $meta_key => $meta_values ) {
-		if ( in_array( $meta_key, $blacklisted_meta, true ) ) {
+		if ( in_array( $meta_key, $excluded_meta, true ) ) {
 			continue;
 		}
 
@@ -175,8 +175,8 @@ function set_meta( $post_id, $meta ) {
 	/**
 	 * Fires after Distributor sets post meta.
 	 *
-	 * Note: All sent meta is included in the `$meta` array, including blacklisted keys.
-	 * Take care to continue to filter out blacklisted keys in any further meta setting.
+	 * Note: All sent meta is included in the `$meta` array, including excluded keys.
+	 * Take care to continue to filter out excluded keys in any further meta setting.
 	 *
 	 * @since 1.3.8
 	 * @hook dt_after_set_meta
@@ -322,23 +322,35 @@ function distributable_post_statuses() {
 }
 
 /**
- * Returns list of blacklisted meta keys
+ * Returns list of excluded meta keys
  *
  * @since  1.2
+ * @deprecated X.X.X Use excluded_meta()
  * @return array
  */
 function blacklisted_meta() {
+	_deprecated_function( __FUNCTION__, 'X.X.X', '\Distributor\Utils\excluded_meta()' );
+	excluded_meta();
+}
+
+/**
+ * Returns list of excluded meta keys
+ *
+ * @since  X.X.X
+ * @return array
+ */
+function excluded_meta() {
+
 	/**
-	 * Filter meta keys that are blacklisted from distribution.
+	 * Filter meta keys that are excluded from distribution.
 	 *
 	 * @since 1.0.0
-	 * @hook dt_blacklisted_meta
 	 *
-	 * @param {array} $meta_keys Blacklisted meta keys. Default `dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _wp_attachment_metadata, _edit_lock, _edit_last, _wp_old_slug, _wp_old_date`.
+	 * @param array $meta_keys Excluded meta keys.
 	 *
-	 * @return {array} Blacklisted meta keys.
+	 * @return array Excluded meta keys.
 	 */
-	return apply_filters(
+	$excluded_meta = apply_filters_deprecated(
 		'dt_blacklisted_meta',
 		[
 			'dt_unlinked',
@@ -356,8 +368,23 @@ function blacklisted_meta() {
 			'_edit_last',
 			'_wp_old_slug',
 			'_wp_old_date',
-		]
+		],
+		'X.X.X',
+		'dt_excluded_meta',
+		__( 'Please consider writing more inclusive code.', 'distributor' )
 	);
+
+	/**
+	 * Filter meta keys that are excluded from distribution.
+	 *
+	 * @since X.X.X
+	 * @hook dt_excluded_meta
+	 *
+	 * @param {array} $meta_keys Excluded meta keys. Default `dt_unlinked, dt_connection_map, dt_subscription_update, dt_subscriptions, dt_subscription_signature, dt_original_post_id, dt_original_post_url, dt_original_blog_id, dt_syndicate_time, _wp_attached_file, _wp_attachment_metadata, _edit_lock, _edit_last, _wp_old_slug, _wp_old_date`.
+	 *
+	 * @return {array} Excluded meta keys.
+	 */
+	return apply_filters( 'dt_excluded_meta', $excluded_meta );
 }
 
 /**
@@ -370,13 +397,12 @@ function blacklisted_meta() {
 function prepare_meta( $post_id ) {
 	$meta          = get_post_meta( $post_id );
 	$prepared_meta = array();
-
-	$blacklisted_meta = blacklisted_meta();
+	$excluded_meta = excluded_meta();
 
 	// Transfer all meta
 	foreach ( $meta as $meta_key => $meta_array ) {
 		foreach ( $meta_array as $meta_value ) {
-			if ( ! in_array( $meta_key, $blacklisted_meta, true ) ) {
+			if ( ! in_array( $meta_key, $excluded_meta, true ) ) {
 				$meta_value = maybe_unserialize( $meta_value );
 				/**
 				 * Filter whether to sync meta.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -345,6 +345,7 @@ function excluded_meta() {
 	 * Filter meta keys that are excluded from distribution.
 	 *
 	 * @since 1.0.0
+	 * @deprecated x.x.x
 	 *
 	 * @param array $meta_keys Excluded meta keys.
 	 *

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -53,6 +53,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
+			]
+		);
+
 		\WP_Mock::expectAction( 'dt_after_set_meta', [ 'key' => [ 'value' ] ], [], 1 );
 
 		\WP_Mock::expectAction( 'dt_after_set_meta', [ 'key' => [ [ 'value' ] ] ], [ 'key' => [ 'value' ] ], 1 );
@@ -143,6 +150,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
+			]
+		);
+
 		Utils\set_meta(
 			1, [
 				'key'  => [ 'value' ],
@@ -199,6 +213,13 @@ class UtilsTest extends TestCase {
 			'wp_slash', [
 				'times'      => 4,
 				'return_arg' => 0,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
 			]
 		);
 
@@ -517,6 +538,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
+			]
+		);
+
 		$formatted_media = Utils\format_media_post( $media_post );
 
 		$this->assertFalse( $formatted_media['featured'] );
@@ -605,6 +633,13 @@ class UtilsTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
+			]
+		);
+
 		$formatted_media = Utils\format_media_post( $media_post );
 
 		$this->assertTrue( $formatted_media['featured'] );
@@ -690,6 +725,13 @@ class UtilsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'remove_filter', [
 				'times' => 1,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
 			]
 		);
 
@@ -852,6 +894,13 @@ class UtilsTest extends TestCase {
 			'wp_slash', [
 				'times'      => 4,
 				'return_arg' => 0,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return_arg' => 1,
 			]
 		);
 


### PR DESCRIPTION
### Description of the Change

There's a handful of places we were using the term `blacklist`. To be more inclusive (and more descriptive), this PR changes those to use the term `excluded`.

There was one utility function and one filter that used the term `blacklist`. I've added deprecations for both of those, though we may be safe to just completely remove/rename the function (more likely though that the filter is being used).

Note also there's a handful of places that will need version numbers updated before we release this. I've left those as `X.X.X` for now.

Closes #960

### How to test the Change

Nothing that really needs tested here, though could test the meta exclusion piece to ensure nothing broke there (though this should just be name changes, no functionality changes).

### Changelog Entry

> Changed - Change uses of `blacklist` and use `exclude` instead
> Deprecated - Deprecate the `Distributor\Utils\blacklisted_meta` function and the `dt_blacklisted_meta` filter

### Credits
Props @dkotter, @jeffpaul 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
