### PR TITLE
fix: use wp_kses_post() instead of esc_url() for HTML output in distributor_the_original_site_link()

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -188,7 +188,7 @@ function distributor_get_original_site_link( $post_id = null ) {
  * @since 1.0
  */
 function distributor_the_original_site_link( $post_id = null ) {
-	echo esc_url( distributor_get_original_site_link( $post_id ) );
+	echo wp_kses_post( distributor_get_original_site_link( $post_id ) );
 }
 
 


### PR DESCRIPTION

### Description of the Change


#### Summary

`distributor_the_original_site_link()` wraps the return value of `distributor_get_original_site_link()` in `esc_url()` before echoing it. `distributor_get_original_site_link()` returns a fully-formed `<a href="...">...</a>` anchor tag — not a bare URL — with `esc_url()` and `esc_html()` already applied internally.

Wrapping HTML in `esc_url()` encodes angle brackets, quotes, and ampersands. The rendered output is escaped text rather than a clickable link.

This PR replaces `esc_url()` with `wp_kses_post()`, which permits the safe HTML subset the getter already produces.

**Before:**
```php
echo esc_url( distributor_get_original_site_link( $post_id ) );
```

**After:**
```php
echo wp_kses_post( distributor_get_original_site_link( $post_id ) );
```

Fixes #1378

---

*Developed and tested with AI assistance (Claude + internal review pipeline). Changes were verified against the function's return value before implementation.*



### How to test the Change

1. Link two sites, either internal or external
2. Create a post on the source site
3. Distribute the post to the destination site
4. On the destination site, check the post ID on the edit post list page
5. Run the WP CLI command `wp eval --url=[destination site] "distributor_the_original_site_link([post id]);"` replacing the placeholders as appropriate
6. Ensure the link tag is shown in the output

### Changelog Entry
> Fixed - Correct escaping of `distributor_the_original_site_link()`

### Credits
Props @thisismyurl

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
