### PR TITLE
Check for an existing image before processing media on the target site.

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -397,6 +397,8 @@ function excluded_meta() {
 				'dt_original_post_url',
 				'dt_original_post_id',
 				'dt_original_blog_id',
+				'dt_original_media_url',
+				'dt_original_media_id',
 				'dt_connection_map',
 				'_wp_old_slug',
 				'_wp_old_date',
@@ -736,7 +738,8 @@ function set_media( $post_id, $media, $args = [] ) {
 
 	foreach ( $media as $media_item ) {
 
-		$args['source_file'] = $media_item['source_file'];
+		$args['original_media_id'] = $media_item['id'];
+		$args['source_file']       = $media_item['source_file'];
 
 		// Delete duplicate if it exists (unless filter says otherwise)
 		/**
@@ -750,7 +753,7 @@ function set_media( $post_id, $media, $args = [] ) {
 		 *
 		 * @return {bool} Whether pre-existing media should be deleted and replaced.
 		 */
-		if ( apply_filters( 'dt_sync_media_delete_and_replace', true, $post_id ) ) {
+		if ( apply_filters( 'dt_sync_media_delete_and_replace', false, $post_id ) ) {
 			if ( ! empty( $current_media[ $media_item['source_url'] ] ) ) {
 				wp_delete_attachment( $current_media[ $media_item['source_url'] ], true );
 			}
@@ -874,8 +877,9 @@ function process_media( $url, $post_id, $args = [] ) {
 	$args = wp_parse_args(
 		$args,
 		[
-			'use_filesystem' => false,
-			'source_file'    => '',
+			'use_filesystem'    => false,
+			'source_file'       => '',
+			'original_media_id' => 0,
 		]
 	);
 
@@ -929,6 +933,15 @@ function process_media( $url, $post_id, $args = [] ) {
 
 	if ( is_null( $media_name ) ) {
 		return false;
+	}
+
+	// Check if the media is already existing on the site. If it is, return the media ID.
+	if ( ! empty( $args['original_media_id'] ) && ! empty( $url ) ) {
+		$existing_media_id = get_attachment_id_by_original_data( $url, $args['original_media_id'] );
+
+		if ( $existing_media_id ) {
+			return $existing_media_id;
+		}
 	}
 
 	$file_array         = array();
@@ -1029,6 +1042,46 @@ function process_media( $url, $post_id, $args = [] ) {
 	}
 
 	return (int) $result;
+}
+
+/**
+ * Get existing media ID based on the original source URL and original media ID.
+ *
+ * @param string $original_url The original source URL.
+ * @param int    $original_id  The original media ID.
+ * @return int|bool The existing media ID or false if not found.
+ */
+function get_attachment_id_by_original_data( $original_url, $original_id ) {
+	$attachments_query = new \WP_Query(
+		array(
+			'post_type'              => 'attachment',
+			'post_status'            => 'any',
+			'posts_per_page'         => 1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_query'     => array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'dt_original_media_id',
+					'value'   => $original_id,
+					'compare' => '=',
+				),
+				array(
+					'key'     => 'dt_original_media_url',
+					'value'   => $original_url,
+					'compare' => '=',
+				),
+			),
+		)
+	);
+
+	if ( ! empty( $attachments_query->posts ) && ! empty( $attachments_query->posts[0] ) ) {
+		return (int) $attachments_query->posts[0];
+	}
+
+	return false;
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1070,8 +1070,8 @@ function get_attachment_id_by_original_data( $original_url, $original_id ) {
 				),
 				array(
 					'key'     => 'dt_original_media_url',
-					'value'   => $original_url,
-					'compare' => '=',
+					'value'   => basename( $original_url ),
+					'compare' => 'LIKE', // Using LIKE to account different source URLs for the same media based on from where it was pulled/pushed. see https://core.trac.wordpress.org/ticket/25650
 				),
 			),
 		)

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -741,14 +741,14 @@ function set_media( $post_id, $media, $args = [] ) {
 		$args['original_media_id'] = $media_item['id'];
 		$args['source_file']       = $media_item['source_file'];
 
-		// Delete duplicate if it exists (unless filter says otherwise)
+		// Delete duplicate if it exists (if filter set to true)
 		/**
 		 * Filter whether media should be deleted and replaced if it already exists.
 		 *
 		 * @since 1.0.0
 		 * @hook dt_sync_media_delete_and_replace
 		 *
-		 * @param {bool}   true     Whether pre-existing media should be deleted and replaced. Default `true`.
+		 * @param {bool}   true     Whether pre-existing media should be deleted and replaced. Default `false`.
 		 * @param {int}    $post_id The post ID.
 		 *
 		 * @return {bool} Whether pre-existing media should be deleted and replaced.
@@ -1061,7 +1061,7 @@ function get_attachment_id_by_original_data( $original_url, $original_id ) {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
-			'meta_query'     => array(
+			'meta_query'             => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'relation' => 'AND',
 				array(
 					'key'     => 'dt_original_media_id',

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -737,9 +737,7 @@ function set_media( $post_id, $media, $args = [] ) {
 	}
 
 	foreach ( $media as $media_item ) {
-
-		$args['original_media_id'] = $media_item['id'];
-		$args['source_file']       = $media_item['source_file'];
+		$args['source_file'] = $media_item['source_file'];
 
 		// Delete duplicate if it exists (if filter set to true)
 		/**
@@ -762,6 +760,13 @@ function set_media( $post_id, $media, $args = [] ) {
 		} else {
 			if ( ! empty( $current_media[ $media_item['source_url'] ] ) ) {
 				$image_id = $current_media[ $media_item['source_url'] ];
+			} elseif ( ! empty( $media_item['id'] ) && ! empty( $media_item['source_url'] ) ) {
+				// Check if the media is already existing on the site. If it is, return the media ID.
+				$image_id = get_attachment_id_by_original_data( $media_item['id'], $media_item['source_url'] );
+
+				if ( ! $image_id ) {
+					$image_id = process_media( $media_item['source_url'], $post_id, $args );
+				}
 			} else {
 				$image_id = process_media( $media_item['source_url'], $post_id, $args );
 			}
@@ -877,9 +882,8 @@ function process_media( $url, $post_id, $args = [] ) {
 	$args = wp_parse_args(
 		$args,
 		[
-			'use_filesystem'    => false,
-			'source_file'       => '',
-			'original_media_id' => 0,
+			'use_filesystem' => false,
+			'source_file'    => '',
 		]
 	);
 
@@ -933,15 +937,6 @@ function process_media( $url, $post_id, $args = [] ) {
 
 	if ( is_null( $media_name ) ) {
 		return false;
-	}
-
-	// Check if the media is already existing on the site. If it is, return the media ID.
-	if ( ! empty( $args['original_media_id'] ) && ! empty( $url ) ) {
-		$existing_media_id = get_attachment_id_by_original_data( $url, $args['original_media_id'] );
-
-		if ( $existing_media_id ) {
-			return $existing_media_id;
-		}
 	}
 
 	$file_array         = array();
@@ -1047,11 +1042,11 @@ function process_media( $url, $post_id, $args = [] ) {
 /**
  * Get existing media ID based on the original source URL and original media ID.
  *
- * @param string $original_url The original source URL.
  * @param int    $original_id  The original media ID.
+ * @param string $original_url The original source URL.
  * @return int|bool The existing media ID or false if not found.
  */
-function get_attachment_id_by_original_data( $original_url, $original_id ) {
+function get_attachment_id_by_original_data( $original_id, $original_url ) {
 	$attachments_query = new \WP_Query(
 		array(
 			'post_type'              => 'attachment',

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -777,12 +777,11 @@ class UtilsTest extends TestCase {
 	 * @since 1.0
 	 * @group Utils
 	 * @runInSeparateProcess
+	 * @dataProvider data_test_set_media
 	 */
-	public function test_set_media() {
+	public function test_set_media( $new_image_id, $source_url, $existing_media_id ) {
 		$post_id    = 1;
 		$media_item = $this->test_format_media_featured();
-
-		$new_image_id = 5;
 
 		$attached_media_post                 = new \stdClass();
 		$attached_media_post->ID             = 3;
@@ -827,17 +826,10 @@ class UtilsTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction(
-			'wp_delete_attachment', [
-				'times' => 1,
-				'args'  => [ $attached_media_post->ID, true ],
-			]
-		);
-
-		\WP_Mock::userFunction(
 			'get_post_meta', [
 				'times'  => 1,
 				'args'   => [ $attached_media_post->ID, 'dt_original_media_url', true ],
-				'return' => 'http://mediaitem.com',
+				'return' => $source_url,
 			]
 		);
 
@@ -851,7 +843,6 @@ class UtilsTest extends TestCase {
 
 		\WP_Mock::userFunction(
 			'Distributor\Utils\process_media', [
-				'times'  => 1,
 				'args'   => [ $media_item['source_url'], $post_id,
 					[
 						'source_file'    => $media_item['source_file'],
@@ -859,6 +850,13 @@ class UtilsTest extends TestCase {
 					]
 				],
 				'return' => $new_image_id,
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'Distributor\Utils\get_attachment_id_by_original_data', [
+				'args'   => [ $media_item['id'], $media_item['source_url'] ],
+				'return' => $existing_media_id,
 			]
 		);
 
@@ -936,6 +934,20 @@ class UtilsTest extends TestCase {
 		);
 
 		Utils\set_media( $post_id, [ $media_item ], [ 'use_filesystem' => false ] );
+	}
+
+	/**
+	 * Data provider for test_set_media
+	 *
+	 * @since 1.0
+	 * @group Utils
+	 */
+	public function data_test_set_media() {
+		return [
+			[ 5, 'http://mediaitem.com/mediaitem.jpg', 0 ],
+			[ 3, 'http://mediaitem.com', 0 ],
+			[ 3, 'http://mediaitem.com/mediaitem.jpg', 3 ],
+		];
 	}
 
 	/**

--- a/tests/php/UtilsTest.php
+++ b/tests/php/UtilsTest.php
@@ -777,7 +777,11 @@ class UtilsTest extends TestCase {
 	 * @since 1.0
 	 * @group Utils
 	 * @runInSeparateProcess
-	 * @dataProvider data_test_set_media
+	 * @dataProvider data_set_media
+	 *
+	 * @param int    $new_image_id      ID of the new image.
+	 * @param string $source_url        Source URL of the media item.
+	 * @param int    $existing_media_id Existing media ID to test for existing media.
 	 */
 	public function test_set_media( $new_image_id, $source_url, $existing_media_id ) {
 		$post_id    = 1;
@@ -939,10 +943,11 @@ class UtilsTest extends TestCase {
 	/**
 	 * Data provider for test_set_media
 	 *
-	 * @since 1.0
 	 * @group Utils
+	 *
+	 * @return array[] Data provider.
 	 */
-	public function data_test_set_media() {
+	public function data_set_media() {
 		return [
 			[ 5, 'http://mediaitem.com/mediaitem.jpg', 0 ],
 			[ 3, 'http://mediaitem.com', 0 ],


### PR DESCRIPTION
### Description of the Change
As reported in #765, when the same image is used in multiple posts and these posts are distributed to connected sites, the media files are imported for each post, creating duplicate copies of the images on the target sites. This PR fixes the media duplication issue by checking for existing media on the target site before creating new media.

Closes #765

### How to test the Change
1. Assign the same image file to multiple posts on the origin site.
2. Distribute these posts to a subsite (network connection) or external connection.
3. Verify that there are no duplicate images on the target site and that images are reused in multiple posts.

### Changelog Entry
> Changed - The default value of the filter `dt_sync_media_delete_and_replace` has been updated from `true` to `false`.
> Fixed - Resolved the media duplication issue when the same image is used in multiple posts.

### Credits
Props @philbraun @jeffpaul @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
