### PR TITLE
Clarify content distribution panel title

### DIFF
--- a/assets/js/gutenberg-plugin.js
+++ b/assets/js/gutenberg-plugin.js
@@ -280,7 +280,7 @@ const isUnlinkedContent = parseInt( dtGutenberg.unlinked ) !== 0;
 const DistributorTitle = () => {
 	return isUnlinkedContent
 		? __( 'Unlinked Content', 'distributor' )
-		: __( 'Pulled Content', 'distributor' );
+		: __( 'Content Distribution', 'distributor' );
 };
 
 /**

--- a/tests/cypress/e2e/distributed-post.test.js
+++ b/tests/cypress/e2e/distributed-post.test.js
@@ -25,7 +25,7 @@ describe( 'Distributed Post Tests', () => {
 			// Ensure the settings panel is open.
 			cy.get( 'button[aria-label="Settings"]' ).then( () => {
 				cy.openDocumentSettingsSidebar( 'Post' );
-				cy.openDocumentSettingsPanel( 'Pulled Content' );
+				cy.openDocumentSettingsPanel( 'Content Distribution' );
 				cy.get( '#distributed-to' ).should(
 					'contain.text',
 					'Distributed to 1 connection'
@@ -46,7 +46,7 @@ describe( 'Distributed Post Tests', () => {
 					$settings.trigger( 'click' );
 				}
 				cy.openDocumentSettingsSidebar( 'Post' );
-				cy.openDocumentSettingsPanel( 'Pulled Content' );
+				cy.openDocumentSettingsPanel( 'Content Distribution' );
 				cy.get( '#distributed-to' ).should(
 					'contain.text',
 					'Distributed to 2 connections'
@@ -91,7 +91,7 @@ describe( 'Distributed Post Tests', () => {
 							$settings.trigger( 'click' );
 						}
 						cy.openDocumentSettingsSidebar( 'Post' );
-						cy.openDocumentSettingsPanel( 'Pulled Content' );
+						cy.openDocumentSettingsPanel( 'Content Distribution' );
 						cy.get( '#distributed-from' ).should(
 							'contain.text',
 							'Pulled & linked on'


### PR DESCRIPTION
## Summary

- rename the editor panel to “Content Distribution”
- update the Cypress selectors for the new heading

Fixes #1352.

## Checks

- `git diff --check`
- browser test not run; it requires the WordPress test environment