### PR TITLE
Re-enable fetured image test.

### DIFF
--- a/tests/cypress/e2e/internal-push.test.js
+++ b/tests/cypress/e2e/internal-push.test.js
@@ -59,7 +59,7 @@ describe( 'Internal Push', () => {
 			);
 
 			// Set Featured Image
-			cy.uploadMedia( 'assets/img/banner-772x250.png' ).then(
+			cy.uploadMedia( 'assets/img/browser-frame.jpg' ).then(
 				( media ) => {
 					if ( media && media.mediaId ) {
 						cy.wpCli(

--- a/tests/cypress/e2e/internal-push.test.js
+++ b/tests/cypress/e2e/internal-push.test.js
@@ -59,7 +59,7 @@ describe( 'Internal Push', () => {
 			);
 
 			// Set Featured Image
-			cy.uploadMedia( 'assets/img/browser-frame.jpg' ).then(
+			cy.uploadMedia( 'tests/cypress/assets/img/browser-frame.jpg' ).then(
 				( media ) => {
 					if ( media && media.mediaId ) {
 						cy.wpCli(

--- a/tests/cypress/e2e/internal-push.test.js
+++ b/tests/cypress/e2e/internal-push.test.js
@@ -59,19 +59,15 @@ describe( 'Internal Push', () => {
 			);
 
 			// Set Featured Image
-			// This test is temporarily disabled due to failures in GitHub actions that are not reproducible locally.
-			// On GitHub the success message expected within the cy.distributorPushPost command is not found as the
-			// distribution fails with an undefined error.
-
-			// cy.uploadMedia( 'assets/img/banner-772x250.png' ).then(
-			// 	( media ) => {
-			// 		if ( media && media.mediaId ) {
-			// 			cy.wpCli(
-			// 				`wp post meta set ${ post.id } _thumbnail_id ${ media.mediaId }`
-			// 			);
-			// 		}
-			// 	}
-			// );
+			cy.uploadMedia( 'assets/img/banner-772x250.png' ).then(
+				( media ) => {
+					if ( media && media.mediaId ) {
+						cy.wpCli(
+							`wp post meta set ${ post.id } _thumbnail_id ${ media.mediaId }`
+						);
+					}
+				}
+			);
 
 			cy.distributorPushPost( post.id, 'second', '', 'publish' ).then(
 				( distributeInfo ) => {
@@ -111,11 +107,11 @@ describe( 'Internal Push', () => {
 						.should( 'contain', content );
 
 					// validate featured image.
-					// cy.wpCli(
-					// 	`wp post meta get ${ distributeInfo.distributedPostId } _thumbnail_id --url=${ siteUrl }`
-					// )
-					// 	.its( 'stdout' )
-					// 	.should( 'not.empty' );
+					cy.wpCli(
+						`wp post meta get ${ distributeInfo.distributedPostId } _thumbnail_id --url=${ siteUrl }`
+					)
+						.its( 'stdout' )
+						.should( 'not.empty' );
 				}
 			);
 		} );


### PR DESCRIPTION
### Description of the Change

Re-enables the featured media test for internal pushes.

The path to the uploaded asset is modified to be relative to the project's root directory rather than the test directory per the `cy.uploadMedia` instructions.

Closes #1076.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry

> Fixed - Featured media E2E tests 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @sudip-md.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
