### PR TITLE
Use `is_using_gutenberg()` wrapper for `use_block_editor_for_post()`.

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -8,6 +8,7 @@
 namespace Distributor\PushUI;
 
 use Distributor\EnqueueScript;
+use Distributor\Utils;
 
 /**
  * Setup actions and filters
@@ -86,7 +87,7 @@ function syndicatable() {
 	}
 
 	// If we're using the classic editor, we need to make sure the post has a distributable status.
-	if ( ! use_block_editor_for_post( $post ) && ! in_array( $post->post_status, \Distributor\Utils\distributable_post_statuses(), true ) ) {
+	if ( ! Utils\is_using_gutenberg( $post ) && ! in_array( $post->post_status, Utils\distributable_post_statuses(), true ) ) {
 		return false;
 	}
 

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -42,7 +42,7 @@ function syndicatable() {
 	// Retrieve the current global post, bail if not set.
 	$post = get_post();
 	if ( empty( $post ) ) {
-		return;
+		return false;
 	}
 
 	/**

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -39,6 +39,12 @@ function setup() {
  * @return  bool
  */
 function syndicatable() {
+	// Retrieve the current global post, bail if not set.
+	$post = get_post();
+	if ( empty( $post ) ) {
+		return;
+	}
+
 	/**
 	 * Filter Distributor capabilities allowed to syndicate content.
 	 *
@@ -78,12 +84,6 @@ function syndicatable() {
 		if ( ! is_singular( $distributable_post_types ) ) {
 			return false;
 		}
-	}
-
-	$post = get_post();
-
-	if ( empty( $post ) ) {
-		return;
 	}
 
 	// If we're using the classic editor, we need to make sure the post has a distributable status.


### PR DESCRIPTION
This ensure against fatal errors in versions of WordPress prior to version 6.1.0. The function is only available within wp-admin in these version of WordPress.

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Use `is_using_gutenberg()` in place of `use_block_editor_for_post()` to avoid fatal errors in older versions of WordPress.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1055 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install a version of WordPress between 5.7 and 6.0
2. Activate Distributor
3. Write a post in the block editor
4. Attempt to save the post
5. On this branch the post ought to save, on `develop` the post will not save.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal error in WordPress versions 6.0 and earlier.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @ravinderk  


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
