### PR TITLE
Add custom filter for subscription request

### DIFF
--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -270,11 +270,24 @@ class SubscriptionsController extends \WP_REST_Controller {
 				return $response;
 			}
 
+			$request['post_data']['content'] = $content;
+
+			/**
+			 * Filter the subscription request from Distributor.
+			 *
+			 * @since TBD
+			 * @hook dt_process_subscription_request
+			 *
+			 * @param {WP_REST_Request} $request Request object.
+			 * @param {WP_Post}         $post    Updated post object.
+			 */
+			$request = apply_filters( 'dt_process_subscription_request', $request, $post );
+
 			wp_update_post(
 				[
 					'ID'           => $request['post_id'],
 					'post_title'   => $request['post_data']['title'],
-					'post_content' => $content,
+					'post_content' => $request['post_data']['content'],
 					'post_excerpt' => $request['post_data']['excerpt'],
 					'post_name'    => $request['post_data']['slug'],
 				]


### PR DESCRIPTION
This PR resolves #1324 

### Description of the Change
This PR introduces a custom filter to enable users modify the `$request` object before it hits the `wp_update_post` call.

Closes #1324

### Changelog Entry
Add custom filter to enable user modify the `$request` object before it hits the `wp_update_post` call.

### Credits
@badasswp

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
