### PR TITLE
Prevent infinite loops in meta data hooks.

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -501,12 +501,12 @@ class DistributorPost {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param  string $canonical_url The post's canonical URL. If specified, this will be returned
-	 *                               if the canonical URL does not need to be replaced by the
-	 *                               original source URL.
+	 * @param  string|null $canonical_url The post's canonical URL. If specified, this will be returned
+	 *                                    if the canonical URL does not need to be replaced by the
+	 *                                    original source URL.
 	 * @return string The post's canonical URL.
 	 */
-	protected function get_canonical_url( $canonical_url = '' ) {
+	protected function get_canonical_url( $canonical_url = null ) {
 		if (
 			$this->is_source
 			|| $this->original_deleted
@@ -514,7 +514,7 @@ class DistributorPost {
 			|| ! $this->connection_id
 			|| ! $this->original_post_url
 		) {
-			if ( empty( $canonical_url ) ) {
+			if ( null === $canonical_url ) {
 				return $this->get_permalink();
 			}
 			return $canonical_url;
@@ -531,11 +531,11 @@ class DistributorPost {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param  string $author_name The post's author name. If specified, this will be returned if the
-	 *                             author name does not need to be replaced by the original source name.
+	 * @param  string|null $author_name The post's author name. If specified, this will be returned if the
+	 *                                  author name does not need to be replaced by the original source name.
 	 * @return string The post's author name.
 	 */
-	protected function get_author_name( $author_name = '' ) {
+	protected function get_author_name( $author_name = null ) {
 		$settings = Utils\get_settings();
 
 		if (
@@ -546,7 +546,7 @@ class DistributorPost {
 			|| ! $this->connection_id
 			|| ! $this->original_post_url
 		) {
-			if ( empty( $author_name ) ) {
+			if ( null === $author_name ) {
 				return get_the_author_meta( 'display_name', $this->post->post_author );
 			}
 			return $author_name;
@@ -564,11 +564,11 @@ class DistributorPost {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param  string $author_link The author's posts URL. If specified, this will be returned if the
-	 *                             author link does not need to be replaced by the original source name.
+	 * @param  string|null $author_link The author's posts URL. If specified, this will be returned if the
+	 *                                  author link does not need to be replaced by the original source name.
 	 * @return string The post's author link.
 	 */
-	protected function get_author_link( $author_link = '' ) {
+	protected function get_author_link( $author_link = null ) {
 		$settings = Utils\get_settings();
 
 		if (
@@ -579,7 +579,7 @@ class DistributorPost {
 			|| ! $this->connection_id
 			|| ! $this->original_post_url
 		) {
-			if ( empty( $author_link ) ) {
+			if ( null === $author_link ) {
 				return get_author_posts_url( $this->post->post_author );
 			}
 			return $author_link;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Fixes an edge case causing an infinite loop on posts without an author or for authors with an empty display name.

The check for getting the default author is now using `null` to indicate the default value should be returned via the built in core functions. The previous loose check using `empty()` was causing the loop. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1064

As this bug relies on `get_the_author_meta()` etc calling the `get_the_author_display_name` hook (and similar for the other methods), I'm unable to add some tests as WP_Mock doesn't fire the hooks.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Generate some empty posts without an author specified via wp-cli: `wp post generate --count=10 --post_title=NoAuthor`
2. Pull or push the post to a second site.
3. On the second site visit Dashboard > Distributor > Settings and turn off (uncheck) "Override Author Byline"
4. Visit the post list in the dashboard of the second site.
5. On this branch it should load successfully, on `develop` it should go in to an infinite loop.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
N/A -- covered by DistributorPost and hook PRs


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @ravinderk 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
