### PR TITLE
Update Push UI messaging when origin post has ben deleted.

### DIFF
--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -566,9 +566,10 @@ function menu_content() {
 		return;
 	}
 
-	$unlinked         = (bool) get_post_meta( $post->ID, 'dt_unlinked', true );
-	$original_blog_id = get_post_meta( $post->ID, 'dt_original_blog_id', true );
-	$original_post_id = get_post_meta( $post->ID, 'dt_original_post_id', true );
+	$unlinked              = (bool) get_post_meta( $post->ID, 'dt_unlinked', true );
+	$original_blog_id      = get_post_meta( $post->ID, 'dt_original_blog_id', true );
+	$original_post_id      = get_post_meta( $post->ID, 'dt_original_post_id', true );
+	$original_post_deleted = get_post_meta( $post->ID, 'dt_original_post_deleted', true );
 
 	if ( ! empty( $original_blog_id ) && ! empty( $original_post_id ) && ! $unlinked && is_multisite() ) {
 		switch_to_blog( $original_blog_id );
@@ -593,7 +594,14 @@ function menu_content() {
 						'<a href="' . esc_url( $site_url ) . '">' . esc_html( $blog_name ) . '</a>'
 					);
 
-					if ( ! empty( $post_url ) ) {
+					if ( $original_post_deleted ) {
+						echo ' '; // Ensure whitespace between sentences.
+						printf(
+							/* translators: 1: post type name */
+							esc_html__( 'However, the origin %1$s has been deleted.', 'distributor' ),
+							esc_html( strtolower( $post_type_object->labels->singular_name ) )
+						);
+					} elseif ( ! empty( $post_url ) ) {
 						?>
 						<a href="<?php echo esc_url( $post_url ); ?>" target="_blank">
 							<?php


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Updates the Push UI messaging when the origin post has been deleted. This changes to text to use the same message as in the block editor interface.

Per the current behaivour, the message in the push UI only changes on multisite (ie, internal connections). 

<img width="930" alt="Screen Shot 2023-06-01 at 3 05 52 pm" src="https://github.com/10up/distributor/assets/519727/8e07e158-c9d2-44ac-82a8-e76ddc07247a">

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1021

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Install and network activate Distrubtor on a multisite instance of WordPress
2. Create at least one sub-site
3. On the main site create and publish a post
4. Push the post to the sub-site (publish, don't push as a draft).
5. Trash the post
6. Open the dashboard of the sub-site 
7. Edit the distributed post on the sub-site
8. On this branch, the message should appear as in the screen shot above
9. One the `develop` branch, the message will invite you to "View original" which links to a 404 error

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Indicate if the origin post has been deleted in Distributor push interface.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @cadic, @jeffpaul, @faisal-alvi. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
