### PR TITLE
Align show-connections-amp template with show-connections

### DIFF
--- a/templates/show-connections-amp.php
+++ b/templates/show-connections-amp.php
@@ -45,7 +45,7 @@
 
 		<div class="connections-selected empty">
 			<header class="with-selected">
-				<?php esc_html_e( 'Selected connections', 'distributor' ); ?>
+				<span class="selected-connections-text"></span>
 				<button class="button button-link selectno-connections unavailable"><?php esc_html_e( 'Clear', 'distributor' ); ?></button>
 			</header>
 			<header class="no-selected">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
On 9to5Toys, which uses an AMP theme, when the client selects a site for post distribution, the site does not appear in the list of selected connections. The console.log displays the JavaScript error: "Uncaught TypeError: Cannot set properties of null (setting 'textContent')." This issue stems from a change outlined here https://github.com/10up/distributor/commit/3f6b39eb4f49fb83e5b6a4391a8e4b22ddfd6a9c, which was not updated in the AMP template.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Updated the Show Connections AMP template

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
