### PR TITLE
Fix: Propagate block index in recursive processing

### DIFF
--- a/includes/classes/RegisteredDataHandler.php
+++ b/includes/classes/RegisteredDataHandler.php
@@ -65,7 +65,7 @@ class RegisteredDataHandler {
 	 * @param array $extra_data      Array of extra data provided by source for the registered data.
 	 * @param array $post_data       Array of post data.
 	 * @param int   $index           Index of the extra data.
-	 * @return array Array with 'blocks' (processed blocks) and 'modified' (bool).
+	 * @return array Array with 'blocks' (processed blocks), 'modified' (bool), and 'index' (int).
 	 */
 	public function process_blocks_data_recursive( $blocks, $registered_data, $extra_data, $post_data, $index = 0 ) {
 		$callback_fn     = $registered_data['post_distribute_cb'] ?? null;
@@ -79,6 +79,7 @@ class RegisteredDataHandler {
 			return array(
 				'blocks'   => $blocks,
 				'modified' => $modified,
+				'index'    => $index,
 			);
 		}
 
@@ -155,12 +156,14 @@ class RegisteredDataHandler {
 					$block['innerBlocks'] = $inner_result['blocks'];
 					$modified             = true;
 				}
+				$index = $inner_result['index'];
 			}
 		}
 
 		return array(
 			'blocks'   => $blocks,
 			'modified' => $modified,
+			'index'    => $index,
 		);
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When distributing posts that contain registered data (e.g., media IDs registered via `distributor_register_data`) inside inner blocks — such as `core/image` blocks nested inside `core/columns` — all sibling inner block instances incorrectly receive `extra_data` from index `0` instead of their own sequential index. In practice this means every image in a columns layout is replaced with the media item from the first column, overwriting the correct media for subsequent columns.

**Root cause:** In `RegisteredDataHandler::process_blocks_data_recursive()`, the `$index` counter is passed by value into each recursive call for inner blocks, but the updated value returned by that call is never read back. Once the recursive call returns, `$index` still holds its pre-call value, so the next parallel branch of inner blocks starts counting from the wrong position.

**Fix:** Three minimal changes to `process_blocks_data_recursive()`:

1. **PHPDoc `@return` tag** — document that the returned array always includes an `'index'` key.
2. **Early-return path** — add `'index' => $index` to the early-return array so every code path returns a consistent shape.
3. **After recursive call** — propagate the child counter back to the parent with `$index = $inner_result['index']`, ensuring sibling branches receive the correct offset.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. On a multisite or two-site Distributor setup, register a media data handler using `distributor_register_data` targeting `core/image` blocks (the built-in `dt_post_distribute_media_cb` callback works).
2. Create a post on the source site containing a `core/columns` block with at least two columns, placing a **different** image block in each column.
3. Distribute (push or pull) that post to a destination site.
4. On the destination site, open the distributed post and confirm that **each column contains the correct, distinct image** — not a duplicate of the first column's image.
5. Verify the same behaviour with three or more columns to confirm the index increments correctly across all siblings.
6. Run the PHP unit test suite (`composer run-tests`) and confirm all tests pass.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensure the block index is correctly propagated during recursive processing of registered data, so inner blocks (e.g., images inside columns) receive the right `extra_data` on distribution.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ggutenberg

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
