### PR TITLE
Fix failing E2E tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -101,7 +101,7 @@ jobs:
       run: npm run copy-htaccess
 
     - name: Test
-      run: npm run cypress:run --config-file tests/cypress/config.js
+      run: npm run cypress:run
 
     - name: Update summary
       if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
 				"mustache": "^4.2.0"
 			},
 			"devDependencies": {
-				"@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-				"@wordpress/env": "^5.0.0",
+				"@10up/cypress-wp-utils": "^0.2.0",
+				"@wordpress/env": "^5.16.0",
 				"@wordpress/scripts": "^26.6.0",
 				"compare-versions": "^4.1.3",
-				"cypress": "^10.8.0",
+				"cypress": "^13.1.0",
 				"cypress-mochawesome-reporter": "^3.5.1",
 				"eslint-plugin-cypress": "^2.12.1",
 				"jsdoc": "^3.6.11",
@@ -28,10 +28,10 @@
 			}
 		},
 		"node_modules/@10up/cypress-wp-utils": {
-			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/10up/cypress-wp-utils.git#52d9387f9e70530abfec1d2b4549a8a9225b0817",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+			"integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
 			}
@@ -2031,9 +2031,9 @@
 			}
 		},
 		"node_modules/@cypress/request": {
-			"version": "2.88.10",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
-			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+			"integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
 			"dev": true,
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
@@ -2049,9 +2049,9 @@
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
+				"qs": "~6.10.3",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
+				"tough-cookie": "^4.1.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^8.3.2"
 			},
@@ -4256,9 +4256,9 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.2.0.tgz",
-			"integrity": "sha512-FxsHCtP2+oKnWbv/GgN3hdjkKTdxS+edA0s807/Zbu30NKSJv3e4aemoxbb0GmqgGEBzbRMcgZ7IdVnWREGNeQ==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
+			"integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
@@ -5062,9 +5062,9 @@
 			}
 		},
 		"node_modules/aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
 			"dev": true
 		},
 		"node_modules/axe-core": {
@@ -6785,15 +6785,15 @@
 			}
 		},
 		"node_modules/cypress": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-10.8.0.tgz",
-			"integrity": "sha512-QVse0dnLm018hgti2enKMVZR9qbIO488YGX06nH5j3Dg1isL38DwrBtyrax02CANU6y8F4EJUuyW6HJKw1jsFA==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+			"integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@cypress/request": "^2.88.10",
+				"@cypress/request": "^3.0.0",
 				"@cypress/xvfb": "^1.2.4",
-				"@types/node": "^14.14.31",
+				"@types/node": "^16.18.39",
 				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
@@ -6805,10 +6805,10 @@
 				"check-more-types": "^2.24.0",
 				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.1",
-				"commander": "^5.1.0",
+				"commander": "^6.2.1",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"enquirer": "^2.3.6",
 				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
@@ -6823,12 +6823,13 @@
 				"listr2": "^3.8.3",
 				"lodash": "^4.17.21",
 				"log-symbols": "^4.0.0",
-				"minimist": "^1.2.6",
+				"minimist": "^1.2.8",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"process": "^0.11.10",
 				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
-				"semver": "^7.3.2",
+				"semver": "^7.5.3",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
 				"untildify": "^4.0.0",
@@ -6838,7 +6839,7 @@
 				"cypress": "bin/cypress"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^16.0.0 || ^18.0.0 || >=20.0.0"
 			}
 		},
 		"node_modules/cypress-mochawesome-reporter": {
@@ -6877,10 +6878,19 @@
 			}
 		},
 		"node_modules/cypress/node_modules/@types/node": {
-			"version": "14.18.29",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-			"integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
+			"version": "16.18.48",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
+			"integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
 			"dev": true
+		},
+		"node_modules/cypress/node_modules/commander": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/cypress/node_modules/extract-zip": {
 			"version": "2.0.1",
@@ -6915,9 +6925,9 @@
 			}
 		},
 		"node_modules/cypress/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -11703,30 +11713,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/jsdom/node_modules/tough-cookie": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-			"dev": true,
-			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/jsdom/node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -14970,6 +14956,15 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -15161,12 +15156,18 @@
 			]
 		},
 		"node_modules/qs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+			"integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
 			"dev": true,
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
 			"engines": {
 				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/querystringify": {
@@ -17408,16 +17409,27 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
 			"dev": true,
 			"dependencies": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
 			},
 			"engines": {
-				"node": ">=0.8"
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/tr46": {
@@ -18838,9 +18850,10 @@
 	},
 	"dependencies": {
 		"@10up/cypress-wp-utils": {
-			"version": "git+ssh://git@github.com/10up/cypress-wp-utils.git#52d9387f9e70530abfec1d2b4549a8a9225b0817",
-			"dev": true,
-			"from": "@10up/cypress-wp-utils@github:10up/cypress-wp-utils#build"
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+			"integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
+			"dev": true
 		},
 		"@ampproject/remapping": {
 			"version": "2.2.1",
@@ -20220,9 +20233,9 @@
 			"requires": {}
 		},
 		"@cypress/request": {
-			"version": "2.88.10",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
-			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+			"integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -20238,9 +20251,9 @@
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
+				"qs": "~6.10.3",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
+				"tough-cookie": "^4.1.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^8.3.2"
 			}
@@ -21978,9 +21991,9 @@
 			}
 		},
 		"@wordpress/env": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.2.0.tgz",
-			"integrity": "sha512-FxsHCtP2+oKnWbv/GgN3hdjkKTdxS+edA0s807/Zbu30NKSJv3e4aemoxbb0GmqgGEBzbRMcgZ7IdVnWREGNeQ==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
+			"integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
@@ -22547,9 +22560,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
 			"dev": true
 		},
 		"axe-core": {
@@ -23849,14 +23862,14 @@
 			}
 		},
 		"cypress": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-10.8.0.tgz",
-			"integrity": "sha512-QVse0dnLm018hgti2enKMVZR9qbIO488YGX06nH5j3Dg1isL38DwrBtyrax02CANU6y8F4EJUuyW6HJKw1jsFA==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+			"integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
 			"dev": true,
 			"requires": {
-				"@cypress/request": "^2.88.10",
+				"@cypress/request": "^3.0.0",
 				"@cypress/xvfb": "^1.2.4",
-				"@types/node": "^14.14.31",
+				"@types/node": "^16.18.39",
 				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
@@ -23868,10 +23881,10 @@
 				"check-more-types": "^2.24.0",
 				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.1",
-				"commander": "^5.1.0",
+				"commander": "^6.2.1",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"enquirer": "^2.3.6",
 				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
@@ -23886,12 +23899,13 @@
 				"listr2": "^3.8.3",
 				"lodash": "^4.17.21",
 				"log-symbols": "^4.0.0",
-				"minimist": "^1.2.6",
+				"minimist": "^1.2.8",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"process": "^0.11.10",
 				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
-				"semver": "^7.3.2",
+				"semver": "^7.5.3",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
 				"untildify": "^4.0.0",
@@ -23899,9 +23913,15 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "14.18.29",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-					"integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
+					"version": "16.18.48",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
+					"integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
+					"dev": true
+				},
+				"commander": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 					"dev": true
 				},
 				"extract-zip": {
@@ -23926,9 +23946,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -27529,24 +27549,6 @@
 						"combined-stream": "^1.0.8",
 						"mime-types": "^2.1.12"
 					}
-				},
-				"tough-cookie": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-					"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-					"dev": true,
-					"requires": {
-						"psl": "^1.1.33",
-						"punycode": "^2.1.1",
-						"universalify": "^0.2.0",
-						"url-parse": "^1.5.3"
-					}
-				},
-				"universalify": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-					"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-					"dev": true
 				}
 			}
 		},
@@ -29952,6 +29954,12 @@
 				}
 			}
 		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -30099,10 +30107,13 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-			"dev": true
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+			"integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+			"dev": true,
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
 		},
 		"querystringify": {
 			"version": "2.2.0",
@@ -31849,13 +31860,23 @@
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+					"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+					"dev": true
+				}
 			}
 		},
 		"tr46": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
 		"mustache": "^4.2.0"
 	},
 	"devDependencies": {
-		"@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-		"@wordpress/env": "^5.0.0",
+		"@10up/cypress-wp-utils": "^0.2.0",
+		"@wordpress/env": "^5.16.0",
 		"@wordpress/scripts": "^26.6.0",
 		"compare-versions": "^4.1.3",
-		"cypress": "^10.8.0",
+		"cypress": "^13.1.0",
 		"cypress-mochawesome-reporter": "^3.5.1",
 		"eslint-plugin-cypress": "^2.12.1",
 		"jsdoc": "^3.6.11",
@@ -58,6 +58,7 @@
 		"env": "wp-env",
 		"env:start": "wp-env start",
 		"env:stop": "wp-env stop",
+		"env:destroy": "wp-env destroy",
 		"to-multisite": "wp-env run tests-cli \"wp core multisite-convert --title='Distributor Multisite'\"",
 		"copy-htaccess": "wp-env run tests-cli \"cp wp-content/plugins/distributor/tests/cypress/.htaccess .htaccess\"",
 		"postenv:start": "./tests/bin/initialize.sh"

--- a/tests/cypress/config.js
+++ b/tests/cypress/config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require( 'cypress' );
 const { readConfig } = require( '@wordpress/env/lib/config' );
 
 module.exports = defineConfig( {
+	chromeWebSecurity: false,
 	fixturesFolder: 'tests/cypress/fixtures',
 	screenshotsFolder: 'tests/cypress/screenshots',
 	videosFolder: 'tests/cypress/videos',

--- a/tests/cypress/e2e/distributed-post.test.js
+++ b/tests/cypress/e2e/distributed-post.test.js
@@ -23,10 +23,7 @@ describe( 'Distributed Post Tests', () => {
 			// Return the the post edit screen.
 			cy.visit( '/wp-admin/post.php?post=' + post.id + '&action=edit' );
 			// Ensure the settings panel is open.
-			cy.get( 'button[aria-label="Settings"]' ).then( ( $settings ) => {
-				if ( $settings.attr( 'aria-expanded' ) === 'false' ) {
-					$settings.trigger( 'click' );
-				}
+			cy.get( 'button[aria-label="Settings"]' ).then( () => {
 				cy.openDocumentSettingsSidebar( 'Post' );
 				cy.openDocumentSettingsPanel( 'Distributor' );
 				cy.get( '#distributed-to' ).should(

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -276,10 +276,13 @@ Cypress.Commands.add( 'createTweetOEmbedPost', ( tweetUrl ) => {
 		title: postTitle,
 		beforeSave: () => {
 			cy.insertBlock( 'core/embed/twitter', 'Twitter' ).then( ( id ) => {
-				cy.get( `#${ id } input[aria-label="Twitter URL"]` )
+				cy.getBlockEditor()
+					.find( `#${ id } input[aria-label="Twitter URL"]` )
 					.click()
 					.type( tweetUrl );
-				cy.get( `#${ id } button[type="submit"]` ).click();
+				cy.getBlockEditor()
+					.find( `#${ id } button[type="submit"]` )
+					.click();
 			} );
 		},
 	} ).then( ( post ) => {

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -18,9 +18,8 @@ import '@10up/cypress-wp-utils';
 // Import commands.js using ES2015 syntax:
 import './commands';
 
-// Preserve WP cookies.
 beforeEach( () => {
-	Cypress.Cookies.defaults( {
-		preserve: /^wordpress.*?/,
+	cy.session( 'login', cy.login, {
+		cacheAcrossSpecs: true,
 	} );
 } );


### PR DESCRIPTION
### Description of the Change

WordPress 6.3 changed how the Block Editor is loaded by default (loaded in an iframe now) and this causes issues with our E2E tests. This PR fixes those issues in the following ways:

1. Update to the latest version of the `@10up/cypress-wp-utils` package and use the new `getBlockEditor` helper command from that. This version contains multiples fixes for WP 6.3
2. Update to the newest version of the `@wordpress/env` package in the v5 release. Originally wanted to update this to the latest overall version but ran into some issues that will need some more time to explore
3. Update Cypress to v13
4. Set the `chromeWebSecurity` Cypress config to `false`, allowing Cypress to more easily interact with iframes

Closes #1125 

### How to test the Change

Ensure all E2E tests pass on this PR

### Changelog Entry

> Changed - Update from Cypress v10 to v13
> Fixed - Ensure our E2E tests pass on WordPress 6.3

### Credits

Props @dkotter, @iamdharmesh 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
