### PR TITLE
Replace `no-response` with `stale` action

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,26 +1,27 @@
-name: No Response
+name: 'Close stale issues'
 
 # **What it does**: Closes issues where the original author doesn't respond to a request for information.
 # **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
-# **Who does it impact**: Everyone that works on docs or docs-internal.
 
 on:
-  issue_comment:
-    types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Schedule for every day at 1:30am UTC
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
 
 jobs:
-  noResponse:
+  stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: actions/stale@v9
         with:
-          token: ${{ github.token }}
-          daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response
-          responseRequiredLabel: "Reporter Feedback" # Label indicating that a response from the original author is required
-          closeComment: >
+          days-before-stale: 7
+          days-before-close: 7
+          stale-issue-message: >
+            It has been 7 days since more information was requested from you in this issue and we have not heard back. This issue is now marked as stale and will be closed in 7 days, but if you have more information to add then please comment and the issue will stay open.
+          close-issue-message: >
             This issue has been automatically closed because there has been no response
             to our request for more information. With only the
             information that is currently in the issue, we don't have enough information
@@ -28,3 +29,7 @@ jobs:
             that we can investigate further. See [this blog post on bug reports and the
             importance of repro steps](https://www.lee-dohm.com/2015/01/04/writing-good-bug-reports/)
             for more information about the kind of information that may be helpful.
+          stale-issue-label: 'stale'
+          close-issue-reason: 'not_planned'
+          any-of-labels: 'Reporter Feedback'
+          remove-stale-when-updated: true


### PR DESCRIPTION
### Description of the Change
This PR replaces the [lee-dohm/no-response](https://github.com/lee-dohm/no-response) action with the [actions/stale](https://github.com/actions/stale) action. I had noticed recently that there were lots of No Response action failures, and after looking into it appears that the former action was no longer supported, throwing node 12/16 warnings, and the hope in changing to a GitHub first-party action will be improved stability (aka action runs not failing randomly) and proper node version support.

### How to test the Change
Check the updated run on this PR

### Changelog Entry
> Changed - Replaced [lee-dohm/no-response](https://github.com/lee-dohm/no-response) with [actions/stale](https://github.com/actions/stale) to help with closing no-response/stale issues.

### Credits
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
