### PR TITLE
Follow react rules of hooks

### DIFF
--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -153,6 +153,26 @@ const DistributorIcon = () => (
  * Add the Distributor panel to Gutenberg
  */
 const DistributorPlugin = () => {
+	// eslint-disable-next-line no-shadow, react-hooks/rules-of-hooks -- permission checks are needed.
+	const postType = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostType()
+	);
+
+	// eslint-disable-next-line no-shadow -- permission checks are needed.
+	const postStatus = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPostAttribute( 'status' )
+	);
+
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const distributorTopMenu = document.querySelector(
+		'#wp-admin-bar-distributor'
+	);
+
+	// eslint-disable-next-line no-shadow -- permission checks are needed.
+	const post = useSelect( ( select ) =>
+		select( 'core/editor' ).getCurrentPost()
+	);
+
 	// Ensure the user has proper permissions
 	if (
 		dtGutenberg.noPermissions &&
@@ -160,16 +180,6 @@ const DistributorPlugin = () => {
 	) {
 		return null;
 	}
-
-	// eslint-disable-next-line no-shadow, react-hooks/rules-of-hooks -- permission checks are needed.
-	const postType = useSelect( ( select ) =>
-		select( 'core/editor' ).getCurrentPostType()
-	);
-
-	// eslint-disable-next-line no-shadow, react-hooks/rules-of-hooks -- permission checks are needed.
-	const postStatus = useSelect( ( select ) =>
-		select( 'core/editor' ).getCurrentPostAttribute( 'status' )
-	);
 
 	// Ensure we are on a supported post type
 	if (
@@ -179,14 +189,6 @@ const DistributorPlugin = () => {
 		return null;
 	}
 
-	const distributorTopMenu = document.querySelector(
-		'#wp-admin-bar-distributor'
-	);
-
-	// eslint-disable-next-line no-shadow, react-hooks/rules-of-hooks -- permission checks are needed.
-	const post = useSelect( ( select ) =>
-		select( 'core/editor' ).getCurrentPost()
-	);
 	// Make the post title and status available to the top menu.
 	dt.postTitle = post.title;
 	dt.postStatus = post.status;

--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -153,12 +153,12 @@ const DistributorIcon = () => (
  * Add the Distributor panel to Gutenberg
  */
 const DistributorPlugin = () => {
-	// eslint-disable-next-line no-shadow, react-hooks/rules-of-hooks -- permission checks are needed.
+	// eslint-disable-next-line no-shadow
 	const postType = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPostType()
 	);
 
-	// eslint-disable-next-line no-shadow -- permission checks are needed.
+	// eslint-disable-next-line no-shadow
 	const postStatus = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPostAttribute( 'status' )
 	);
@@ -168,12 +168,12 @@ const DistributorPlugin = () => {
 		'#wp-admin-bar-distributor'
 	);
 
-	// eslint-disable-next-line no-shadow -- permission checks are needed.
+	// eslint-disable-next-line no-shadow
 	const post = useSelect( ( select ) =>
 		select( 'core/editor' ).getCurrentPost()
 	);
 
-	// Ensure the user has proper permissions
+	// Ensure the user has proper permissions.
 	if (
 		dtGutenberg.noPermissions &&
 		1 === parseInt( dtGutenberg.noPermissions )
@@ -181,7 +181,7 @@ const DistributorPlugin = () => {
 		return null;
 	}
 
-	// Ensure we are on a supported post type
+	// Ensure we are on a supported post type.
 	if (
 		dtGutenberg.supportedPostTypes &&
 		dtGutenberg.supportedPostTypes[ postType ] === undefined
@@ -193,7 +193,7 @@ const DistributorPlugin = () => {
 	dt.postTitle = post.title;
 	dt.postStatus = post.status;
 
-	// If we are on a non-supported post status, change what we show
+	// If we are on a non-supported post status, change what we show.
 	if (
 		dtGutenberg.supportedPostStati &&
 		! dtGutenberg.supportedPostStati.includes( postStatus )


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Follow react rules of hooks
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1205

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Start on a test site running WP 6.5 RC 3 and Distributor. 
2. Edit a post/page, and create a new synced pattern.
3. Click on the synced pattern, and then click 'Edit original' in the block toolbar to open the synced pattern in the new editor.
4. Make edits and save them -- best I can tell they save fine!
5. Click the 'back' button to return to the post/page editor; note that the error displays there initially, too.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - JS synced patterns editor


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kirtangajjar

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
