### PR TITLE
Ensure author ID is correctly set.

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -847,7 +847,7 @@ class DistributorPost {
 		}
 
 		// Additional data required for wp_insert_post().
-		$insert['post_author'] = isset( $this->post->post_author ) ? $this->post->post_author : get_current_user_id();
+		$insert['post_author'] = ! empty( $this->post->post_author ) ? $this->post->post_author : get_current_user_id();
 
 		// If the post has blocks, use the raw content.
 		if ( $this->has_blocks() ) {

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -381,6 +381,7 @@ class WordPressExternalConnection extends ExternalConnection {
 			unset( $post_array['post_date_gmt'] );
 			unset( $post_array['post_modified'] );
 			unset( $post_array['post_modified_gmt'] );
+			unset( $post_array['post_author'] );
 
 			if ( ! empty( $item_array['post_id'] ) ) {
 				$update           = true;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

In block themes an invalid author ID (such as zero) prevents the filter running on the author name due to some [code in the post author block](https://github.com/WordPress/gutenberg/blob/b8cd4c93e8d56e27575c3831a3f504a5a92e4d6a/packages/block-library/src/post-author/index.php#L23-L25).

This modifies the check for an invalid author ID when pulling/pushing posts to ensure that a valid ID is used.

When pulling from an external post, this removes the author ID of the remove user and records the post as authored by the user pulling the post. Author IDs almost certainly do not match across external connections so there is a risk the author is being assigned to a user that ought not be able to edit the post.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1129

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install Distributor on a network
2. Activate the 2023 theme if required
3. Create a sub-site
4. Use WPCLI to generate posts on the main site `wp post generate --count=10 ` -- this will generate posts with the author `0`
5. On the sub-site, uncheck "pull as draft" pull one of the generated posts 
6. Once the post has been pulled, click view for the post
7. The author block should correctly show the source site on the front end.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Invalid author IDs being set when pushing and pulling posts.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
