### PR TITLE
Fix the WordPress Playground integration

### DIFF
--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -21,7 +21,7 @@
     },
     {
       "step": "wp-cli",
-      "command": "wp plugin activate distributor-stable --network"
+      "command": "wp plugin activate https-github.com-10up-distributor-stable --network"
     },
     {
       "step": "wp-cli",

--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -11,8 +11,9 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github-proxy.com/proxy/?repo=10up/distributor&branch=stable"
+        "resource": "git:directory",
+        "url": "https://github.com/10up/distributor",
+        "ref": "stable"
       }
     },
     {


### PR DESCRIPTION
### Description of the Change

We recently had a report that the WordPress Playground instance we use for demo purposes was no longer working. In testing, it was installing Distributor properly but was failing when trying to network-activate the plugin. It seems the issue is related to the [deprecation of `github-proxy.com`](https://make.wordpress.org/playground/2025/12/19/action-required-github-proxy-com-shutdown/) that we use to download Distributor, as the final slug that is now downloaded is different (`https-github.com-10up-distributor-stable` vs `distributor-stable`).

This PR fixes that and in addition, moves away from using `github-proxy.com` and now uses the new `git:directory` resource to avoid any deprecation notices.

### How to test the Change

Can load the Playground environment and ensure it works properly by using the following link:

[Playground](https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22landingPage%22:%22/wp-admin/admin.php?page=pull%22,%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22git:directory%22,%22url%22:%22https://github.com/10up/distributor%22,%22ref%22:%22stable%22}},{%22step%22:%22enableMultisite%22},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20plugin%20activate%20https-github.com-10up-distributor-stable%20--network%22},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20site%20create%20--slug=test%22}]})

### Changelog Entry

> Fixed - Ensure our WordPress Playground integration works properly without any deprecation warnings

### Credits

Props @ianfs-com, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
