### PR TITLE
Add snippet for setting meta data automatically.

### DIFF
--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -88,3 +88,28 @@ add_filter( 'dt_push_post_args', function( $post_body, $post ) {
     return $post_body;
 }, 10, 2 );
 ```
+
+### Set custom meta data on distributed content.
+
+Site owners may wish to modify the meta data on distributed content upon pushing or pulling.
+
+To set an item of meta data you can use the `dt_after_set_meta` hook.
+
+```php
+/**
+ * Automatically store custom meta data on distributed posts.
+ */
+add_action( 'dt_after_set_meta', function( $meta, $existing_meta, $post_id ) {
+	update_post_meta( $post_id, 'myplugin_custom_meta', 'some_value', true );
+}, 10, 3 );
+
+/**
+ * Automatically unlink a post once it is distributed.
+ *
+ * This prevents updates to the original content from modifying the copies
+ * distributed on other sites.
+ */
+add_action( 'dt_after_set_meta', function( $meta, $existing_meta, $post_id ) {
+	update_post_meta( $post_id, 'dt_unlinked', '1', true );
+}, 10, 3 );
+```

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -428,7 +428,7 @@ class WordPressExternalConnection extends ExternalConnection {
 				update_post_meta( $new_post, 'dt_full_connection', true );
 			}
 
-			if ( ! empty( $post_array['meta'] ) ) {
+			if ( isset( $post_array['meta'] ) && is_array( $post_array['meta'] ) ) {
 				// Filter documented in includes/classes/InternalConnections/NetworkSiteConnection.php.
 				if ( apply_filters( 'dt_pull_post_meta', true, $new_post, $post_array['meta'], $item_array['remote_post_id'], $post_array, $this ) ) {
 					\Distributor\Utils\set_meta( $new_post, $post_array['meta'] );

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -268,6 +268,15 @@ class WordPressExternalConnectionTest extends TestCase {
 		\WP_Mock::userFunction( 'delete_post_meta' );
 
 		\WP_Mock::userFunction(
+			'apply_filters_deprecated',
+			[
+				'return' => function( $name, $args ) {
+					return $args[0];
+				},
+			]
+		);
+
+		\WP_Mock::userFunction(
 			'wp_remote_retrieve_headers', [
 				'return' => [
 					'X-Distributor' => 'yes',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Provides snippet for setting both Distributor and custom meta data using the `dt_after_set_meta` hook.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #971

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Snippets for setting meta data automatically.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @iamdharmesh. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
