### PR TITLE
Fix ltrim deprecation warning in 8.1

### DIFF
--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -367,9 +367,12 @@ class PullListTable extends \WP_List_Table {
 
 			if ( ! empty( $new_post ) ) {
 				$actions = [
-					'edit' => '<a href="' . esc_url( get_edit_post_link( $new_post_id ) ) . '">' . esc_html__( 'Edit', 'distributor' ) . '</a>',
 					'view' => '<a href="' . esc_url( get_permalink( $new_post_id ) ) . '">' . esc_html__( 'View', 'distributor' ) . '</a>',
 				];
+
+				if ( current_user_can( 'edit_post', $new_post_id ) ) {
+					$actions['edit'] = '<a href="' . esc_url( get_edit_post_link( $new_post_id ) ) . '">' . esc_html__( 'Edit', 'distributor' ) . '</a>';
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of the Change
Fix Deprecation notice (PHP 8.1 and above) in PullListTable when distributed posts are not allowed to be edited.

Closes #1164

### How to test the Change

Follow issue reproduction steps linked on the issue. You should not see deprecation notice in that case.

### Changelog Entry
> Fixed - Deprecation notice  in PullListTable when distributed posts are not allowed to be edited


### Credits
Props @kirtangajjar


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
