### PR TITLE
Fix disabled buttons in distributed posts

### DIFF
--- a/assets/css/gutenberg-syndicated-post.scss
+++ b/assets/css/gutenberg-syndicated-post.scss
@@ -28,7 +28,9 @@ body.dt-linked-post {
 
 	.edit-post-welcome-guide,
 	.edit-post-header__settings,
+	.editor-header__settings,
 	.components-time-picker,
+	.editor-post-status,
 	.react-datepicker,
 	.components-panel__header {
 
@@ -52,6 +54,7 @@ body.dt-linked-post {
 	.editor-post-publish-button,
 	.edit-post-post-schedule__toggle,
 	.components-menu-item__button,
+	.editor-all-actions-button,
 	.editor-post-publish-panel button {
 		opacity: 1;
 		pointer-events: auto;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes the https://github.com/10up/distributor/issues/1249 issues.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1249

### How to test the Change
Update the site you distributed the post to WP 6.6 and/or distribute a post with the "As draft" checkbox checked to a site that is running WP 6.6. Observe that the Publish button is enabled and publish button is working.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @phpbits 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
