### PR TITLE
Avoid deprecation notice on PHP 8.1 due to converting `false` to `array`

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -832,12 +832,13 @@ class NetworkSiteConnection extends Connection {
 		$authorized_sites = get_transient( $cache_key );
 
 		if ( $force || false === $authorized_sites ) {
-			$sites           = get_sites(
+			$authorized_sites = ! is_array( $authorized_sites ) ? array() : $authorized_sites;
+			$sites            = get_sites(
 				array(
 					'number' => 1000,
 				)
 			);
-			$current_blog_id = (int) get_current_blog_id();
+			$current_blog_id  = (int) get_current_blog_id();
 
 			foreach ( $sites as $site ) {
 				$blog_id = (int) $site->blog_id;

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -832,7 +832,7 @@ class NetworkSiteConnection extends Connection {
 		$authorized_sites = get_transient( $cache_key );
 
 		if ( $force || false === $authorized_sites ) {
-			$authorized_sites = ! is_array( $authorized_sites ) ? array() : $authorized_sites;
+			$authorized_sites = array();
 			$sites            = get_sites(
 				array(
 					'number' => 1000,


### PR DESCRIPTION
### Description of the Change

In testing something else on Distributor, I was going PHP deprecation notices showing up on the internal Pull Content screen. This notice said: `PHP Deprecated: Automatic conversion of false to array is deprecated`. Looking at the code, we have a place where a value may be `false` and then later we use that as an `array` but we don't ever set that as an `array` first.

This PR fixes that by adding a check to convert that variable to an `array` if it isn't already.

### How to test the Change

In an environment running PHP 8.1, go to the internal Pull screen and notice a PHP deprecation notice.

Check out the code in this PR and note the notice should no longer be there.

Ensure all connections show up properly in the Pull dropdown, that you can switch between connections successfully, and that you can pull in content.

### Changelog Entry

> Fixed - Handle a PHP deprecation notice around converting `false` to `array`

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
