### PR TITLE
Avoid fatal error when Pulling an item that has been Pulled already on a different site

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -279,10 +279,10 @@ class NetworkSiteConnection extends Connection {
 			$current_blog_id = get_current_blog_id();
 
 			if ( ! empty( $post_props['meta']['dt_connection_map'] ) ) {
-				foreach ( $post_props['meta']['dt_connection_map'] as $distributed ) {
+				foreach ( $post_props['meta']['dt_connection_map'] as $connection_type => $distributed ) {
 					$distributed = maybe_unserialize( $distributed );
 
-					if ( array_key_exists( $current_blog_id, $distributed['internal'] ) ) {
+					if ( 'internal' === $connection_type && array_key_exists( $current_blog_id, $distributed ) ) {
 						$dt_pull_messages['duplicated'] = 1;
 						continue 2;
 					}


### PR DESCRIPTION
### Description of the Change

Within a multisite instance, if you Pull an item from one site to another (say from Site A to Site B), the original item has the connection details stored in the `dt_connection_map` meta.

If you then pull that same item into a different site (say from Site A into Site C) we check if the original item has that meta and if so, we check to see if the current site ID exists within that meta (which would indicate a duplicate item).

The problem here is the code we run looks for a different structure than what we actually have. Unsure if this is a new bug coming out of the v2 release or if this is a long standing issue that just hasn't been found. **EDIT**: Tested further and seems to be something that was always an issue but PHP 8.1 (maybe 8.0 but didn't test that) started throwing a fatal error instead of just a warning. So anyone running PHP 7.4 or less wouldn't see this.

This PR fixes this by using the correct data structure.

Closes #1158 

### How to test the Change

1. Set up a WordPress multisite with Distributor active and at least three sites in place
2. Create a piece of content on the first site
3. On the latest released version of Distributor, Pull this content into the second site
4. Then try pulling this content into the third site. A PHP fatal error should happen
5. Check out this PR, create a new piece of content on the first site and run through the steps again
6. No PHP fatals should happen

### Changelog Entry

> Fixed - Avoid a PHP fatal error when pulling content that has previously been pulled into a different network site

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
