### PR TITLE
Account for unpublished post statuses.

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -860,14 +860,16 @@ class DistributorPost {
 		if ( ! empty( $args['remote_post_id'] ) ) {
 			// Updating an existing post.
 			$insert['ID'] = (int) $args['remote_post_id'];
+			// Never update the post status when updating a post.
 			unset( $insert['post_status'] );
-		}
-
-		if ( ! empty( $args['post_status'] ) ) {
+		} elseif ( ! empty( $args['post_status'] ) ) {
 			$insert['post_status'] = $args['post_status'];
 		}
 
-		if ( 'future' === $insert['post_status'] ) {
+		if (
+			isset( $insert['post_status'] )
+			&& 'future' === $insert['post_status']
+		) {
 			// Set the post date to the future date.
 			$insert['post_date']     = $post_data['date'];
 			$insert['post_date_gmt'] = $post_data['date_gmt'];

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -782,6 +782,9 @@ class DistributorPost {
 			'excerpt'                        => $this->post->post_excerpt,
 			'parent'                         => ! empty( $this->post->post_parent ) ? (int) $this->post->post_parent : 0,
 			'status'                         => $this->post->post_status,
+			'date'                           => $this->post->post_date,
+			'date_gmt'                       => $this->post->post_date_gmt,
+
 			'distributor_media'              => $this->get_media(),
 			'distributor_terms'              => $this->get_terms(),
 			'distributor_meta'               => $this->get_meta(),
@@ -862,6 +865,12 @@ class DistributorPost {
 
 		if ( ! empty( $args['post_status'] ) ) {
 			$insert['post_status'] = $args['post_status'];
+		}
+
+		if ( 'future' === $insert['post_status'] ) {
+			// Set the post date to the future date.
+			$insert['post_date']     = $post_data['date'];
+			$insert['post_date_gmt'] = $post_data['date_gmt'];
 		}
 
 		// Post meta used by wp_insert_post, wp_update_post.

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -930,6 +930,15 @@ class DistributorPost {
 	protected function to_rest( $rest_args = array() ) {
 		$post_data = $this->post_data();
 
+		/*
+		 * Unset dates.
+		 *
+		 * External connections do not allow for the pulling or pushing of
+		 * scheduled posts so these can be ignored.
+		 */
+		unset( $post_data['date'] );
+		unset( $post_data['date_gmt'] );
+
 		if ( ! empty( $post_data['parent'] ) ) {
 			$post_data['distributor_original_post_parent'] = (int) $post_data['parent'];
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"cypress-mochawesome-reporter": "^3.5.1",
 				"eslint-plugin-cypress": "^2.12.1",
 				"jsdoc": "^3.6.11",
+				"mochawesome-json-to-md": "^0.7.2",
 				"node-wp-i18n": "^1.2.6",
 				"wp-hookdoc": "^0.2.0"
 			},
@@ -13067,6 +13068,18 @@
 			},
 			"peerDependencies": {
 				"mocha": ">=7"
+			}
+		},
+		"node_modules/mochawesome-json-to-md": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+			"integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+			"dev": true,
+			"dependencies": {
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"mochawesome-json-to-md": "index.js"
 			}
 		},
 		"node_modules/mochawesome-merge": {
@@ -28689,6 +28702,15 @@
 				"mochawesome-report-generator": "^6.2.0",
 				"strip-ansi": "^6.0.1",
 				"uuid": "^8.3.2"
+			}
+		},
+		"mochawesome-json-to-md": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+			"integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+			"dev": true,
+			"requires": {
+				"yargs": "^17.0.1"
 			}
 		},
 		"mochawesome-merge": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"cypress-mochawesome-reporter": "^3.5.1",
 		"eslint-plugin-cypress": "^2.12.1",
 		"jsdoc": "^3.6.11",
+		"mochawesome-json-to-md": "^0.7.2",
 		"node-wp-i18n": "^1.2.6",
 		"wp-hookdoc": "^0.2.0"
 	},

--- a/tests/php/DistributorPostTest.php
+++ b/tests/php/DistributorPostTest.php
@@ -1468,6 +1468,8 @@ class DistributorPostTest extends TestCase {
 			'excerpt'                        => 'Test Excerpt',
 			'parent'                         => 0,
 			'status'                         => 'publish',
+			'date'                           => '2020-01-01 00:00:00',
+			'date_gmt'                       => '2020-01-01 00:00:00',
 			'distributor_media'              => array(),
 			'distributor_terms'              => array(
 				'category' => array(),
@@ -1644,8 +1646,10 @@ class DistributorPostTest extends TestCase {
 			'type'                           => 'post',
 			'content'                        => '<!-- wp:paragraph --><p>Test Content</p><!-- /wp:paragraph -->',
 			'excerpt'                        => 'Test Excerpt',
-			'parent'			             => 0,
+			'parent'                         => 0,
 			'status'                         => 'publish',
+			'date'                           => '2020-01-01 00:00:00',
+			'date_gmt'                       => '2020-01-01 00:00:00',
 			'distributor_media'              => array(),
 			'distributor_terms'              => array(
 				'category' => array(),

--- a/tests/php/DistributorPostTest.php
+++ b/tests/php/DistributorPostTest.php
@@ -1480,7 +1480,7 @@ class DistributorPostTest extends TestCase {
 			'distributor_original_post_id'   => 1,
 		);
 
-		$this->assertSame( $post_data_expected, $post_data_actual );
+		$this->assertSame( $post_data_expected, $post_data_actual, 'Post data is not in an expected form' );
 
 		// Make sure it looks good to insert.
 		$to_insert_actual = $dt_post->to_insert();
@@ -1504,7 +1504,7 @@ class DistributorPostTest extends TestCase {
 			),
 		);
 
-		$this->assertSame( $to_insert_expected, $to_insert_actual );
+		$this->assertSame( $to_insert_expected, $to_insert_actual, 'Insert post data is not in an expected form' );
 
 		// Make sure it looks correct for a REST request.
 		$to_rest_actual = $dt_post->to_rest();
@@ -1528,7 +1528,7 @@ class DistributorPostTest extends TestCase {
 
 		);
 
-		$this->assertSame( $to_rest_expected, $to_rest_actual );
+		$this->assertSame( $to_rest_expected, $to_rest_actual, 'REST API data is not in an expected form' );
 	}
 
 	/**
@@ -1658,7 +1658,7 @@ class DistributorPostTest extends TestCase {
 			'distributor_original_post_id'   => 1,
 		);
 
-		$this->assertSame( $post_data_expected, $post_data_actual );
+		$this->assertSame( $post_data_expected, $post_data_actual, 'Post data is not in an expected form' );
 
 		// Make sure it looks good to insert.
 		$to_insert_actual = $dt_post->to_insert();
@@ -1682,7 +1682,7 @@ class DistributorPostTest extends TestCase {
 			),
 		);
 
-		$this->assertSame( $to_insert_expected, $to_insert_actual );
+		$this->assertSame( $to_insert_expected, $to_insert_actual, 'Insert post data is not in an expected form' );
 
 		// Make sure it looks correct for a REST request.
 		$to_rest_actual = $dt_post->to_rest();
@@ -1706,7 +1706,7 @@ class DistributorPostTest extends TestCase {
 			'distributor_raw_content'        => '<!-- wp:paragraph --><p>Test Content</p><!-- /wp:paragraph -->',
 		);
 
-		$this->assertSame( $to_rest_expected, $to_rest_actual );
+		$this->assertSame( $to_rest_expected, $to_rest_actual, 'REST API data is not in an expected form' );
 	}
 
 	/**

--- a/tests/php/DistributorPostTest.php
+++ b/tests/php/DistributorPostTest.php
@@ -1384,6 +1384,173 @@ class DistributorPostTest extends TestCase {
 	 * @covers ::to_json()
 	 * @runInSeparateProcess
 	 */
+	public function test_scheduled_post_data_without_blocks() {
+		$this->setup_post_mock(
+			array(
+				'post_status' => 'future',
+				'post_date' => '2120-01-01 00:00:00',
+				'post_date_gmt' => '2120-01-01 00:00:00',
+				'post_modified' => '2120-01-01 00:00:00',
+				'post_modified_gmt' => '2120-01-01 00:00:00',
+			)
+		);
+		$this->setup_post_meta_mock(
+			array (
+				'dt_original_post_id'  => array( '10' ),
+				'dt_original_blog_id'  => array( '2' ),
+				'dt_syndicate_time'    => array ( '1670383190' ),
+				'dt_original_post_url' => array ( 'http://origin.example.org/?p=10' ),
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'get_the_title',
+			array(
+				'return' => 'Test Post',
+			)
+		);
+		\WP_Mock::userFunction(
+			'get_bloginfo',
+			array(
+				'return' => function( $info ) {
+					switch ( $info ) {
+						case 'charset':
+							return 'UTF-8';
+						case 'name':
+							return 'Test Internal Origin';
+						default:
+							return '';
+					}
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'get_permalink',
+			array(
+				'return' => 'http://example.org/?p=1',
+			)
+		);
+
+		// Get Media: mock empty set as method is tested above.
+		\WP_Mock::userFunction(
+			'has_blocks',
+			array(
+				'return' => false,
+			)
+		);
+		\WP_Mock::userFunction(
+			'get_attached_media',
+			array(
+				'return' => array(),
+			)
+		);
+		\WP_Mock::userFunction(
+			'get_post_thumbnail_id',
+			array(
+				'return' => false,
+			)
+		);
+
+		// Get Terms: mock empty set as method is tested above.
+		\WP_Mock::userFunction(
+			'get_taxonomies',
+			array(
+				'return' => array( 'category', 'post_tag' ),
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_get_object_terms',
+			array(
+				'return' => array(),
+			)
+		);
+
+		$dt_post = new DistributorPost( 1 );
+		$post_data_actual = $dt_post->post_data();
+
+		$post_data_expected = array(
+			'title'                          => 'Test Post',
+			'slug'                           => 'test-post',
+			'type'                           => 'post',
+			'content'                        => 'Test Content',
+			'excerpt'                        => 'Test Excerpt',
+			'parent'                         => 0,
+			'status'                         => 'future',
+			'date'                           => '2120-01-01 00:00:00',
+			'date_gmt'                       => '2120-01-01 00:00:00',
+			'distributor_media'              => array(),
+			'distributor_terms'              => array(
+				'category' => array(),
+				'post_tag' => array(),
+			),
+			'distributor_meta'  => array(),
+			'distributor_original_site_name' => 'Test Internal Origin',
+			'distributor_original_site_url'  => 'http://test.com',
+			'distributor_original_post_url'  => 'http://example.org/?p=1',
+			'distributor_original_post_id'   => 1,
+		);
+
+		$this->assertSame( $post_data_expected, $post_data_actual, 'Post data is not in an expected form' );
+
+		// Make sure it looks good to insert.
+		$to_insert_actual = $dt_post->to_insert();
+		$to_insert_expected = array(
+			'post_title'    => 'Test Post',
+			'post_name'     => 'test-post',
+			'post_type'     => 'post',
+			'post_content'  => 'Test Content',
+			'post_excerpt'  => 'Test Excerpt',
+			'post_status'   => 'future',
+			'terms'             => array(
+				'category'      => array(),
+				'post_tag'      => array(),
+			),
+			'meta'          => array(),
+			'media'         => array(),
+			'post_author'   => 1,
+			'post_date'     => '2120-01-01 00:00:00',
+			'post_date_gmt' => '2120-01-01 00:00:00',
+			'meta_input'    => array(
+				'dt_original_post_id'  => 1,
+				'dt_original_post_url' => 'http://example.org/?p=1',
+			),
+		);
+
+		$this->assertSame( $to_insert_expected, $to_insert_actual, 'Insert post data is not in an expected form' );
+
+		// Make sure it looks correct for a REST request.
+		$to_rest_actual = $dt_post->to_rest();
+		$to_rest_expected = array(
+			'title'                          => 'Test Post',
+			'slug'                           => 'test-post',
+			'type'                           => 'post',
+			'content'                        => 'Test Content',
+			'excerpt'                        => 'Test Excerpt',
+			'status'                         => 'future',
+			'distributor_media'              => array(),
+			'distributor_terms'              => array(
+				'category' => array(),
+				'post_tag' => array(),
+			),
+			'distributor_meta'  => array(),
+			'distributor_original_site_name' => 'Test Internal Origin',
+			'distributor_original_site_url'  => 'http://test.com',
+			'distributor_original_post_url'  => 'http://example.org/?p=1',
+			'distributor_remote_post_id'     => 1,
+
+		);
+
+		$this->assertSame( $to_rest_expected, $to_rest_actual, 'REST API data is not in an expected form' );
+	}
+
+	/**
+	 * Test methods for formatting the post data without blocks.
+	 *
+	 * @covers ::post_data()
+	 * @covers ::to_insert()
+	 * @covers ::to_json()
+	 * @runInSeparateProcess
+	 */
 	public function test_post_data_without_blocks() {
 		$this->setup_post_mock();
 		$this->setup_post_meta_mock(

--- a/tests/php/NetworkSiteConnectionsTest.php
+++ b/tests/php/NetworkSiteConnectionsTest.php
@@ -72,11 +72,13 @@ class NetworkSiteConnectionsTest extends TestCase {
 			'get_post', [
 				'return' => (object) [
 					'ID'           => 111,
-					'post_content' => '',
-					'post_excerpt' => '',
-					'post_type'    => '',
-					'post_name'    => '',
-					'post_status'  => 'publish',
+					'post_content'  => '',
+					'post_excerpt'  => '',
+					'post_type'     => '',
+					'post_name'     => '',
+					'post_status'   => 'publish',
+					'post_date'     => '2020-01-01 00:00:00',
+					'post_date_gmt' => '2020-01-01 00:00:00',
 				],
 			]
 		);
@@ -277,6 +279,8 @@ class NetworkSiteConnectionsTest extends TestCase {
 					'post_status' => 'publish',
 					'post_content' => 'My post content',
 					'post_excerpt' => 'My post excerpt',
+					'post_date' => '2020-01-01 00:00:00',
+					'post_date_gmt' => '2020-01-01 00:00:00',
 					'meta'      => [],
 				],
 			]
@@ -429,6 +433,8 @@ class NetworkSiteConnectionsTest extends TestCase {
 					'post_status' => 'publish',
 					'post_content' => 'My post content',
 					'post_excerpt' => 'My post excerpt',
+					'post_date' => '2020-01-01 00:00:00',
+					'post_date_gmt' => '2020-01-01 00:00:00',
 				],
 			]
 		);

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -125,12 +125,14 @@ class WordPressExternalConnectionTest extends TestCase {
 		);
 
 		$post = (object) [
-			'post_content' => 'my post content',
-			'post_type'    => $post_type,
-			'post_excerpt' => 'post excerpt',
-			'post_name'    => 'slug',
-			'post_status'  => 'publish',
-			'ID'           => 1,
+			'post_content'  => 'my post content',
+			'post_type'     => $post_type,
+			'post_excerpt'  => 'post excerpt',
+			'post_name'     => 'slug',
+			'post_status'   => 'publish',
+			'ID'            => 1,
+			'post_date'     => '2020-01-01 00:00:00',
+			'post_date_gmt' => '2020-01-01 00:00:00',
 		];
 
 		\WP_Mock::userFunction(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Fixes various issues relating to post statuses:

* (network) when pulling scheduled posts, set the post date per original site
* (network) when pulling draft posts, ensure the post is not published when "pull as draft" is unchecked

> **Note**
>
> End-to-end tests are passing but the code to push the summary to the GitHub action's summary page is failing. This is reporting a false negative for successful tests.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
See #1149

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install Distributor on a Multisite Install
2. Create a sub site
3. Generate some draft posts on the main site: `wp post generate --count=5 --post_title="MS1 Draft" --post_author=1 --post_status=draft`
4. Generate some scheduled posts on the main site: `wp post generate --count=5 --post_title="MS1 Scheduled" --post_author=1 --post_status=future --post_date="2123-11-20 21:46:18"`
5. Open the sub site's dashboard
6. Go to Distributor > Pull Content
7. Uncheck "pull as draft"
8. Pull a scheduled post via the post's actions
9. Return to new posts
10. Uncheck "pull as draft"
11. Pull a draft post via the post's action
12. Return to new posts
13. Uncheck "pull as draft"
14. Check multiple scheduled posts' checkbox
15. Select "pull" from the bulk action drop down
16. Click "Apply"
17. Return to new post
18. Uncheck "pull as draft"
19. Check multiple draft posts' checkbox
20. Select "pull" from the bulk action drop down
21. Click "Apply"
22. Go the the All posts screen
23. Ensure draft posts remain in draft
24. Ensure scheduled posts are scheduled


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Prevent early publishing of scheduled posts when pulled internally.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @jeffpaul, @dkotter, @maxledoux, @pcrumm 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
