### PR TITLE
Limited external connection warning incorrect

### DIFF
--- a/assets/css/admin-external-connection.css
+++ b/assets/css/admin-external-connection.css
@@ -110,7 +110,6 @@
 }
 
 .endpoint-result[data-endpoint-state="error"]::before,
-.endpoint-result[data-endpoint-state="warning"]::before,
 .endpoint-result[data-endpoint-state="valid"]::before {
 	content: " ";
 	display: inline-block;
@@ -127,10 +126,6 @@
 
 .endpoint-result[data-endpoint-state="valid"]::before {
 	background-color: #62ff00;
-}
-
-.endpoint-result[data-endpoint-state="warning"]::before {
-	background-color: #ffe000;
 }
 
 .endpoint-result .dashicons-yes {

--- a/assets/css/admin-external-connections.css
+++ b/assets/css/admin-external-connections.css
@@ -20,7 +20,3 @@
 .connection-status.valid {
 	background-color: #62ff00;
 }
-
-.connection-status.warning {
-	background-color: #ffe000;
-}

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -348,6 +348,18 @@ function checkConnections() {
 						'polite'
 					);
 				}
+			} else if ( 'no' === response.data.is_authenticated ) {
+				endpointResult.setAttribute( 'data-endpoint-state', 'error' );
+
+				endpointResult.innerText = __(
+					'No connection found.',
+					'distributor'
+				);
+
+				speak(
+					__( 'No connection found.', 'distributor' ),
+					'polite'
+				);
 			} else if (
 				response.data.errors.no_distributor ||
 				! response.data.can_post.length
@@ -382,15 +394,6 @@ function checkConnections() {
 							'distributor'
 						) }`,
 						'polite'
-					);
-				}
-
-				if ( 'no' === response.data.is_authenticated ) {
-					warnings.push(
-						__(
-							'Authentication failed due to invalid credentials.',
-							'distributor'
-						)
 					);
 				}
 

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -380,51 +380,6 @@ function checkConnections() {
 						'polite'
 					);
 				}
-			} else if (
-				response.data.errors.no_distributor ||
-				! response.data.can_post.length
-			) {
-				endpointResult.setAttribute( 'data-endpoint-state', 'warning' );
-				endpointResult.innerText = __(
-					'Limited connection established.',
-					'distributor'
-				);
-
-				const warnings = [];
-
-				speak(
-					`${ __(
-						'Limited connection established.',
-						'distributor'
-					) }`,
-					'polite'
-				);
-
-				if ( 'yes' === response.data.is_authenticated ) {
-					warnings.push(
-						__(
-							'Authentication succeeded but your account does not have permissions to create posts on the external site.',
-							'distributor'
-						)
-					);
-				}
-
-				warnings.push(
-					__( 'Push distribution unavailable.', 'distributor' )
-				);
-				warnings.push(
-					__(
-						'Pull distribution limited to basic content, i.e. title and content body.',
-						'distributor'
-					)
-				);
-
-				warnings.forEach( ( warning ) => {
-					const warningNode = document.createElement( 'li' );
-					warningNode.innerText = warning;
-
-					endpointErrors.append( warningNode );
-				} );
 			} else {
 				endpointResult.setAttribute( 'data-endpoint-state', 'valid' );
 				endpointResult.innerText = __(

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -314,7 +314,11 @@ function checkConnections() {
 		.done( ( response ) => {
 			if ( ! response.success ) {
 				endpointResult.setAttribute( 'data-endpoint-state', 'error' );
-			} else if ( response.data.errors.no_external_connection ) {
+			} else if (
+				response.data.errors.no_external_connection ||
+				'no' === response.data.is_authenticated ||
+				response.data.errors.no_distributor
+			) {
 				endpointResult.setAttribute( 'data-endpoint-state', 'error' );
 
 				if ( response.data.endpoint_suggestion ) {
@@ -337,6 +341,18 @@ function checkConnections() {
 						}`,
 						'polite'
 					);
+				} else if ( response.data.errors.no_distributor ) {
+					endpointResult.innerText = __(
+						'Distributor not installed on remote site.',
+						'distributor'
+					);
+					speak(
+						__(
+							'Distributor not installed on remote site.',
+							'distributor'
+						),
+						'polite'
+					);
 				} else {
 					endpointResult.innerText = __(
 						'No connection found.',
@@ -348,18 +364,6 @@ function checkConnections() {
 						'polite'
 					);
 				}
-			} else if ( 'no' === response.data.is_authenticated ) {
-				endpointResult.setAttribute( 'data-endpoint-state', 'error' );
-
-				endpointResult.innerText = __(
-					'No connection found.',
-					'distributor'
-				);
-
-				speak(
-					__( 'No connection found.', 'distributor' ),
-					'polite'
-				);
 			} else if (
 				response.data.errors.no_distributor ||
 				! response.data.can_post.length
@@ -372,30 +376,13 @@ function checkConnections() {
 
 				const warnings = [];
 
-				if ( response.data.errors.no_distributor ) {
-					endpointResult.innerText += ` ${ __(
-						'Distributor not installed on remote site.',
+				speak(
+					`${ __(
+						'Limited connection established.',
 						'distributor'
-					) }`;
-					speak(
-						`${ __(
-							'Limited connection established.',
-							'distributor'
-						) } ${ __(
-							'Distributor not installed on remote site.',
-							'distributor'
-						) }`,
-						'polite'
-					);
-				} else {
-					speak(
-						`${ __(
-							'Limited connection established.',
-							'distributor'
-						) }`,
-						'polite'
-					);
-				}
+					) }`,
+					'polite'
+				);
 
 				if ( 'yes' === response.data.is_authenticated ) {
 					warnings.push(

--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -317,7 +317,8 @@ function checkConnections() {
 			} else if (
 				response.data.errors.no_external_connection ||
 				'no' === response.data.is_authenticated ||
-				response.data.errors.no_distributor
+				response.data.errors.no_distributor ||
+				! response.data.can_post.length
 			) {
 				endpointResult.setAttribute( 'data-endpoint-state', 'error' );
 
@@ -349,6 +350,21 @@ function checkConnections() {
 					speak(
 						__(
 							'Distributor not installed on remote site.',
+							'distributor'
+						),
+						'polite'
+					);
+				} else if (
+					'no' === response.data.is_authenticated ||
+					response.data.errors.no_types
+				) {
+					endpointResult.innerText = __(
+						'Authentication failed due to insufficient or invalid credentials.',
+						'distributor'
+					);
+					speak(
+						__(
+							'Authentication failed due to insufficient or invalid credentials.',
 							'distributor'
 						),
 						'polite'

--- a/includes/debug-info.php
+++ b/includes/debug-info.php
@@ -267,7 +267,7 @@ function get_external_connection_status( $external_connection_status ) {
 		}
 
 		if ( empty( $external_connection_status['can_post'] ) ) {
-			$status = __( 'warning', 'distributor' );
+			$status = __( 'error', 'distributor' );
 		}
 	}
 

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -78,7 +78,7 @@ function output_status_column( $column_name, $post_id ) {
 			}
 
 			if ( empty( $external_connection_status['can_post'] ) ) {
-				$status = 'warning';
+				$status = 'error';
 			}
 		}
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -600,8 +600,11 @@ function check_post_types_permissions() {
 	);
 
 	foreach ( $types as $type ) {
-		$caps                  = $type->cap;
-		$response['can_get'][] = $type->name;
+		$caps = $type->cap;
+
+		if ( current_user_can( $caps->edit_posts ) ) {
+			$response['can_post'][] = $type->name;
+		}
 
 		if ( current_user_can( $caps->edit_posts ) && current_user_can( $caps->create_posts ) && current_user_can( $caps->publish_posts ) ) {
 			$response['can_post'][] = $type->name;

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -603,7 +603,7 @@ function check_post_types_permissions() {
 		$caps = $type->cap;
 
 		if ( current_user_can( $caps->edit_posts ) ) {
-			$response['can_post'][] = $type->name;
+			$response['can_get'][] = $type->name;
 		}
 
 		if ( current_user_can( $caps->edit_posts ) && current_user_can( $caps->create_posts ) && current_user_can( $caps->publish_posts ) ) {

--- a/tests/cypress/e2e/external-connection.test.js
+++ b/tests/cypress/e2e/external-connection.test.js
@@ -96,7 +96,7 @@ describe( 'Admin can add a new external connection', () => {
 			.should( 'have.class', 'error' );
 	} );
 
-	it( 'Should display limited connection warning', () => {
+	it( 'Should display error when credentials are invalid', () => {
 		cy.visit( '/wp-admin/admin.php?page=distributor' );
 		cy.get( '.page-title-action' ).contains( 'Add New' ).click();
 
@@ -109,9 +109,9 @@ describe( 'Admin can add a new external connection', () => {
 		cy.get( '#dt_external_connection_url' ).type(
 			'http://localhost/second/wp-json'
 		);
-		cy.get( '.description.endpoint-result' ).should(
+		cy.get( '.endpoint-result' ).should(
 			'contain.text',
-			'Limited connection established.'
+			'No connection found'
 		);
 	} );
 } );

--- a/tests/cypress/e2e/external-connection.test.js
+++ b/tests/cypress/e2e/external-connection.test.js
@@ -111,7 +111,7 @@ describe( 'Admin can add a new external connection', () => {
 		);
 		cy.get( '.endpoint-result' ).should(
 			'contain.text',
-			'No connection found'
+			'Authentication failed due to insufficient or invalid credentials.'
 		);
 	} );
 } );

--- a/tests/cypress/e2e/external-connection.test.js
+++ b/tests/cypress/e2e/external-connection.test.js
@@ -57,27 +57,6 @@ describe( 'Admin can add a new external connection', () => {
 		cy.get( '#title' ).should( 'have.value', name );
 	} );
 
-	it( 'Should display warning status', () => {
-		cy.visit( '/wp-admin/admin.php?page=distributor' );
-		cy.get( '.page-title-action' ).contains( 'Add New' ).click();
-
-		const name = randomName();
-		cy.get( '#title' ).click().type( name );
-
-		cy.get( '.manual-setup-button' ).click();
-		cy.get( '#dt_external_connection_url' ).type(
-			'http://' + randomName()
-		);
-		cy.get( '#create-connection' ).click();
-
-		cy.visit( '/wp-admin/admin.php?page=distributor' );
-		cy.get( '.row-title' )
-			.contains( name )
-			.closest( '.hentry' )
-			.find( '.connection-status' )
-			.should( 'have.class', 'warning' );
-	} );
-
 	it( 'Should display error status', () => {
 		cy.visit( '/wp-admin/admin.php?page=distributor' );
 		cy.get( '.page-title-action' ).contains( 'Add New' ).click();


### PR DESCRIPTION
### Description of the Change
Closes #1071 

### How to test the Change

1. Go to the WP Dashboard > Distributor > External Connections > Add new
2. Click Manually Set Up Connection.
3. Enter an incorrect username and password combination
4. Enter a valid REST API endpoint in the URL field for a site that is running Distributor
5. Instead of the yellow warning, you should see a red error with a `Authentication failed due to insufficient or invalid credentials.` message instead
6. The push and pull permissions list will show no post types can be pushed or pulled
7. Save the connection
8. Visit Distributor > Pull Content
9. The new connection will not be listed as the site does not have any pullable content types
10. Publish a new post
11. Click "Distribute"
12. The new external connection will not be listed as the site does not have any pushable content types

### Changelog Entry

> Changed external connection status error messages when checking status

### Credits
Props @theskinnyghost 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
