### PR TITLE
    fix: prevent undefined array key warning in DistributorPost::get_extra_data

### DIFF
--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -672,6 +672,7 @@ class DistributorPost {
 	 * }
 	 */
 	protected function get_extra_data() {
+		$this->populate_source_site();
 		// Post data to pass to the filter.
 		$post_data = array(
 			'title'                          => html_entity_decode( get_the_title( $this->post->ID ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
@@ -685,8 +686,8 @@ class DistributorPost {
 			'date_gmt'                       => $this->post->post_date_gmt,
 
 			// Original site and post data.
-			'distributor_original_site_name' => $this->source_site['name'],
-			'distributor_original_site_url'  => $this->source_site['home_url'],
+			'distributor_original_site_name' => $this->source_site['name'] ?? '',
+			'distributor_original_site_url'  => $this->source_site['home_url'] ?? '',
 			'distributor_original_post_url'  => $this->get_permalink(),
 			'distributor_original_post_id'   => $this->post->ID,
 		);

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -686,8 +686,8 @@ class DistributorPost {
 			'date_gmt'                       => $this->post->post_date_gmt,
 
 			// Original site and post data.
-			'distributor_original_site_name' => $this->source_site['name'] ?? '',
-			'distributor_original_site_url'  => $this->source_site['home_url'] ?? '',
+			'distributor_original_site_name' => $this->source_site['name'],
+			'distributor_original_site_url'  => $this->source_site['home_url'],
 			'distributor_original_post_url'  => $this->get_permalink(),
 			'distributor_original_post_id'   => $this->post->ID,
 		);


### PR DESCRIPTION

### Description of the Change

Prevent undefined array key warning in `DistributorPost::get_extra_data()`

Call `populate_source_site()` explicitly at the start of `get_extra_data()` before accessing source_site array keys. Direct array access bypasses the `__get` magic method when source_site is already a declared but empty property, causing an undefined array key warning on source site save.

Added null coalescing fallbacks as a secondary guard.

Fixes #1371

### How to test the Change

1. Connect a site to an external connection
2. Enable logging of PHP warnings to an external file in wp-config, on both the source and target site
3. Create, publish and distribute a post
4. Update the post
5. Ensure the target site does not throw the warning `PHP Warning:  Undefined array key "name" in /vagrant/content/plugins/distributor/includes/classes/DistributorPost.php on line 688`

### Changelog Entry
> Fixed - Prevent undefined array key warning in `DistributorPost::get_extra_data()`

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oleksandrhurskyi, @peterwilsoncc


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
