### PR TITLE
Update all actions we use in our workflows to pull from specific pinned commits

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,13 +9,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Use desired version of NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
           node-version-file: '.nvmrc'
+
     - name: Check versions
       run: npm -v; node -v
+
     - name: npm install, and build docs
       run: |
         npm install
@@ -23,8 +26,9 @@ jobs:
         npm run build:docs
       env:
         CI: true
+
     - name: Deploy to GH Pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: './docs-built'

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Use desired version of NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
           node-version-file: '.nvmrc'
+
     - name: Set PHP version
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         php-version: 7.4
         tools: composer:v2, wp
@@ -42,6 +44,7 @@ jobs:
         composer install --no-dev
         npm install
         npm run release
+
     - name: Push to Stable
       env:
         GITHUB_REPOSITORY: ${{ github.event.repository.name }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 7
           days-before-close: 7

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -26,7 +26,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -34,7 +34,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -48,4 +48,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Use desired version of NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
           node-version-file: '.nvmrc'
 
     - name: Cache Node
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: |
           node_modules
@@ -56,10 +56,10 @@ jobs:
             core: {name: 'WP stable', version: 'latest'}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Use desired version of NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
           node-version-file: '.nvmrc'
 
@@ -67,7 +67,7 @@ jobs:
       run: npm -v; node -v
 
     - name: Cache Node
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: |
           node_modules
@@ -84,7 +84,7 @@ jobs:
 
     - name: Cache dependencies
       id: cache-composer
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       env:
         cache-name: cache-composer
       with:
@@ -92,7 +92,7 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
     - name: Set PHP version
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         php-version: ${{ matrix.php.version }}
         coverage: none
@@ -127,8 +127,9 @@ jobs:
           npx mochawesome-json-to-md -p ./tests/cypress/reports/mochawesome.json -o ./tests/cypress/reports/mochawesome.md
           npx mochawesome-report-generator tests/cypress/reports/mochawesome.json -o tests/cypress/reports/
           cat ./tests/cypress/reports/mochawesome.md >> $GITHUB_STEP_SUMMARY
+
     - name: Make artifacts available
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: failure()
       with:
         name: cypress-artifact

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
         with:
           license-check: true
           vulnerability-check: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
         with:
           license-check: true
           vulnerability-check: false

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -14,18 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
+
       - name: Use desired version of NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
+
       - name: Set PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: 7.4
           tools: composer:v2, wp
+
       - name: Check versions
         run: |
           npm -v
@@ -42,7 +45,7 @@ jobs:
           rm -rf ./release && unzip ${{ github.event.repository.name }}.zip -d ./release
 
       - name: Upload the ZIP file as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ github.event.repository.name }}
           path: release

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,31 +18,38 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Use desired version of NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
           node-version-file: '.nvmrc'
+
     - name: Cache Node
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: |
           node_modules
           ~/.cache
           ~/.npm
         key: ${{ hashFiles('package-lock.json') }}
+
     - name: Check versions
       run: npm -v; node -v
+
     - name: npm install
       run: npm install
+
     - name: Generate linting report
       run: npm run lint:js -- --output-file eslint-report.json --format json
       continue-on-error: true
+
     - name: Annotate code linting results
-      uses: ataylorme/eslint-annotate-action@1.2.0
+      uses: ataylorme/eslint-annotate-action@5f4dc2e3af8d3c21b727edb597e5503510b1dc9c # v2.2.0
       with:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
         report-json: 'eslint-report.json'
+
     - name: Update summary
       run: |
         npm_config_yes=true npx github:10up/eslint-json-to-md --path ./eslint-report.json --output ./eslint-report.md
@@ -53,15 +60,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: |
             **/*.php
 
       - name: Set PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: 7.4
           tools: composer:v2, cs2pr

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -6,9 +6,11 @@ jobs:
   release-pull-request-automation:
     if: ${{ github.event.ref_type == 'branch' && contains( github.ref, 'release/' ) }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Generate title
         run: |
           BRANCH=${GITHUB_REF##*/}
@@ -16,6 +18,7 @@ jobs:
           VERSION=${BRANCH#'release/'}
           echo "result="Release: ${VERSION}"" >> $GITHUB_OUTPUT
         id: title
+
       - name: Create Pull Request
         run: gh pr create --draft --title "${{ steps.title.outputs.result }}" --body-file ./.github/release-pull-request-template.md
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Create ZIP
       run: |
         git archive --prefix=distributor/ HEAD -o distributor.zip
+
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -20,7 +20,7 @@ jobs:
   Validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: 10up/action-repo-automator@trunk
+      - uses: 10up/action-repo-automator@280f5dc0b4ed1b5c50c816e08623bdefce55cdce # v2.1.3
         with:
           fail-label: needs:feedback
           pass-label: needs:code-review

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set standard 10up cache directories
       run: |
         composer config -g cache-dir "${{ env.COMPOSER_CACHE }}"
 
     - name: Prepare composer cache
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ env.COMPOSER_CACHE }}
         key: composer-${{ env.COMPOSER_VERSION }}-${{ hashFiles('**/composer.lock') }}
@@ -43,7 +43,7 @@ jobs:
           composer-${{ env.COMPOSER_VERSION }}-
 
     - name: Set PHP version
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         php-version: ${{ matrix.php }}
         coverage: none

--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: WordPress version checker
-        uses: skaut/wordpress-version-checker@master
+        uses: skaut/wordpress-version-checker@9d247334f5b30202cb9c1f4aee74c52f37399f69 # v2.2.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"mustache": "^4.2.0"
 			},
 			"devDependencies": {
-				"@10up/cypress-wp-utils": "^0.4.0",
+				"@10up/cypress-wp-utils": "^0.5.0",
 				"@wordpress/env": "^10.5.0",
 				"@wordpress/scripts": "^26.19.0",
 				"compare-versions": "^4.1.3",
@@ -30,9 +30,9 @@
 			}
 		},
 		"node_modules/@10up/cypress-wp-utils": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.4.0.tgz",
-			"integrity": "sha512-7cNELIX6ml5V9JEU83iEyQ6dkZ77ImdR5HKjUP4oyArQogPVcFPUnokU7GInH8DicqXbESrrkxZ0IfnNtNWh+A==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.5.0.tgz",
+			"integrity": "sha512-i6Z1CtW8qyw2qGN393jb2tcAT62cwmh7W0Yps3lwpHC/1c1b5LbnwyuAg/WNz5X7eIY5mL8Xq/a8u17T73Lsbw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0"
@@ -21276,9 +21276,9 @@
 	},
 	"dependencies": {
 		"@10up/cypress-wp-utils": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.4.0.tgz",
-			"integrity": "sha512-7cNELIX6ml5V9JEU83iEyQ6dkZ77ImdR5HKjUP4oyArQogPVcFPUnokU7GInH8DicqXbESrrkxZ0IfnNtNWh+A==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.5.0.tgz",
+			"integrity": "sha512-i6Z1CtW8qyw2qGN393jb2tcAT62cwmh7W0Yps3lwpHC/1c1b5LbnwyuAg/WNz5X7eIY5mL8Xq/a8u17T73Lsbw==",
 			"dev": true
 		},
 		"@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"mustache": "^4.2.0"
 	},
 	"devDependencies": {
-		"@10up/cypress-wp-utils": "^0.4.0",
+		"@10up/cypress-wp-utils": "^0.5.0",
 		"@wordpress/env": "^10.5.0",
 		"@wordpress/scripts": "^26.19.0",
 		"compare-versions": "^4.1.3",


### PR DESCRIPTION
### Description of the Change

In order to help protect against compromised actions, instead of including actions based on their major version (like v4), this PR switches all the actions we use to pull based on the commit hash from the latest release.

While this does impact maintenance a bit going forward, it ensures that we we're always using actions that we (hopefully) trust and if an action gets compromised (which [happens](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)) we don't have to worry that we're using a compromised action. This also goes along with what [GitHub suggests](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### How to test the Change

Ensure all our workflows still run as expected

### Changelog Entry

> Developer - Update all third-party actions our workflows rely on to use versions based on specific commit hashes.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
