### PR TITLE
Add check for internal connection

### DIFF
--- a/includes/pull-ui.php
+++ b/includes/pull-ui.php
@@ -576,8 +576,10 @@ function output_pull_errors() {
 
 	if ( is_a( $connection_now, '\Distributor\ExternalConnection' ) ) {
 		$error_key = "external_{$connection_now->id}";
-	} else {
+	} elseif ( is_a( $connection_now, '\Distributor\InternalConnections\NetworkSiteConnection' ) ) {
 		$error_key = "internal_{$connection_now->site->blog_id}";
+	} else {
+		return;
 	}
 
 	$pull_errors = get_transient( 'dt_connection_pull_errors_' . $error_key );


### PR DESCRIPTION
### Description of the Change

Adds a check to see if a connection is internal and if it's not, exits early.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1157

### How to test the Change

1. Open a URL with invalid connection id like: `admin.php?page=pull&connection_type=external&connection_id=1`.
2. Check debug log and ensure that the no warning is shown.
3. Open a URL with external connection and open it's screen as in step 1.
4. Check debug log and ensure that the no warning is shown.
5. Open a URL with network connection and open it's screen as in step 1
6. Check debug log and ensure that the no warning is shown.

### Changelog Entry

> Fixed - Warning on invalid connection id

### Credits
Props @kirtangajjar


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] All new and existing tests pass.
