### PR TITLE
Fix eslint errors

### DIFF
--- a/assets/js/admin-external-connection.js
+++ b/assets/js/admin-external-connection.js
@@ -324,7 +324,7 @@ function checkConnections() {
 
 				if ( response.data.endpoint_suggestion ) {
 					endpointResult.innerText = `${ __(
-						'Did you mean: ',
+						'Did you mean:',
 						'distributor'
 					) } `;
 
@@ -337,7 +337,7 @@ function checkConnections() {
 					endpointResult.appendChild( suggestion );
 
 					speak(
-						`${ __( 'Did you mean: ', 'distributor' ) } ${
+						`${ __( 'Did you mean:', 'distributor' ) } ${
 							response.data.endpoint_suggestion
 						}`,
 						'polite'

--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -151,7 +151,7 @@ const RenderDistributedFrom = () => {
 					) }
 				</span>
 				<span id="distributed-data">
-					{ __( 'Updating the ', 'distributor' ) }
+					{ __( 'Updating the', 'distributor' ) }{ ' ' }
 					<a href={ dtGutenberg.postUrl }>
 						{ __( 'Original Content', 'distributor' ) }
 					</a>
@@ -217,7 +217,7 @@ const RenderDistributedFrom = () => {
 				) }
 			</span>
 			<span id="distributed-data">
-				{ __( 'This post has been unlinked from the ', 'distributor' ) }
+				{ __( 'This post has been unlinked from the', 'distributor' ) }{ ' ' }
 				<a href={ dtGutenberg.postUrl }>
 					{ __( 'Original Content', 'distributor' ) }
 				</a>
@@ -239,12 +239,12 @@ const RenderDistributedFrom = () => {
 					overlayClassName="distributed-modal-overlay"
 				>
 					<span id="distributed-data">
-						{ __( 'Restoring the link to the ', 'distributor' ) }
+						{ __( 'Restoring the link to the', 'distributor' ) }{ ' ' }
 						<a href={ dtGutenberg.postUrl }>
 							{ __( 'Original Content', 'distributor' ) }
-						</a>
+						</a>{ ' ' }
 						{ __(
-							' will start updating this post automatically from the Original, overwriting current content.',
+							'will start updating this post automatically from the Original, overwriting current content.',
 							'distributor'
 						) }
 					</span>

--- a/tests/bin/set-core-version.js
+++ b/tests/bin/set-core-version.js
@@ -10,7 +10,9 @@ const config = fs.existsSync( path ) ? require( path ) : {};
 
 const args = process.argv.slice( 2 );
 
-if ( args.length == 0 ) exit( 0 );
+if ( args.length == 0 ) {
+	exit( 0 );
+}
 
 if ( args[ 0 ] == 'latest' ) {
 	config.core = null;


### PR DESCRIPTION
### Description of the Change
See https://github.com/10up/distributor/runs/43468641642 - this PR fixes the errors listed there.

- Translations should not contain flanking whitespace
- Expected { after 'if' condition.

### How to test the Change
Most changes are simply moving a space outside of a translatable string, or removing a redundant space in the case of template literals.

### Changelog Entry
Developer - fix eslint errors.

### Credits
Props @GaryJones

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
