### PR TITLE
fixed: install composer when lint phpcs workflow in github

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,7 +70,6 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: composer install
 
       - name: Test all files


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

I found that phpcs linting is failing because phpcs composer package is missing. Composer packages installs only if any PHP file changes in the branch. I fix this issue in a pull request.

Ref: https://github.com/10up/distributor/actions/runs/5374342837/jobs/9749600369

Regression cause by: https://github.com/10up/distributor/pull/1075

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed: install composer when lint phpcs workflow in github


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ravinderk 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
