### PR TITLE
Bump Wordpress Version minimum requirement 6.6

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -47,11 +47,11 @@ jobs:
           - {name: 'PHP Default', version: null}
         core:
           - {name: 'WP stable', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
         include:
           - php: {name: 'PHP 7.4', version: '7.4'}
-            core: {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+            core: {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - php: {name: 'PHP 8.1', version: '8.1'}
             core: {name: 'WP stable', version: 'latest'}
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -132,7 +132,7 @@ jobs:
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: failure()
       with:
-        name: cypress-artifact
+        name: cypress-artifact-${{matrix.php.name}}-${{matrix.core.name}}
         retention-days: 2
         path: |
             ${{ github.workspace }}/tests/cypress/screenshots/

--- a/distributor.php
+++ b/distributor.php
@@ -5,7 +5,7 @@
  * Update URI:        https://distributorplugin.com
  * Description:       Makes it easy to distribute and reuse content across your websites, whether inside of a multisite or across the web.
  * Version:           2.1.0
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up Inc.
  * Author URI:        https://distributorplugin.com

--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,7 @@ There are two connection types: `internal` and `external`.
 == Upgrade Notice ==
 
 = 2.0.5 =
-**Distributor now requires WordPress 6.4 or later.**
+**Distributor now requires WordPress 6.6 or later.**
 
 = 2.0.0 =
 **Distributor now requires PHP 7.4 or later and WordPress 5.7 or later.**

--- a/tests/cypress/e2e/images.test.js
+++ b/tests/cypress/e2e/images.test.js
@@ -33,8 +33,13 @@ describe( '[Block Editor] Image distribution tests', () => {
 				.find( `#${ id } button.components-button` )
 				.contains( 'Media Library' )
 				.click();
-			cy.get( '.attachments-browser .attachment' ).eq( 1 ).click();
-			cy.get( '.media-button-select' ).click();
+			cy.get( '[id^=__wp-uploader-id-]:visible' )
+				.find( '.attachments-browser .attachment' )
+				.eq( 1 )
+				.click();
+			cy.get( '[id^=__wp-uploader-id-]:visible' )
+				.find( '.media-button-select' )
+				.click();
 			cy.getBlockEditor().find( `#${ id } img` ).should( 'be.visible' );
 		} );
 	};


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1308 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Follow the critical flows to test the PR

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "require at least" version 6.6


@ankitguptaindia @jeffpaul @vikrampm1 I've created this PR to address the closure of issue #1308 . In this update, I've only modified the minimum required WordPress version to 6.6.