### PR TITLE
Fix undefined error logs

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -463,6 +463,10 @@ function register_endpoints() {
 		'distributor_meta',
 		array(
 			'get_callback'    => function( $post_array ) {
+				if ( ! isset( $post_array['id'] ) ) {
+					return false;
+				}
+
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
 				}
@@ -482,6 +486,10 @@ function register_endpoints() {
 		'distributor_terms',
 		array(
 			'get_callback'    => function( $post_array ) {
+				if ( ! isset( $post_array['id'] ) ) {
+					return false;
+				}
+
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
 				}
@@ -501,6 +509,10 @@ function register_endpoints() {
 		'distributor_media',
 		array(
 			'get_callback'    => function( $post_array ) {
+				if ( ! isset( $post_array['id'] ) ) {
+					return false;
+				}
+
 				if ( ! current_user_can( 'edit_post', $post_array['id'] ) ) {
 					return false;
 				}
@@ -520,7 +532,7 @@ function register_endpoints() {
 		'distributor_original_site_name',
 		array(
 			'get_callback'    => function( $post_array ) {
-				$site_name = get_post_meta( $post_array['id'], 'dt_original_site_name', true );
+				$site_name = isset( $post_array['id'] ) ? get_post_meta( $post_array['id'], 'dt_original_site_name', true ) : '';
 
 				if ( ! $site_name ) {
 					$site_name = get_bloginfo( 'name' );
@@ -541,7 +553,7 @@ function register_endpoints() {
 		'distributor_original_site_url',
 		array(
 			'get_callback'    => function( $post_array ) {
-				$site_url = get_post_meta( $post_array['id'], 'dt_original_site_url', true );
+				$site_url = isset( $post_array['id'] ) ? get_post_meta( $post_array['id'], 'dt_original_site_url', true ) : '';
 
 				if ( ! $site_url ) {
 					$site_url = home_url();
@@ -802,7 +814,7 @@ function register_push_errors_field() {
 			'push-errors',
 			array(
 				'get_callback' => function( $params ) {
-					$media_errors = get_transient( 'dt_media_errors_' . $params['id'] );
+					$media_errors = isset( $params['id'] ) ? get_transient( 'dt_media_errors_' . $params['id'] ) : '';
 
 					if ( ! empty( $media_errors ) ) {
 						delete_transient( 'dt_media_errors_' . $params['id'] );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
In WordPress 6.6, there are undefined 'id' PHP logs. This PR fixes the issue.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @phpbits


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
