### PR TITLE
Ensure post abstraction methods use correct site ID.

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -17,6 +17,13 @@ use WP_Post;
  * includes the phrase Distributor to make it clear to developers `use`ing
  * the class that they are not using the `WP_Post` object.
  *
+ * Developer note: This class uses the `__call()` magic method to ensure the
+ * post data is from the correct site on multisite installs. This is to avoid
+ * repeating code to determine if `switch_to_blog()` is required.
+ *
+ * When adding new methods to this class, please ensure that the method is
+ * protected to ensure the magic method is used.
+ *
  * @since x.x.x
  */
 class DistributorPost {

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -95,6 +95,13 @@ class DistributorPost {
 	public $connection_id = 0;
 
 	/**
+	 * The site ID of this post.
+	 *
+	 * @var int
+	 */
+	public $site_id = 0;
+
+	/**
 	 * The source site data for internal connections.
 	 *
 	 * This is an array of site data for the source site. This is set by
@@ -122,7 +129,8 @@ class DistributorPost {
 			return;
 		}
 
-		$this->post = $post;
+		$this->post    = $post;
+		$this->site_id = get_current_blog_id();
 
 		/*
 		 * The original post ID is listed as excluded post meta and therefore

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -204,8 +204,10 @@ class DistributorPost {
 		}
 
 		if ( get_current_blog_id() !== $this->site_id ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- throwing a warning is the correct behavior.
-			trigger_error( 'DistributorPost object is not on the correct site.', E_USER_WARNING );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- throwing a warning is the correct behavior.
+				trigger_error( 'DistributorPost object is not on the correct site.', E_USER_WARNING );
+			}
 			switch_to_blog( $this->site_id );
 			$switched = true;
 		}

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -237,14 +237,21 @@ class DistributorPost {
 		$cache_key = md5( "{$name}::" . wp_json_encode( $arguments ) );
 		if ( ! method_exists( $this, $name ) ) {
 			// Emulate default behavior of calling non existent method (a fatal error).
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput -- class and name are safe.
-			trigger_error( 'Call to undefined method ' . __CLASS__ . '::' . $name . '()', E_USER_ERROR );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error(
+				sprintf(
+					/* translators: %s: method name */
+					esc_html__( 'Call to undefined method %s', 'distributor' ),
+					esc_html( __CLASS__ . '::' . $name . '()' )
+				),
+				E_USER_ERROR
+			);
 		}
 
 		if ( get_current_blog_id() !== $this->site_id ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- throwing a warning is the correct behavior.
-				trigger_error( 'DistributorPost object is not on the correct site.', E_USER_WARNING );
+				trigger_error( esc_html__( 'DistributorPost object was called from a switched site.', 'distributor' ), E_USER_WARNING );
 			}
 			// array_key_exists as opposed to isset to avoid false negatives.
 			if ( array_key_exists( $cache_key, $this->switched_site_cache ) ) {

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -129,8 +129,8 @@ class DistributorPost {
 			return;
 		}
 
-		$this->post    = $post;
 		$this->site_id = get_current_blog_id();
+		$this->post    = $post;
 
 		/*
 		 * The original post ID is listed as excluded post meta and therefore

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -25,6 +25,24 @@ use WP_Post;
  * protected to ensure the magic method is used.
  *
  * @since x.x.x
+ *
+ * @method bool has_blocks()
+ * @method bool has_block( string $block_name )
+ * @method int  get_the_ID()
+ * @method string get_permalink()
+ * @method string get_post_type()
+ * @method int|false get_post_thumbnail_id()
+ * @method string|false get_post_thumbnail_url( string $size = 'post-thumbnail' )
+ * @method string|false get_the_post_thumbnail( string $size = 'post-thumbnail', array $attr = '' )
+ * @method string get_canonical_url( string $canonical_url = '' )
+ * @method string get_author_name( string $author_name = '' )
+ * @method string get_author_link( string $author_link = '' )
+ * @method array get_meta()
+ * @method array get_terms()
+ * @method array get_media()
+ * @method array post_data()
+ * @method array to_insert()
+ * @method string to_json( int $options = 0, int $depth = 512 )
  */
 class DistributorPost {
 	/**

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -22,7 +22,9 @@ use WP_Post;
  * repeating code to determine if `switch_to_blog()` is required.
  *
  * When adding new methods to this class, please ensure that the method is
- * protected to ensure the magic method is used.
+ * protected to ensure the magic method is used. If the method is intended to
+ * be public, please add it to the `@method` docblock below to ensure it is
+ * shown in IDEs.
  *
  * @since x.x.x
  *

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -319,7 +319,7 @@ class DistributorPost {
 	 *
 	 * @return bool Whether the post has blocks.
 	 */
-	public function has_blocks() {
+	protected function has_blocks() {
 		return has_blocks( $this->post->post_content );
 	}
 
@@ -335,7 +335,7 @@ class DistributorPost {
 	 * @param string $block_name Full block type to look for.
 	 * @return bool Whether the post content contains the specified block.
 	 */
-	public function has_block( $block_name ) {
+	protected function has_block( $block_name ) {
 		return has_block( $block_name, $this->post->post_content );
 	}
 
@@ -344,7 +344,7 @@ class DistributorPost {
 	 *
 	 * @return int Post ID.
 	 */
-	public function get_the_id() {
+	protected function get_the_id() {
 		return $this->post->ID;
 	}
 
@@ -353,7 +353,7 @@ class DistributorPost {
 	 *
 	 * @return string Post permalink.
 	 */
-	public function get_permalink() {
+	protected function get_permalink() {
 		return get_permalink( $this->post );
 	}
 
@@ -362,7 +362,7 @@ class DistributorPost {
 	 *
 	 * @return string Post type.
 	 */
-	public function get_post_type() {
+	protected function get_post_type() {
 		return get_post_type( $this->post );
 	}
 
@@ -371,7 +371,7 @@ class DistributorPost {
 	 *
 	 * @return int|false Post thumbnail ID or false if no thumbnail is set.
 	 */
-	public function get_post_thumbnail_id() {
+	protected function get_post_thumbnail_id() {
 		return get_post_thumbnail_id( $this->post );
 	}
 
@@ -381,7 +381,7 @@ class DistributorPost {
 	 * @param string $size Thumbnail size. Defaults to 'post-thumbnail'.
 	 * @return string|false The post's thumbnail URL or false if no thumbnail is set.
 	 */
-	public function get_post_thumbnail_url( $size = 'post-thumbnail' ) {
+	protected function get_post_thumbnail_url( $size = 'post-thumbnail' ) {
 		return get_the_post_thumbnail_url( $this->post, $size );
 	}
 
@@ -392,7 +392,7 @@ class DistributorPost {
 	 * @param array  $attr Optional. Attributes for the image markup. Default empty.
 	 * @return string|false The post's thumbnail HTML or false if no thumbnail is set.
 	 */
-	public function get_the_post_thumbnail( $size = 'post-thumbnail', $attr = '' ) {
+	protected function get_the_post_thumbnail( $size = 'post-thumbnail', $attr = '' ) {
 		return get_the_post_thumbnail( $this->post, $size, $attr );
 	}
 
@@ -407,7 +407,7 @@ class DistributorPost {
 	 *                               original source URL.
 	 * @return string The post's canonical URL.
 	 */
-	public function get_canonical_url( $canonical_url = '' ) {
+	protected function get_canonical_url( $canonical_url = '' ) {
 		if (
 			$this->is_source
 			|| $this->original_deleted
@@ -434,7 +434,7 @@ class DistributorPost {
 	 *                             author name does not need to be replaced by the original source name.
 	 * @return string The post's author name.
 	 */
-	public function get_author_name( $author_name = '' ) {
+	protected function get_author_name( $author_name = '' ) {
 		$settings = Utils\get_settings();
 
 		if (
@@ -465,7 +465,7 @@ class DistributorPost {
 	 *                             author link does not need to be replaced by the original source name.
 	 * @return string The post's author link.
 	 */
-	public function get_author_link( $author_link = '' ) {
+	protected function get_author_link( $author_link = '' ) {
 		$settings = Utils\get_settings();
 
 		if (
@@ -491,7 +491,7 @@ class DistributorPost {
 	 *
 	 * @return array Array of meta data.
 	 */
-	public function get_meta() {
+	protected function get_meta() {
 		return Utils\prepare_meta( $this->post->ID );
 	}
 
@@ -502,7 +502,7 @@ class DistributorPost {
 	 *    @type WP_Term[] Post terms keyed by taxonomy.
 	 * }
 	 */
-	public function get_terms() {
+	protected function get_terms() {
 		return Utils\prepare_taxonomy_terms( $this->post->ID );
 	}
 
@@ -511,7 +511,7 @@ class DistributorPost {
 	 *
 	 * @return array
 	 */
-	public function get_media() {
+	protected function get_media() {
 		$post_id = $this->post->ID;
 		if ( $this->has_blocks() ) {
 			$raw_media = $this->parse_media_blocks();
@@ -551,7 +551,7 @@ class DistributorPost {
 	 *
 	 * @return WP_Post[] Array of media posts.
 	 */
-	public function parse_media_blocks() {
+	protected function parse_media_blocks() {
 		$found = false;
 
 		// Note: changes to the cache key or group should be reflected in `includes/settings.php`
@@ -595,7 +595,7 @@ class DistributorPost {
 	 * @param array $block Block to parse.
 	 * @return int[] Array of media attachment IDs.
 	 */
-	private function parse_blocks_for_attachment_id( $block ) {
+	protected function parse_blocks_for_attachment_id( $block ) {
 		$media_blocks = array(
 			'core/image' => 'id',
 			'core/audio' => 'id',
@@ -654,7 +654,7 @@ class DistributorPost {
 	 *    @type array  $distributor_meta  Post meta.
 	 * }
 	 */
-	public function post_data() {
+	protected function post_data() {
 		return [
 			'title'             => html_entity_decode( get_the_title( $this->post->ID ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
 			'slug'              => $this->post->post_name,
@@ -687,7 +687,7 @@ class DistributorPost {
 	 *    @type array  $distributor_media Media data.
 	 * }
 	 */
-	public function to_insert() {
+	protected function to_insert() {
 		$insert       = [];
 		$post_data    = $this->post_data();
 		$key_mappings = [
@@ -717,7 +717,7 @@ class DistributorPost {
 	 * @param int $depth   Optional. Maximum depth to walk through $data. Default 512.
 	 * @return string JSON encoded post data.
 	 */
-	public function to_json( $options = 0, $depth = 512 ) {
+	protected function to_json( $options = 0, $depth = 512 ) {
 		$post_data = $this->post_data();
 
 		/*

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -217,6 +217,42 @@ class DistributorPost {
 	}
 
 	/**
+	 * Magic getter method.
+	 *
+	 * This method is used to get the value of the `source_site` property and
+	 * populate it if needs be. For internal connections the post permalink is
+	 * updated with live data.
+	 *
+	 * @param string $name Property name.
+	 * @return mixed
+	 */
+	public function __get( $name ) {
+		if ( in_array( $name, array( 'source_site', 'original_post_url' ), true ) ) {
+			$this->populate_source_site();
+		}
+
+		return $this->$name;
+	}
+
+	/**
+	 * Magic isset method.
+	 *
+	 * This method is used to check if the `source_site` property is set and
+	 * populate it if needs be.
+	 *
+	 * @param string $name Property name.
+	 * @return bool
+	 */
+	public function __isset( $name ) {
+		if ( 'source_site' === $name && empty( $this->source_site ) ) {
+			$this->populate_source_site();
+			return ! empty( $this->source_site );
+		}
+
+		return isset( $this->$name );
+	}
+
+	/**
 	 * Populate the source site data for internal connections.
 	 *
 	 * This populates data from the source site used by internal connections.
@@ -268,42 +304,6 @@ class DistributorPost {
 		if ( $switch_to_site ) {
 			restore_current_blog();
 		}
-	}
-
-	/**
-	 * Magic getter method.
-	 *
-	 * This method is used to get the value of the `source_site` property and
-	 * populate it if needs be. For internal connections the post permalink is
-	 * updated with live data.
-	 *
-	 * @param string $name Property name.
-	 * @return mixed
-	 */
-	public function __get( $name ) {
-		if ( in_array( $name, array( 'source_site', 'original_post_url' ), true ) ) {
-			$this->populate_source_site();
-		}
-
-		return $this->$name;
-	}
-
-	/**
-	 * Magic isset method.
-	 *
-	 * This method is used to check if the `source_site` property is set and
-	 * populate it if needs be.
-	 *
-	 * @param string $name Property name.
-	 * @return bool
-	 */
-	public function __isset( $name ) {
-		if ( 'source_site' === $name && empty( $this->source_site ) ) {
-			$this->populate_source_site();
-			return ! empty( $this->source_site );
-		}
-
-		return isset( $this->$name );
 	}
 
 	/**

--- a/tests/php/DistributorPostTest.php
+++ b/tests/php/DistributorPostTest.php
@@ -34,6 +34,13 @@ class DistributorPostTest extends TestCase {
 			]
 		);
 
+		\WP_Mock::userFunction(
+			'get_current_blog_id',
+			[
+				'return' => 1,
+			]
+		);
+
 		// Return voids.
 		\WP_Mock::userFunction( '_prime_post_caches' );
 		\WP_Mock::userFunction( 'update_object_term_cache' );

--- a/tests/php/DistributorPostTest.php
+++ b/tests/php/DistributorPostTest.php
@@ -115,6 +115,29 @@ class DistributorPostTest extends TestCase {
 	}
 
 	/**
+	 * Test the DistributorPost object for public methods.
+	 *
+	 * Only magic methods are expected to be public as the class uses the
+	 * __call() method to handle all other methods.
+	 *
+	 * @covers ::__construct
+	 * @runInSeparateProcess
+	 */
+	public function test_public_methods() {
+		$actual_methods = get_class_methods( 'Distributor\DistributorPost' );
+		$expected_methods = array(
+			'__construct',
+			'__call',
+			'__get',
+			'__isset',
+		);
+
+		sort( $actual_methods );
+		sort( $expected_methods );
+		$this->assertSame( $expected_methods, $actual_methods, 'Only magic methods are expected to be public.' );
+	}
+
+	/**
 	 * Test the DistributorPost object for internal connections.
 	 *
 	 * @covers ::__construct

--- a/tests/php/HooksTest.php
+++ b/tests/php/HooksTest.php
@@ -17,6 +17,12 @@ class HooksTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		\WP_Mock::userFunction(
+			'get_current_blog_id',
+			[
+				'return' => 1,
+			]
+		);
 
 		// Return voids.
 		\WP_Mock::userFunction( '_prime_post_caches' );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This resolves an issue in which the post abstraction can return a mix of data on Multisite networks when the site is switched.

It introduces the `DistributorPost::__call()` magic method to ensure the current site (`get_current_blog_id()`) matches the site ID used to instantiate the object.

To match the PHP behavior without the magic method, a fatal error is thrown if the method name does not exist.

To discourage developers from calling the helper methods while using a switched site, a notice is thrown if the magic method needs to switch sites.

To avoid site switching when possible, an in memory cache is used to bypass the site switch the second or subsequent time a method is called. The cached data is only used if the object is called from the wrong site to reduce the risk of errors caused by the addition/removal of hooks during runtime. Basically it's a performance compromise.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1007.
Supersedes #1004.

### TODO

* [x] Test interaction of magic methods: ensure `$dt_post->source_site` doesn't result in multiple switches

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Inconsistent data returned from post abstraction after site switch on multisite.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @dkotter  

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
