### PR TITLE
Consider multisite for posts abstraction.

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -406,7 +406,6 @@ class DistributorPost {
 		}
 
 		return $thumbnail[ $hash ];
-		return get_the_post_thumbnail( $this->post, $size, $attr );
 	}
 
 	/**

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -186,11 +186,21 @@ class DistributorPost {
 
 		$this->site_id = get_current_blog_id();
 
-		// Pre-populate the post data to account for switching sites.
 		if ( ! is_multisite() ) {
 			return;
 		}
 
+		/*
+		 * Populate the source site data for internal connections.
+		 *
+		 * On multisite installations, call each of the methods using a static
+		 * for internal caching to account for site switching.
+		 *
+		 * This ensures the data returned is for the post used to create this
+		 * object. If the method is subsequently called after `switch_to_blog()`
+		 * then the returned data will relate to the initial site rather than
+		 * the switched site.
+		 */
 		$this->get_permalink();
 		$this->get_post_thumbnail_id();
 		$this->get_post_thumbnail_url();


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Accounts for multisite in the post abstraction helper methods.

Ensures the site switched correctly when using accessing post data. This prevents incorrect data during post ID collisions, or missing data if the post does not exist on the switched site.

Uses a lot of statics to avoid needless switching. This might not be worth it.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1007

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
