### PR TITLE
Store and update post status in `dt` object.

### DIFF
--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -187,7 +187,6 @@ const DistributorPlugin = () => {
 	const post = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPost()
 	);
-	console.log( post );
 	// Make the post title available to the top menu.
 	dt.postTitle = post.title;
 	// Make the post status available to the top menu.

--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -187,8 +187,11 @@ const DistributorPlugin = () => {
 	const post = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPost()
 	);
+	console.log( post );
 	// Make the post title available to the top menu.
 	dt.postTitle = post.title;
+	// Make the post status available to the top menu.
+	dt.postStatus = post.status;
 
 	// If we are on a non-supported post status, change what we show
 	if (

--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -187,9 +187,8 @@ const DistributorPlugin = () => {
 	const post = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPost()
 	);
-	// Make the post title available to the top menu.
+	// Make the post title and status available to the top menu.
 	dt.postTitle = post.title;
-	// Make the post status available to the top menu.
 	dt.postStatus = post.status;
 
 	// If we are on a non-supported post status, change what we show

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -399,7 +399,6 @@ jQuery( window ).on( 'load', () => {
 							foundConnections: mustacheData.connections.length,
 							showSearch: 5 < mustacheData.connections.length,
 							postTitle: dt.postTitle,
-							postStatus: dt.postStatus,
 						}
 					);
 
@@ -408,7 +407,6 @@ jQuery( window ).on( 'load', () => {
 					distributorPushWrapper.innerHTML = template( {
 						connections: dtConnections,
 						postTitle: dt.postTitle,
-						postStatus: dt.postStatus,
 					} );
 				}
 

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -50,7 +50,6 @@ jQuery( window ).on( 'load', () => {
 	let selectAllConnections = '';
 	let selectNoConnections = '';
 	let connectionsSearchInput = '';
-	let postStatusInput = '';
 	let asDraftInput = '';
 	let errorDetails = '';
 
@@ -91,7 +90,6 @@ jQuery( window ).on( 'load', () => {
 		connectionsSearchInput = document.getElementById(
 			'dt-connection-search'
 		);
-		postStatusInput = document.getElementById( 'dt-post-status' );
 		asDraftInput = document.getElementById( 'dt-as-draft' );
 		errorDetails = document.querySelector( '.dt-error ul.details' );
 

--- a/assets/js/push.js
+++ b/assets/js/push.js
@@ -401,6 +401,7 @@ jQuery( window ).on( 'load', () => {
 							foundConnections: mustacheData.connections.length,
 							showSearch: 5 < mustacheData.connections.length,
 							postTitle: dt.postTitle,
+							postStatus: dt.postStatus,
 						}
 					);
 
@@ -409,6 +410,7 @@ jQuery( window ).on( 'load', () => {
 					distributorPushWrapper.innerHTML = template( {
 						connections: dtConnections,
 						postTitle: dt.postTitle,
+						postStatus: dt.postStatus,
 					} );
 				}
 
@@ -516,7 +518,7 @@ jQuery( window ).on( 'load', () => {
 		data.postStatus =
 			null !== asDraftInput && asDraftInput.checked
 				? 'draft'
-				: postStatusInput.value;
+				: dt.postStatus;
 
 		const xhr = dt.usexhr ? { withCredentials: true } : false;
 

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -414,6 +414,7 @@ function enqueue_scripts( $hook ) {
 		'loadConnectionsNonce' => wp_create_nonce( 'dt-load-connections' ),
 		'postId'               => (int) get_the_ID(),
 		'postTitle'            => get_the_title(),
+		'postStatus'           => get_post_status(),
 		'ajaxurl'              => esc_url( admin_url( 'admin-ajax.php' ) ),
 
 		/**

--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -55,7 +55,6 @@
 			<div class="selected-connections-list"></div>
 
 			<div class="action-wrapper">
-				<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
 				<?php
 				$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
 				/**

--- a/templates/show-connections.php
+++ b/templates/show-connections.php
@@ -53,7 +53,6 @@
 			<div class="selected-connections-list"></div>
 
 			<div class="action-wrapper">
-				<input type="hidden" id="dt-post-status" value="<?php echo esc_attr( $post->post_status ); ?>">
 				<?php
 				$as_draft = ( 'draft' !== $post->post_status ) ? true : false;
 				/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Fixes a bug introduced during the 2.0.0 release cycle in which unchecking the send as draft checkbox would cause an error for posts that had changed status while the editor was open.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Fixes #141 
Follow up to #1022 

> **Note**
>
> The custom Cypress `distributorPushPost` command automatically reloads to page before attempting to distribute (this allows us to distribute a post ID from anywhere). I tried to use `cy.url()` to only refresh pages when needed but without success.
>
> Any assistance here would be most helpful.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Create and publish a new post
2. The Distributor menu will appear
3. Hover over the menu, select a destination to push to
4. Uncheck the "Send as draft" checkbox
5. Click "Distribute"

On this branch the post should successfully distribute. On develop the post will:
* show an error for external connections
* apparently succeed for network connections but if you visit the site's admin the post will not appear.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Just add this PR to the existing entry `Toggles the Distributor admin bar element in Gutenberg based on the post status`


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
