### PR TITLE
Update `unlink` warning message copy

### DIFF
--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -64,7 +64,7 @@ const RenderShowAdminBar = () => {
 				{ sprintf(
 					/* translators: 1: Post type or generic term content. */
 					__( 'Distribute %1$s', 'distributor' ),
-					dtGutenberg.postTypeSingular ||
+					dtGutenberg.postTypeSingular.toLowerCase() ||
 						_x(
 							'content',
 							'generic term for post content',

--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -14,7 +14,7 @@ if (
 		message = sprintf(
 			/* translators: 1) Distributor post type singular name, 2) Source of content. */
 			__(
-				'This %1$s was distributed from %2$s. However, the origin post has been deleted.'
+				'This %1$s was distributed from %2$s. However, the origin %1$s has been deleted.'
 			),
 			dtGutenberg.postTypeSingular,
 			dtGutenberg.originalLocationName
@@ -23,7 +23,7 @@ if (
 		message = sprintf(
 			/* translators: 1) Source of content, 2) Distributor post type singular name. */
 			__(
-				'Distributed from %1$s. This %2$s is linked to the origin post. Edits to the origin post will update this remote version.',
+				'Distributed from %1$s. This %2$s is linked to the origin %2$s. Edits to the origin %2$s will update this remote version.',
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
@@ -31,19 +31,27 @@ if (
 		);
 
 		actions.push( {
-			label: __( 'Unlink from the origin post.', 'distributor' ),
+			label: sprintf(
+				/* translators: 1) Distributor post type singular name. */
+				__( 'Unlink from the origin %1$s.', 'distributor' ),
+				dtGutenberg.postTypeSingular
+			),
 			url: dtGutenberg.unlinkNonceUrl,
 		} );
 
 		actions.push( {
-			label: __( 'View the origin post', 'distributor' ),
+			label: sprintf(
+				/* translators: 1) Distributor post type singular name. */
+				__( 'View the origin %1$s', 'distributor' ),
+				dtGutenberg.postTypeSingular
+			),
 			url: dtGutenberg.postUrl,
 		} );
 	} else {
 		message = sprintf(
 			/* translators: 1) Source of content, 2) Distributor post type singular name. */
 			__(
-				'Originally distributed from %1$s. This %2$s has been unlinked from the origin post. Edits to the origin post will not update this remote version.',
+				'Originally distributed from %1$s. This %2$s has been unlinked from the origin %2$s. Edits to the origin %2$s will not update this remote version.',
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
@@ -51,12 +59,20 @@ if (
 		);
 
 		actions.push( {
-			label: __( 'Relink to the origin post.', 'distributor' ),
+			label: sprintf(
+				/* translators: 1) Distributor post type singular name. */
+				__( 'Relink to the origin %1$s.', 'distributor' ),
+				dtGutenberg.postTypeSingular
+			),
 			url: dtGutenberg.linkNonceUrl,
 		} );
 
 		actions.push( {
-			label: __( 'View the origin post', 'distributor' ),
+			label: sprintf(
+				/* translators: 1) Distributor post type singular name. */
+				__( 'View the origin %1$s', 'distributor' ),
+				dtGutenberg.postTypeSingular
+			),
 			url: dtGutenberg.postUrl,
 		} );
 	}

--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -42,7 +42,7 @@ if (
 		actions.push( {
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
-				__( 'View the origin %1$s', 'distributor' ),
+				__( 'View the origin %1$s.', 'distributor' ),
 				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.postUrl,
@@ -70,7 +70,7 @@ if (
 		actions.push( {
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
-				__( 'View the origin %1$s', 'distributor' ),
+				__( 'View the origin %1$s.', 'distributor' ),
 				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.postUrl,

--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -16,7 +16,7 @@ if (
 			__(
 				'This %1$s was distributed from %2$s. However, the origin %1$s has been deleted.'
 			),
-			dtGutenberg.postTypeSingular,
+			dtGutenberg.postTypeSingular.toLowerCase(),
 			dtGutenberg.originalLocationName
 		);
 	} else if ( ! parseInt( dtGutenberg.unlinked ) ) {
@@ -27,14 +27,14 @@ if (
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
-			dtGutenberg.postTypeSingular
+			dtGutenberg.postTypeSingular.toLowerCase()
 		);
 
 		actions.push( {
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
 				__( 'Unlink from the origin %1$s.', 'distributor' ),
-				dtGutenberg.postTypeSingular
+				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.unlinkNonceUrl,
 		} );
@@ -43,7 +43,7 @@ if (
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
 				__( 'View the origin %1$s', 'distributor' ),
-				dtGutenberg.postTypeSingular
+				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.postUrl,
 		} );
@@ -55,14 +55,14 @@ if (
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
-			dtGutenberg.postTypeSingular
+			dtGutenberg.postTypeSingular.toLowerCase()
 		);
 
 		actions.push( {
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
 				__( 'Relink to the origin %1$s.', 'distributor' ),
-				dtGutenberg.postTypeSingular
+				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.linkNonceUrl,
 		} );
@@ -71,7 +71,7 @@ if (
 			label: sprintf(
 				/* translators: 1) Distributor post type singular name. */
 				__( 'View the origin %1$s', 'distributor' ),
-				dtGutenberg.postTypeSingular
+				dtGutenberg.postTypeSingular.toLowerCase()
 			),
 			url: dtGutenberg.postUrl,
 		} );

--- a/assets/js/gutenberg-syndicated-post.js
+++ b/assets/js/gutenberg-syndicated-post.js
@@ -14,7 +14,7 @@ if (
 		message = sprintf(
 			/* translators: 1) Distributor post type singular name, 2) Source of content. */
 			__(
-				'This %1$s was distributed from %2$s. However, the original has been deleted.'
+				'This %1$s was distributed from %2$s. However, the origin post has been deleted.'
 			),
 			dtGutenberg.postTypeSingular,
 			dtGutenberg.originalLocationName
@@ -23,7 +23,7 @@ if (
 		message = sprintf(
 			/* translators: 1) Source of content, 2) Distributor post type singular name. */
 			__(
-				'Distributed from %1$s. This %2$s is linked to the original. Edits to the original will update this version.',
+				'Distributed from %1$s. This %2$s is linked to the origin post. Edits to the origin post will update this remote version.',
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
@@ -31,19 +31,19 @@ if (
 		);
 
 		actions.push( {
-			label: __( 'Unlink from original.', 'distributor' ),
+			label: __( 'Unlink from the origin post.', 'distributor' ),
 			url: dtGutenberg.unlinkNonceUrl,
 		} );
 
 		actions.push( {
-			label: __( 'View Original', 'distributor' ),
+			label: __( 'View the origin post', 'distributor' ),
 			url: dtGutenberg.postUrl,
 		} );
 	} else {
 		message = sprintf(
 			/* translators: 1) Source of content, 2) Distributor post type singular name. */
 			__(
-				'Originally distributed from %1$s. This %2$s has been unlinked from the original. Edits to the original will not update this version.',
+				'Originally distributed from %1$s. This %2$s has been unlinked from the origin post. Edits to the origin post will not update this remote version.',
 				'distributor'
 			),
 			dtGutenberg.originalLocationName,
@@ -51,12 +51,12 @@ if (
 		);
 
 		actions.push( {
-			label: __( 'Relink to original.', 'distributor' ),
+			label: __( 'Relink to the origin post.', 'distributor' ),
 			url: dtGutenberg.linkNonceUrl,
 		} );
 
 		actions.push( {
-			label: __( 'View Original', 'distributor' ),
+			label: __( 'View the origin post', 'distributor' ),
 			url: dtGutenberg.postUrl,
 		} );
 	}

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -598,7 +598,7 @@ function menu_content() {
 					if ( ! empty( $post_url ) ) {
 						?>
 						<a href="<?php echo esc_url( $post_url ); ?>" target="_blank">
-							<?php esc_html_e( 'View original', 'distributor' ); ?>
+							<?php esc_html_e( 'View the origin post', 'distributor' ); ?>
 						</a>
 						<?php
 					}

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -600,7 +600,7 @@ function menu_content() {
 							echo wp_kses_post(
 								sprintf(
 									/* translators: 1) Distributor post type singular name. */
-									__( 'View the origin %1$s', 'distributor' ),
+									__( 'View the origin %1$s.', 'distributor' ),
 									esc_html( strtolower( $post_type_object->labels->singular_name ) ),
 								)
 							);

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -598,7 +598,15 @@ function menu_content() {
 					if ( ! empty( $post_url ) ) {
 						?>
 						<a href="<?php echo esc_url( $post_url ); ?>" target="_blank">
-							<?php esc_html_e( 'View the origin post', 'distributor' ); ?>
+							<?php
+							echo wp_kses_post(
+								sprintf(
+									/* translators: 1) Distributor post type singular name. */
+									__( 'View the origin %1$s', 'distributor' ),
+									esc_html( strtolower( $post_type_object->labels->singular_name ) ),
+								)
+							);
+							?>
 						</a>
 						<?php
 					}

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -586,13 +586,11 @@ function menu_content() {
 					<?php /* translators: %s: post type name */ ?>
 
 					<?php
-					echo wp_kses_post(
-						sprintf(
-							/* translators: 1) Distributor post type singular name, 2) Source of content. */
-							__( 'This %1$s was distributed from %2$s.', 'distributor' ),
-							esc_html( strtolower( $post_type_object->labels->singular_name ) ),
-							'<a href="' . esc_url( $site_url ) . '">' . esc_html( $blog_name ) . '</a>'
-						)
+					printf(
+						/* translators: 1) Distributor post type singular name, 2) Source of content. */
+						esc_html__( 'This %1$s was distributed from %2$s.', 'distributor' ),
+						esc_html( strtolower( $post_type_object->labels->singular_name ) ),
+						'<a href="' . esc_url( $site_url ) . '">' . esc_html( $blog_name ) . '</a>'
 					);
 
 					if ( ! empty( $post_url ) ) {

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -478,8 +478,23 @@ function syndicated_message( $post ) {
 					?>
 					</p>
 					<p>
-					<span><a href="<?php echo esc_url( $unlink_url ); ?>"><?php echo esc_html__( 'Unlink from the origin post.', 'distributor' ); ?></a></span>
-					<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View the origin post.', 'distributor' ); ?></a></span>
+					<span><a href="<?php echo esc_url( $unlink_url ); ?>">
+						<?php
+							printf(
+								/* translators: 1) Distributor post type singular name. */
+								esc_html__( 'Unlink from the origin %1$s.', 'distributor' ),
+								esc_html( strtolower( $post_type_singular ) )
+							);
+						?></a></span>
+					<span><a href="<?php echo esc_url( $original_post_url ); ?>">
+						<?php
+							printf(
+								/* translators: 1) Distributor post type singular name. */
+								esc_html__( 'View the origin %1$s.', 'distributor' ),
+								esc_html( strtolower( $post_type_singular ) )
+							);
+						?>
+					</a></span>
 				<?php endif; ?>
 			</p>
 		<?php else : ?>

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -455,7 +455,7 @@ function syndicated_message( $post ) {
 				<?php
 					printf(
 						/* translators: 1) Distributor post type singular name, 2) Source of content. */
-						esc_html__( 'This %1$s was distributed from %2$s. However, the origin post has been deleted.', 'distributor' ),
+						esc_html__( 'This %1$s was distributed from %2$s. However, the origin %1$s has been deleted.', 'distributor' ),
 						esc_html( strtolower( $post_type_singular ) ),
 						esc_html( $original_location_name )
 					);
@@ -466,7 +466,7 @@ function syndicated_message( $post ) {
 				<?php
 					printf(
 						/* translators: 1) Source of content, 2) Distributor post type singular name. */
-						esc_html__( 'Distributed from %1$s. This %2$s is linked to the origin post. Edits to the origin post will update this remote version.', 'distributor' ),
+						esc_html__( 'Distributed from %1$s. This %2$s is linked to the origin %2$s. Edits to the origin %2$s will update this remote version.', 'distributor' ),
 						esc_html( $original_location_name ),
 						esc_html( strtolower( $post_type_singular ) )
 					);
@@ -488,7 +488,7 @@ function syndicated_message( $post ) {
 				printf(
 					/* translators: 1) Source of content, 2) Distributor post type singular name. */
 					esc_html__(
-						'Originally distributed from %1$s. This %2$s has been unlinked from the origin post. Edits to the origin post will not update this remote version.',
+						'Originally distributed from %1$s. This %2$s has been unlinked from the origin %2$s. Edits to the origin %2$s will not update this remote version.',
 						'distributor'
 					),
 					esc_html( $original_location_name ),
@@ -498,8 +498,24 @@ function syndicated_message( $post ) {
 				?>
 			</p>
 			<p>
-				<span><a href="<?php echo esc_url( $relink_url ); ?>"><?php echo esc_html__( 'Relink to the origin post.', 'distributor' ); ?></a></span>
-				<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View the origin post.', 'distributor' ); ?></a></span>
+				<span><a href="<?php echo esc_url( $relink_url ); ?>">
+				<?php
+					printf(
+						/* translators: 1) Distributor post type singular name. */
+						esc_html__( 'Relink to the origin %1$s.', 'distributor' ),
+						esc_html( strtolower( $post_type_singular ) )
+					);
+				?>
+				</a></span>
+				<span><a href="<?php echo esc_url( $original_post_url ); ?>">
+				<?php
+					printf(
+						/* translators: 1) Distributor post type singular name. */
+						esc_html__( 'View the origin %1$s', 'distributor' ),
+						esc_html( strtolower( $post_type_singular ) )
+					);
+				?>
+			</a></span>
 			</p>
 		<?php endif; ?>
 	</div>

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -455,7 +455,7 @@ function syndicated_message( $post ) {
 				<?php
 					printf(
 						/* translators: 1) Distributor post type singular name, 2) Source of content. */
-						esc_html__( 'This %1$s was distributed from %2$s. However, the original has been deleted.', 'distributor' ),
+						esc_html__( 'This %1$s was distributed from %2$s. However, the origin post has been deleted.', 'distributor' ),
 						esc_html( strtolower( $post_type_singular ) ),
 						esc_html( $original_location_name )
 					);
@@ -466,7 +466,7 @@ function syndicated_message( $post ) {
 				<?php
 					printf(
 						/* translators: 1) Source of content, 2) Distributor post type singular name. */
-						esc_html__( 'Distributed from %1$s. This %2$s is linked to the original. Edits to the original will update this version.', 'distributor' ),
+						esc_html__( 'Distributed from %1$s. This %2$s is linked to the origin post. Edits to the origin post will update this remote version.', 'distributor' ),
 						esc_html( $original_location_name ),
 						esc_html( strtolower( $post_type_singular ) )
 					);
@@ -478,8 +478,8 @@ function syndicated_message( $post ) {
 					?>
 					</p>
 					<p>
-					<span><a href="<?php echo esc_url( $unlink_url ); ?>"><?php echo esc_html__( 'Unlink from original.', 'distributor' ); ?></a></span>
-					<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View Original.', 'distributor' ); ?></a></span>
+					<span><a href="<?php echo esc_url( $unlink_url ); ?>"><?php echo esc_html__( 'Unlink from the origin post.', 'distributor' ); ?></a></span>
+					<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View the origin post.', 'distributor' ); ?></a></span>
 				<?php endif; ?>
 			</p>
 		<?php else : ?>
@@ -488,7 +488,7 @@ function syndicated_message( $post ) {
 				printf(
 					/* translators: 1) Source of content, 2) Distributor post type singular name. */
 					esc_html__(
-						'Originally distributed from %1$s. This %2$s has been unlinked from the original. Edits to the original will not update this version.',
+						'Originally distributed from %1$s. This %2$s has been unlinked from the origin post. Edits to the origin post will not update this remote version.',
 						'distributor'
 					),
 					esc_html( $original_location_name ),
@@ -498,8 +498,8 @@ function syndicated_message( $post ) {
 				?>
 			</p>
 			<p>
-				<span><a href="<?php echo esc_url( $relink_url ); ?>"><?php echo esc_html__( 'Relink to original.', 'distributor' ); ?></a></span>
-				<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View Original.', 'distributor' ); ?></a></span>
+				<span><a href="<?php echo esc_url( $relink_url ); ?>"><?php echo esc_html__( 'Relink to the origin post.', 'distributor' ); ?></a></span>
+				<span><a href="<?php echo esc_url( $original_post_url ); ?>"><?php echo esc_html__( 'View the origin post.', 'distributor' ); ?></a></span>
 			</p>
 		<?php endif; ?>
 	</div>

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -485,6 +485,7 @@ function syndicated_message( $post ) {
 								esc_html__( 'Unlink from the origin %1$s.', 'distributor' ),
 								esc_html( strtolower( $post_type_singular ) )
 							);
+						// phpcs:ignore Squiz.PHP.EmbeddedPhp.ContentAfterEnd, avoids layout issues.
 						?></a></span>
 					<span><a href="<?php echo esc_url( $original_post_url ); ?>">
 						<?php
@@ -520,8 +521,8 @@ function syndicated_message( $post ) {
 						esc_html__( 'Relink to the origin %1$s.', 'distributor' ),
 						esc_html( strtolower( $post_type_singular ) )
 					);
-				?>
-				</a></span>
+				// phpcs:ignore Squiz.PHP.EmbeddedPhp.ContentAfterEnd, avoids layout issues.
+				?></a></span>
 				<span><a href="<?php echo esc_url( $original_post_url ); ?>">
 				<?php
 					printf(

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -526,7 +526,7 @@ function syndicated_message( $post ) {
 				<?php
 					printf(
 						/* translators: 1) Distributor post type singular name. */
-						esc_html__( 'View the origin %1$s', 'distributor' ),
+						esc_html__( 'View the origin %1$s.', 'distributor' ),
 						esc_html( strtolower( $post_type_singular ) )
 					);
 				?>

--- a/tests/wpacceptance/DistributedPostTest.php
+++ b/tests/wpacceptance/DistributedPostTest.php
@@ -75,12 +75,12 @@ class DistributedPost extends \TestCase {
 
 		// Make sure we see distributed status admin notice and that it shows as linked
 		if ( $editor_has_blocks ) {
-			$I->seeText( 'Distributed from Site One. The original will update this version unless you unlink from original.View Original', '.components-notice__content' );
+			$I->seeText( 'Distributed from Site One. The origin post will update this version unless you unlink from the origin post. View the origin post', '.components-notice__content' );
 			$element = $I->getElement( '.components-notice__action' );
-			$I->seeText( 'unlink from original.', '.components-notice__action' );
+			$I->seeText( 'unlink from the origin post.', '.components-notice__action' );
 		} else {
 			$I->seeText( 'Distributed from', '.syndicate-status');
-			$I->seeText( 'unlink from the original', '.syndicate-status' );
+			$I->seeText( 'unlink from the origin post', '.syndicate-status' );
 		}
 
 		// Now let's check in the front end

--- a/tests/wpacceptance/LinkUnlinkTest.php
+++ b/tests/wpacceptance/LinkUnlinkTest.php
@@ -30,7 +30,7 @@ class LinkUnlinkTest extends \TestCase {
 
 		// I see linked link
 		if ( $editor_has_blocks ) {
-			$I->seeLink( 'View Original' );
+			$I->seeLink( 'View the origin post' );
 			// Unlink post
 			$I->click( '.components-notice__action' );
 
@@ -39,13 +39,13 @@ class LinkUnlinkTest extends \TestCase {
 			sleep( 1 );
 
 			// I see unlinked text
-			$I->seeText( 'Originally distributed from Site One. This Post has been unlinked from the original. However, you can alwaysrestore it.View Original', '.components-notice__content' );
+			$I->seeText( 'Originally distributed from Site One. This Post has been unlinked from the origin post. However, you can always restore it. View the origin post', '.components-notice__content' );
 
 			// I can interact with title field
 			$I->canInteractWithField( '#post-title-0' );
 
 		} else {
-			$I->seeLink( 'unlink from the original' );
+			$I->seeLink( 'unlink from the origin post' );
 			// I cant interact with title field
 			$I->cannotInteractWithField( '#title' );
 			// Unlink post
@@ -54,7 +54,7 @@ class LinkUnlinkTest extends \TestCase {
 			$I->waitUntilElementVisible( 'body.post-php' );;
 
 			// I see unlinked text
-			$I->seeText( 'This post has been unlinked from the original', '.syndicate-status' );
+			$I->seeText( 'This post has been unlinked from the origin post', '.syndicate-status' );
 
 			// I can interact with title field
 			$I->canInteractWithField( '#title' );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
The editor notice that displays on remote, distributed posts has some odd spacing (line break where a single space should be, no space after a period) and is missing trailing periods in some instances.  This PR attempts to clean up that spacing and missing periods as well as further clarify the terms of "origin" and "remote" posts when referring to distributed content.

See the [screenshot](https://webtrainingwheels.com/wp-content/uploads/2016/06/unlink.jpg) from a [sample how-to post](https://webtrainingwheels.com/syncing-content-between-wordpress-sites-wp-site-sync/):

![unlink](https://user-images.githubusercontent.com/2818133/213822624-9deae83c-b20e-47cd-b758-6ddb5d6cbb02.jpg)

While I've attempted various searches through the codebase to try and catch all the instances, its possible I missed some so having someone else run a spot-check on this branch to ensure things are **all** properly updated would be wonderful.

### How to test the Change
Ask ChatGPT, I'm curious if it knows.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Descriptive warning message copy on remote, distributed posts.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul, @peterwilsoncc, @cadic.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
