### PR TITLE
add filter to DistributorPost::to_pull_list

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -918,7 +918,17 @@ class DistributorPost {
 		$display_data['distributor_original_site_name'] = $this->source_site['name'];
 		$display_data['distributor_original_site_url']  = $this->source_site['home_url'];
 
-		return $display_data;
+		/**
+		 * Filters the post data for when they are being formated for a pull
+		 *
+		 * @since 2.0.3
+		 * @hook dt_post_to_pull
+		 *
+		 * @param {array} $display_data The post data.
+		 *
+		 * @return {array} Modified post data.
+		 */
+		return apply_filters( 'dt_post_to_pull', $display_data );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Adds a new hook to `DistributorPost::to_pull_list` method to allow third party plugins to add additional data to the post being pulled by another site.

This is a useful alternative to extend the post data when pulling posts. Apart from that, the only other way plugins can add data to posts is by writing data to the post meta table, which is not always convenient.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

In the site where the content is going to be pulled from, add a snippet to add custom data to the post:
```PHP
add_filter( 'dt_post_to_pull', function( $post_data ) {
    $post_data['custom_field'] = 'custom_value';
} );
```

Now in the site where you are pulling the content from, add a snippet to inspect the contents of the pulled post and make sure the custom data is there:
```PHP
add_action( 'dt_pull_post', function ( $new_post_id, $connection, $post_array ) {

    if ( isset( $post_array['custom_field']) && $post_array['custom_field'] == 'custom_value') {
        error_log( 'It worked!' );
    }

} );
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `dt_post_to_pull` filter that allows plugins to add custom data to a post being pulled by another site.



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @leogermani


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.

I suppose the documentation is automatically generated in this case. Doc block looks good.

Also suppose this does not require new tests.