### PR TITLE
Update phpcs to 3.13.6.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -99,7 +99,7 @@ jobs:
         tools: composer:v2
 
     - name: Composer install
-      run: composer install
+      run: composer install --no-dev
 
     - name: Build
       run: npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
-          php-version: 7.4
+          php-version: 8.0
           tools: composer:v2, cs2pr
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     }
   },
   "require-dev": {
-    "10up/phpcs-composer": "dev-master",
     "10up/wp_mock": "~0.4",
     "phpunit/phpunit": "^8.5",
     "yoast/phpunit-polyfills": "^1.0",
-    "automattic/vipwpcs": "^2.3"
+    "automattic/vipwpcs": "^3.0",
+    "10up/phpcs-composer": "dev-trunk"
   },
   "scripts": {
     "lint": "@php phpcs . --runtime-set testVersion 7.4-",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36f131fe6d6e7b9fd934f1e8d604781a",
+    "content-hash": "7edb4d79d878f1971c051626cad32835",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -60,25 +60,27 @@
     "packages-dev": [
         {
             "name": "10up/phpcs-composer",
-            "version": "dev-master",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/phpcs-composer.git",
-                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6"
+                "reference": "0236e922017b33c179ee7fcbc558f5b8fb76cb5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/4a2f47d5ed0493836ef33ee2edad32192699fad6",
-                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/0236e922017b33c179ee7fcbc558f5b8fb76cb5e",
+                "reference": "0236e922017b33c179ee7fcbc558f5b8fb76cb5e",
                 "shasum": ""
             },
             "require": {
-                "automattic/vipwpcs": "^2.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "*",
-                "phpcompatibility/phpcompatibility-wp": "^2",
-                "squizlabs/php_codesniffer": "3.7.1",
-                "wp-coding-standards/wpcs": "*"
+                "automattic/vipwpcs": "^3.0",
+                "phpcompatibility/phpcompatibility-wp": "^2"
             },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "phpcompatibility/php-compatibility": "10.0.0-alpha2 as 9.99.99"
+            },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -93,9 +95,9 @@
             "description": "10up's PHP CodeSniffer Ruleset",
             "support": {
                 "issues": "https://github.com/10up/phpcs-composer/issues",
-                "source": "https://github.com/10up/phpcs-composer/tree/2.0.1"
+                "source": "https://github.com/10up/phpcs-composer/tree/trunk"
             },
-            "time": "2023-09-14T12:16:59+00:00"
+            "time": "2026-08-12T03:23:16+00:00"
         },
         {
             "name": "10up/wp_mock",
@@ -136,24 +138,28 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/master"
+            },
             "time": "2019-03-16T03:44:39+00:00"
         },
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.21",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d"
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
-                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4"
@@ -170,7 +176,7 @@
                 }
             ],
             "description": "Method redefinition (monkey-patching) functionality for PHP.",
-            "homepage": "http://patchwork2.org/",
+            "homepage": "https://antecedent.github.io/patchwork/",
             "keywords": [
                 "aop",
                 "aspect",
@@ -182,37 +188,38 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.21"
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
             },
-            "time": "2022-02-07T07:28:34+00:00"
+            "time": "2025-09-17T09:00:56+00:00"
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/9c47cd036754e0e5f354a9914568f052043c3f30",
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
-                "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
-                "wp-coding-standards/wpcs": "^2.3"
+                "php": ">=7.4",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "sirbrillig/phpcs-variable-analysis": "^2.13.0",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -229,6 +236,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -236,39 +244,42 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2026-07-27T14:33:48+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -278,17 +289,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -308,10 +318,29 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -385,20 +414,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -406,8 +435,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -430,44 +459,44 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.5.0",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
-                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -478,12 +507,20 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework",
@@ -501,27 +538,30 @@
                 "testing"
             ],
             "support": {
+                "docs": "https://docs.mockery.io/",
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.0"
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
             },
-            "time": "2022-01-20T13:18:17+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -556,15 +596,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -748,28 +788,28 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.2",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -799,33 +839,53 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2022-10-25T01:46:02+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.4",
+            "version": "2.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -854,9 +914,203 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2022-10-24T09:00:36+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1152,30 +1406,29 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-08-04T08:28:15+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.52",
+            "version": "8.5.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858"
+                "reference": "416a546dfbf773a98501bc97791e00c88b89668b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1015741814413c156abb0f53d7db7bbd03c6e858",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/416a546dfbf773a98501bc97791e00c88b89668b",
+                "reference": "416a546dfbf773a98501bc97791e00c88b89668b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5.0",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1188,7 +1441,7 @@
                 "sebastian/comparator": "^3.0.7",
                 "sebastian/diff": "^3.0.6",
                 "sebastian/environment": "^4.2.5",
-                "sebastian/exporter": "^3.1.8",
+                "sebastian/exporter": "^3.1.9",
                 "sebastian/global-state": "^3.0.6",
                 "sebastian/object-enumerator": "^3.0.5",
                 "sebastian/resource-operations": "^2.0.3",
@@ -1235,31 +1488,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.52"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.54"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:20:18+00:00"
+            "time": "2026-08-11T06:06:51+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1533,16 +1770,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.8",
+            "version": "3.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296"
+                "reference": "0cd58aaf479f1e18dfef818b8b8a4ccba188e545"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64cfeaa341951ceb2019d7b98232399d57bb2296",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0cd58aaf479f1e18dfef818b8b8a4ccba188e545",
+                "reference": "0cd58aaf479f1e18dfef818b8b8a4ccba188e545",
                 "shasum": ""
             },
             "require": {
@@ -1598,7 +1835,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.8"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.9"
             },
             "funding": [
                 {
@@ -1618,7 +1855,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T05:55:14+00:00"
+            "time": "2026-08-11T04:45:00+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1810,16 +2047,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a"
+                "reference": "4d3432ab12baebb4da6b7ad65d92847287f593b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/8fe7e75986a9d24b4cceae847314035df7703a5a",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/4d3432ab12baebb4da6b7ad65d92847287f593b8",
+                "reference": "4d3432ab12baebb4da6b7ad65d92847287f593b8",
                 "shasum": ""
             },
             "require": {
@@ -1861,7 +2098,7 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1881,7 +2118,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:25:53+00:00"
+            "time": "2026-08-11T05:21:46+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2039,28 +2276,27 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.3",
+            "version": "v2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8"
+                "reference": "a15e970b8a0bf64cfa5e86d941f5e6b08855f369"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c921498b474212fe4552928bbeb68d70250ce5e8",
-                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/a15e970b8a0bf64cfa5e86d941f5e6b08855f369",
+                "reference": "a15e970b8a0bf64cfa5e86d941f5e6b08855f369",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.5.7 || ^4.0.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
-                "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-                "sirbrillig/phpcs-import-detection": "^1.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpstan/phpstan": "^1.7 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -2083,25 +2319,29 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2022-02-21T17:01:13+00:00"
+            "time": "2025-09-30T22:22:48+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2111,18 +2351,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -2130,21 +2365,49 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2198,30 +2461,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2238,6 +2509,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2245,20 +2517,26 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
                 "shasum": ""
             },
             "require": {
@@ -2266,13 +2544,14 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -2304,9 +2583,10 @@
             ],
             "support": {
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2025-08-10T04:54:36+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -64,21 +64,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/phpcs-composer.git",
-                "reference": "a3b05c0dafbb4a5df8b47f845074157c096e84a6"
+                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/a3b05c0dafbb4a5df8b47f845074157c096e84a6",
-                "reference": "a3b05c0dafbb4a5df8b47f845074157c096e84a6",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/4a2f47d5ed0493836ef33ee2edad32192699fad6",
+                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6",
                 "shasum": ""
             },
             "require": {
+                "automattic/vipwpcs": "^2.3",
                 "dealerdirect/phpcodesniffer-composer-installer": "*",
                 "phpcompatibility/phpcompatibility-wp": "^2",
                 "squizlabs/php_codesniffer": "3.7.1",
                 "wp-coding-standards/wpcs": "*"
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -86,15 +86,16 @@
             ],
             "authors": [
                 {
-                    "name": "Ephraim Gregor",
-                    "email": "ephraim.gregor@10up.com"
+                    "name": "10up",
+                    "homepage": "https://10up.com/"
                 }
             ],
+            "description": "10up's PHP CodeSniffer Ruleset",
             "support": {
                 "issues": "https://github.com/10up/phpcs-composer/issues",
-                "source": "https://github.com/10up/phpcs-composer/tree/master"
+                "source": "https://github.com/10up/phpcs-composer/tree/2.0.1"
             },
-            "time": "2022-11-03T18:34:24+00:00"
+            "time": "2023-09-14T12:16:59+00:00"
         },
         {
             "name": "10up/wp_mock",

--- a/distributor.php
+++ b/distributor.php
@@ -92,7 +92,7 @@ function site_meets_php_requirements() {
  */
 register_activation_hook(
 	__FILE__,
-	function() {
+	function () {
 		if (
 			! site_meets_wp_requirements() &&
 			! site_meets_php_requirements()
@@ -131,7 +131,7 @@ register_activation_hook(
 
 add_action(
 	'plugins_loaded',
-	function() {
+	function () {
 		if ( site_meets_wp_requirements() && site_meets_php_requirements() ) {
 			// Do nothing, everything is fine.
 			return;
@@ -139,7 +139,7 @@ add_action(
 
 		add_action(
 			'admin_notices',
-			function() {
+			function () {
 				if (
 					! site_meets_wp_requirements() &&
 					! site_meets_php_requirements()

--- a/includes/auto-distribute.php
+++ b/includes/auto-distribute.php
@@ -15,7 +15,7 @@ namespace Distributor\AutoDistribute;
  * @since 2.2.0
  */
 function setup() {
-	$n = function( $function ) {
+	$n = function ( $function ) {
 		return __NAMESPACE__ . "\\$function";
 	};
 

--- a/includes/auto-distribute.php
+++ b/includes/auto-distribute.php
@@ -15,8 +15,8 @@ namespace Distributor\AutoDistribute;
  * @since 2.2.0
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
+	$n = function ( $callback_function ) {
+		return __NAMESPACE__ . "\\$callback_function";
 	};
 
 	if ( ! enabled() ) {

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -18,17 +18,17 @@ use YahnisElsts\PluginUpdateChecker\v5p7\PucFactory;
  * PSR-4 autoloading
  */
 spl_autoload_register(
-	function ( $class ) {
+	function ( $load_class ) {
 			// Project-specific namespace prefix.
 			$prefix = 'Distributor\\';
 			// Base directory for the namespace prefix.
 			$base_dir = __DIR__ . '/classes/';
 			// Does the class use the namespace prefix?
 			$len = strlen( $prefix );
-		if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+		if ( strncmp( $prefix, $load_class, $len ) !== 0 ) {
 			return;
 		}
-			$relative_class = substr( $class, $len );
+			$relative_class = substr( $load_class, $len );
 			$file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
 			// If the file exists, require it.
 		if ( file_exists( $file ) ) {

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -18,7 +18,7 @@ use YahnisElsts\PluginUpdateChecker\v5p7\PucFactory;
  * PSR-4 autoloading
  */
 spl_autoload_register(
-	function( $class ) {
+	function ( $class ) {
 			// Project-specific namespace prefix.
 			$prefix = 'Distributor\\';
 			// Base directory for the namespace prefix.
@@ -42,7 +42,7 @@ spl_autoload_register(
  */
 add_action(
 	'send_headers',
-	function() {
+	function () {
 		if ( ! headers_sent() ) {
 			header( 'X-Distributor: yes' );
 		}
@@ -54,7 +54,7 @@ add_action(
  */
 add_filter(
 	'rest_post_dispatch',
-	function( $response ) {
+	function ( $response ) {
 		$response->header( 'X-Distributor', 'yes' );
 		$response->header( 'X-Distributor-Version', DT_VERSION );
 
@@ -92,11 +92,11 @@ require_once __DIR__ . '/auto-distribute.php';
 // Include application passwords.
 add_action(
 	'plugins_loaded',
-	function() {
+	function () {
 		if ( ! wp_is_application_passwords_available() ) {
 			add_action(
 				'admin_notices',
-				function() {
+				function () {
 					if ( get_current_screen()->id !== 'toplevel_page_distributor' ) {
 						return;
 					}
@@ -124,7 +124,7 @@ add_action(
 // Override some styles for application passwords until we can get these changes upstream.
 add_action(
 	'admin_enqueue_scripts',
-	function() {
+	function () {
 		$asset_file = DT_PLUGIN_PATH . '/dist/js/admin-css.min.asset.php';
 		// Fallback asset data.
 		$asset_data = array(
@@ -201,7 +201,7 @@ if ( class_exists( '\\YahnisElsts\\PluginUpdateChecker\\v5p7\\PucFactory' ) ) {
  */
 add_action(
 	'init',
-	function() {
+	function () {
 		\Distributor\Connections::factory()->register( '\Distributor\ExternalConnections\WordPressExternalConnection' );
 		\Distributor\Connections::factory()->register( '\Distributor\ExternalConnections\WordPressDotcomExternalConnection' );
 		if (

--- a/includes/classes/API/SubscriptionsController.php
+++ b/includes/classes/API/SubscriptionsController.php
@@ -35,7 +35,6 @@ class SubscriptionsController extends \WP_REST_Controller {
 
 		$this->meta = new \WP_REST_Post_Meta_Fields( $this->post_type );
 		add_filter( 'rest_authentication_errors', array( $this, 'dt_verify_signature_authentication' ) );
-
 	}
 
 	/**

--- a/includes/classes/Authentication.php
+++ b/includes/classes/Authentication.php
@@ -7,7 +7,7 @@
 
 namespace Distributor;
 
-use \Distributor\ExternalConnection as ExternalConnection;
+use Distributor\ExternalConnection;
 
 /**
  * Authentication types extend this base abstract class. Authentication types
@@ -128,7 +128,7 @@ abstract class Authentication {
 		self::$error_message = $error_message;
 		add_action(
 			'auth_admin_notices',
-			function() {
+			function () {
 				?>
 		<div class="notice notice-error is-dismissible">
 			<p>

--- a/includes/classes/Authentications/WordPressBasicAuth.php
+++ b/includes/classes/Authentications/WordPressBasicAuth.php
@@ -7,7 +7,7 @@
 
 namespace Distributor\Authentications;
 
-use \Distributor\Authentication as Authentication;
+use Distributor\Authentication;
 
 /**
  * This auth type is simple username/password WP style
@@ -156,7 +156,8 @@ class WordPressBasicAuth extends Authentication {
 			<span class="description"><?php esc_html_e( 'A username from the external WordPress site to connect with. For full functionality, this needs to be a user with an administrator role.', 'distributor' ); ?></span>
 
 			<p>
-				<label for="dt_username"><?php esc_html_e( 'Password', 'distributor' ); ?> <?php
+				<label for="dt_username"><?php esc_html_e( 'Password', 'distributor' ); ?>
+				<?php
 				if ( ! empty( $args['base64_encoded'] ) ) :
 					?>
 					<a class="change-password" href="#"><?php esc_html_e( '(Change)', 'distributor' ); ?></a><?php endif; ?></label><br>

--- a/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
+++ b/includes/classes/Authentications/WordPressDotcomOauth2Authentication.php
@@ -7,7 +7,7 @@
 
 namespace Distributor\Authentications;
 
-use \Distributor\Authentication as Authentication;
+use Distributor\Authentication;
 
 /**
  * Enables WordPress.com Oauth2 authentication.
@@ -212,7 +212,6 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 			}
 		}
 		return false;
-
 	}
 
 	/**
@@ -463,7 +462,7 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 			// Allow wp_safe_redirect to redirect to the .com authorization endpoint.
 			add_filter(
 				'allowed_redirect_hosts',
-				function( $content ) {
+				function ( $content ) {
 					$content[] = 'public-api.wordpress.com';
 					return $content;
 				}
@@ -478,7 +477,6 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 			self::log_authentication_error( ' fetch_access_token() Failed -- ' . $ex->getMessage() );
 			return false;
 		}
-
 	}
 
 	/**
@@ -523,7 +521,7 @@ class WordPressDotcomOauth2Authentication extends Authentication {
 		if ( is_wp_error( $response ) ) {
 
 			self::log_authentication_error( 'Failed to validate token giving error ' . $response->get_error_message() );
-			$count ++;
+			++$count;
 			if ( $count <= 3 ) {
 				self::is_valid_token( $count );
 			}

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -905,8 +905,8 @@ class DistributorPost {
 			// Filter out classes that are not image classes.
 			$classes = array_filter(
 				$classes,
-				function ( $class ) {
-					return strpos( $class, 'wp-image-' ) === 0;
+				function ( $html_class ) {
+					return strpos( $html_class, 'wp-image-' ) === 0;
 				}
 			);
 

--- a/includes/classes/DistributorPost.php
+++ b/includes/classes/DistributorPost.php
@@ -905,7 +905,7 @@ class DistributorPost {
 			// Filter out classes that are not image classes.
 			$classes = array_filter(
 				$classes,
-				function( $class ) {
+				function ( $class ) {
 					return strpos( $class, 'wp-image-' ) === 0;
 				}
 			);

--- a/includes/classes/ExternalConnection.php
+++ b/includes/classes/ExternalConnection.php
@@ -7,7 +7,7 @@
 
 namespace Distributor;
 
-use \Distributor\Connection as Connection;
+use Distributor\Connection;
 
 /**
  * External connections extend this base abstract class. External connections are used to push and pull content.

--- a/includes/classes/ExternalConnections/WordPressDotcomExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressDotcomExternalConnection.php
@@ -7,7 +7,7 @@
 
 namespace Distributor\ExternalConnections;
 
-use \Distributor\ExternalConnections\WordPressExternalConnection as WordPressExternalConnection;
+use Distributor\ExternalConnections\WordPressExternalConnection;
 
 /**
  * WP.COM external connection class
@@ -47,5 +47,4 @@ class WordPressDotcomExternalConnection extends WordPressExternalConnection {
 	 * @var string
 	 */
 	public static $namespace = 'wp/v2';
-
 }

--- a/includes/classes/ExternalConnections/WordPressExternalConnection.php
+++ b/includes/classes/ExternalConnections/WordPressExternalConnection.php
@@ -8,9 +8,9 @@
 namespace Distributor\ExternalConnections;
 
 use Distributor\DistributorPost;
-use \Distributor\ExternalConnection as ExternalConnection;
+use Distributor\ExternalConnection;
 use Distributor\RegisteredDataHandler;
-use \Distributor\Utils;
+use Distributor\Utils;
 
 /**
  * Class handling WP external connections

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -598,6 +598,7 @@ class NetworkSiteConnection extends Connection {
 
 				$query_args['post__in'] = $args['post__in'];
 			} elseif ( isset( $args['post__not_in'] ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 				$query_args['post__not_in'] = $args['post__not_in'];
 			}
 

--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -7,11 +7,11 @@
 
 namespace Distributor\InternalConnections;
 
-use \Distributor\DistributorPost;
-use \Distributor\Connection as Connection;
+use Distributor\DistributorPost;
+use Distributor\Connection;
 use Distributor\RegisteredDataHandler;
 use Distributor\Utils;
-use \WP_Site as WP_Site;
+use WP_Site;
 
 /**
  * A network site connection let's you push and pull content within your blog
@@ -352,7 +352,7 @@ class NetworkSiteConnection extends Connection {
 				 */
 				if ( apply_filters( 'dt_pull_post_media', true, $new_post_id, $post['media'], $item_array['remote_post_id'], $post_array, $this ) ) {
 					\Distributor\Utils\set_media( $new_post_id, $post['media'], [ 'use_filesystem' => true ] );
-				};
+				}
 
 				/**
 				 * Allow bypassing of all terms processing.

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -538,6 +538,7 @@ class PullListTable extends \WP_List_Table {
 			$post_ids = array_merge( $skipped, $syndicated );
 
 			if ( ! empty( $post_ids ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 				$remote_get_args['post__not_in'] = $post_ids;
 			}
 

--- a/includes/classes/PullListTable.php
+++ b/includes/classes/PullListTable.php
@@ -217,7 +217,7 @@ class PullListTable extends \WP_List_Table {
 					}
 
 					/* translators: %s: time of pull */
-					echo sprintf( esc_html__( 'Pulled %s', 'distributor' ), esc_html( $h_time ) );
+					printf( esc_html__( 'Pulled %s', 'distributor' ), esc_html( $h_time ) );
 				}
 			}
 		} else {
@@ -440,7 +440,7 @@ class PullListTable extends \WP_List_Table {
 		 */
 		$class = sanitize_html_class( apply_filters( 'dt_pull_list_table_tr_class', 'dt-table-row', $item ) );
 
-		echo sprintf( '<tr class="%s">', esc_attr( $class ) );
+		printf( '<tr class="%s">', esc_attr( $class ) );
 		$this->single_row_columns( $item );
 		echo '</tr>';
 	}

--- a/includes/classes/RegisteredDataHandler.php
+++ b/includes/classes/RegisteredDataHandler.php
@@ -108,7 +108,7 @@ class RegisteredDataHandler {
 
 						$modified = true;
 					}
-					$index++;
+					++$index;
 				} elseif ( isset( $block['attrs'][ $block_attribute ] ) ) {
 					$source_data        = $block['attrs'][ $block_attribute ];
 					$current_extra_data = $extra_data[ $index ] ?? array();
@@ -146,7 +146,7 @@ class RegisteredDataHandler {
 
 						$modified = true;
 					}
-					$index++;
+					++$index;
 				}
 			}
 
@@ -365,7 +365,7 @@ class RegisteredDataHandler {
 
 			if ( $result['modified'] ) {
 				$post_content = serialize_blocks( $result['blocks'] );
-			};
+			}
 		}
 
 		/**
@@ -582,13 +582,13 @@ class RegisteredDataHandler {
 			$registered_data      = distributor_get_registered_data();
 			$registered_post_data = array_filter(
 				$registered_data,
-				function( $arr ) {
+				function ( $arr ) {
 					return 'post' === $arr['type'];
 				}
 			);
 
 			if ( ! empty( $registered_post_data ) && ! empty( $extra_data ) ) {
-				$prevent_processing = function() {
+				$prevent_processing = function () {
 					return false;
 				};
 				// Disable the process_extra_data filter to prevent infinite loop.

--- a/includes/debug-info.php
+++ b/includes/debug-info.php
@@ -20,7 +20,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'admin_init',
-		function() {
+		function () {
 			/**
 			 * Filter whether the debug info is enabled. Enabled by default, return false to disable.
 			 *
@@ -311,7 +311,7 @@ function get_external_connection_status( $external_connection_status ) {
  */
 function format_connection_data( $data ) {
 	$formatted = array_map(
-		function( $key, $value ) {
+		function ( $key, $value ) {
 			return sprintf( '- %1$s: %2$s', $key, $value );
 		},
 		array_keys( $data ),

--- a/includes/distributed-post-ui.php
+++ b/includes/distributed-post-ui.php
@@ -17,7 +17,7 @@ use Distributor\EnqueueScript;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_post_scripts_styles' );
 			add_action( 'post_submitbox_misc_actions', __NAMESPACE__ . '\distributed_to' );
 			add_action( 'in_admin_header', __NAMESPACE__ . '\add_help_tab' );

--- a/includes/external-connection-cpt.php
+++ b/includes/external-connection-cpt.php
@@ -18,7 +18,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'init', __NAMESPACE__ . '\setup_cpt' );
 			add_filter( 'enter_title_here', __NAMESPACE__ . '\filter_enter_title_here', 10, 2 );
 			add_filter( 'post_updated_messages', __NAMESPACE__ . '\filter_post_updated_messages' );
@@ -176,7 +176,7 @@ function setup_list_table() {
 			foreach ( (array) $post_ids as $post_id ) {
 				wp_delete_post( $post_id );
 
-				$deleted++;
+				++$deleted;
 			}
 			$sendback = add_query_arg( 'deleted', $deleted, $sendback );
 
@@ -516,7 +516,7 @@ function meta_box_external_connection_details( $post ) {
 		$selected  = $external_connection_class::$slug === $external_connection_type ||
 			( '' === $external_connection_type && 1 === $index );
 		$is_hidden = ! $selected;
-		$index++;
+		++$index;
 		?>
 		<div class="auth-credentials <?php echo esc_attr( $auth_handler_class_again::$slug ); ?> <?php echo esc_attr( $external_connection_class::$slug ); ?>">
 			<?php $auth_handler_class_again::credentials_form( $auth ); ?>

--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -250,7 +250,7 @@ function distributor_get_registered_data() {
  * @param int $source_post_id The source post ID.
  * @return array The extra data of the media to be distributed to the target site.
  */
-function distributor_media_pre_distribute_callback( $media_id, $source_post_id ) {
+function distributor_media_pre_distribute_callback( $media_id, $source_post_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat
 	if ( ! $media_id ) {
 		return array();
 	}
@@ -283,7 +283,7 @@ function distributor_media_pre_distribute_callback( $media_id, $source_post_id )
  * @param array $post_data        The post data.
  * @return int The ID of the distributed media.
  */
-function distributor_media_post_distribute_callback( $media_extra_data, $source_media_id, $post_data ) {
+function distributor_media_post_distribute_callback( $media_extra_data, $source_media_id, $post_data ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat
 	if ( ! isset( $media_extra_data['url'] ) ) {
 		return $source_media_id;
 	}
@@ -338,7 +338,7 @@ function distributor_media_post_distribute_callback( $media_extra_data, $source_
  * @param int $source_post_id The source post ID.
  * @return array The data of the post to be distributed to the target site.
  */
-function distributor_post_pre_distribute_callback( $post_id, $source_post_id ) {
+function distributor_post_pre_distribute_callback( $post_id, $source_post_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat
 	if ( ! $post_id ) {
 		return array();
 	}
@@ -534,7 +534,7 @@ function distributor_post_post_distribute_callback( $post_extra_data, $source_po
  * @param int $source_post_id The source post ID.
  * @return array|WP_Term The data of the term to be distributed to the target site.
  */
-function distributor_term_pre_distribute_callback( $term_id, $source_post_id ) {
+function distributor_term_pre_distribute_callback( $term_id, $source_post_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat
 	if ( ! $term_id ) {
 		return array();
 	}
@@ -569,7 +569,7 @@ function distributor_term_pre_distribute_callback( $term_id, $source_post_id ) {
  * @param array $post_data       The post data.
  * @return int The ID of the distributed term.
  */
-function distributor_term_post_distribute_callback( $term_extra_data, $source_term_id, $post_data ) {
+function distributor_term_post_distribute_callback( $term_extra_data, $source_term_id, $post_data ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat
 	if ( ! $term_extra_data ) {
 		return $source_term_id;
 	}

--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -468,7 +468,7 @@ function distributor_post_post_distribute_callback( $post_extra_data, $source_po
 		// For external connections and push direction, it is already handled via push from source site we don't have to handle it here.
 		if ( 'internal' === $connection_type || ( 'pull' === $connection_direction && 'external' === $connection_type ) ) {
 			// Disable the process_extra_data filter to prevent infinite loop.
-			$prevent_processing = function() {
+			$prevent_processing = function () {
 				return false;
 			};
 			add_filter( 'dt_process_extra_data', $prevent_processing, 9999 );

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -15,8 +15,8 @@ use WP_Post;
  * Setup actions and filters
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
+	$n = function ( $callback_function ) {
+		return __NAMESPACE__ . "\\$callback_function";
 	};
 
 	add_filter( 'get_canonical_url', $n( 'get_canonical_url' ), 10, 2 );

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -15,7 +15,7 @@ use WP_Post;
  * Setup actions and filters
  */
 function setup() {
-	$n = function( $function ) {
+	$n = function ( $function ) {
 		return __NAMESPACE__ . "\\$function";
 	};
 
@@ -26,7 +26,6 @@ function setup() {
 	add_filter( 'get_the_author_display_name', $n( 'get_the_author_display_name' ), 10, 3 );
 	add_filter( 'author_link', $n( 'filter_author_link' ) );
 	add_filter( 'get_the_author_user_url', $n( 'get_the_author_user_url' ), 10, 3 );
-
 }
 
 /**

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -18,7 +18,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 			add_filter( 'amp_dev_mode_element_xpaths', __NAMESPACE__ . '\add_element_xpaths' );
@@ -78,10 +78,8 @@ function syndicatable() {
 		if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {
 			return false;
 		}
-	} else {
-		if ( ! is_singular( $distributable_post_types ) ) {
+	} elseif ( ! is_singular( $distributable_post_types ) ) {
 			return false;
-		}
 	}
 
 	// If we're using the classic editor, we need to make sure the post has a distributable status.

--- a/includes/push-ui.php
+++ b/includes/push-ui.php
@@ -408,7 +408,7 @@ function ajax_push() {
  * @param  string $hook WP hook.
  * @since  0.8
  */
-function enqueue_scripts( $hook ) {
+function enqueue_scripts( $hook ) { //phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	if ( ! syndicatable() ) {
 		return;
 	}

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -719,6 +719,7 @@ function get_pull_content_list( $request ) {
 		 */
 		$args['post__in'] = array_diff( $request['include'], $request['exclude'] );
 	} elseif ( ! empty( $request['exclude'] ) ) {
+		// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 		$args['post__not_in'] = $request['exclude'];
 	} elseif ( ! empty( $request['include'] ) ) {
 		$args['post__in'] = $request['include'];

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -20,7 +20,7 @@ use WP_Error;
 function setup() {
 	add_action(
 		'init',
-		function() {
+		function () {
 			add_action( 'rest_api_init', __NAMESPACE__ . '\register_endpoints' );
 			add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
 			add_action( 'rest_api_init', __NAMESPACE__ . '\register_push_errors_field' );
@@ -210,7 +210,7 @@ function get_pull_content_list_args() {
 				'type' => 'integer',
 			),
 			'default'           => array(),
-			'sanitize_callback' => function( $param ) {
+			'sanitize_callback' => function ( $param ) {
 				if ( ! is_array( $param ) ) {
 					$param = array( $param );
 				}
@@ -241,7 +241,7 @@ function get_pull_content_list_args() {
 				'type' => 'string',
 			),
 			'default'           => array( 'post' ),
-			'validate_callback' => function( $param ) {
+			'validate_callback' => function ( $param ) {
 				if ( is_string( $param ) ) {
 					return sanitize_key( $param ) === $param;
 				}
@@ -254,7 +254,7 @@ function get_pull_content_list_args() {
 
 				return true;
 			},
-			'sanitize_callback' => function( $param ) {
+			'sanitize_callback' => function ( $param ) {
 				if ( is_string( $param ) ) {
 					$param = array( $param );
 				}
@@ -288,7 +288,7 @@ function get_pull_content_list_args() {
 
 				$param = array_filter(
 					$param,
-					function( $post_type ) {
+					function ( $post_type ) {
 						$post_type_object = get_post_type_object( $post_type );
 						return current_user_can( $post_type_object->cap->edit_posts );
 					}
@@ -314,7 +314,7 @@ function get_pull_content_list_args() {
 			'items'             => array(
 				'type' => 'string',
 			),
-			'validate_callback' => function( $param ) {
+			'validate_callback' => function ( $param ) {
 				if ( is_string( $param ) ) {
 					return sanitize_key( $param ) === $param;
 				}
@@ -327,7 +327,7 @@ function get_pull_content_list_args() {
 
 				return true;
 			},
-			'sanitize_callback' => function( $param ) {
+			'sanitize_callback' => function ( $param ) {
 				if ( is_string( $param ) ) {
 					$param = array( $param );
 				}
@@ -524,7 +524,7 @@ function register_endpoints() {
 		$post_types,
 		'distributor_meta',
 		array(
-			'get_callback'    => function( $post_array ) {
+			'get_callback'    => function ( $post_array ) {
 				if ( ! isset( $post_array['id'] ) ) {
 					return false;
 				}
@@ -535,7 +535,7 @@ function register_endpoints() {
 
 				return \Distributor\Utils\prepare_meta( $post_array['id'] );
 			},
-			'update_callback' => function( $value, $post ) { },
+			'update_callback' => function ( $value, $post ) { },
 			'schema'          => array(
 				'description' => esc_html__( 'Post meta for Distributor.', 'distributor' ),
 				'type'        => 'object',
@@ -547,7 +547,7 @@ function register_endpoints() {
 		$post_types,
 		'distributor_terms',
 		array(
-			'get_callback'    => function( $post_array ) {
+			'get_callback'    => function ( $post_array ) {
 				if ( ! isset( $post_array['id'] ) ) {
 					return false;
 				}
@@ -558,7 +558,7 @@ function register_endpoints() {
 
 				return \Distributor\Utils\prepare_taxonomy_terms( $post_array['id'] );
 			},
-			'update_callback' => function( $value, $post ) { },
+			'update_callback' => function ( $value, $post ) { },
 			'schema'          => array(
 				'description' => esc_html__( 'Taxonomy terms for Distributor.', 'distributor' ),
 				'type'        => 'object',
@@ -570,7 +570,7 @@ function register_endpoints() {
 		$post_types,
 		'distributor_media',
 		array(
-			'get_callback'    => function( $post_array ) {
+			'get_callback'    => function ( $post_array ) {
 				if ( ! isset( $post_array['id'] ) ) {
 					return false;
 				}
@@ -581,7 +581,7 @@ function register_endpoints() {
 
 				return \Distributor\Utils\prepare_media( $post_array['id'] );
 			},
-			'update_callback' => function( $value, $post ) { },
+			'update_callback' => function ( $value, $post ) { },
 			'schema'          => array(
 				'description' => esc_html__( 'Media for Distributor.', 'distributor' ),
 				'type'        => 'object',
@@ -593,7 +593,7 @@ function register_endpoints() {
 		$post_types,
 		'distributor_original_site_name',
 		array(
-			'get_callback'    => function( $post_array ) {
+			'get_callback'    => function ( $post_array ) {
 				$site_name = isset( $post_array['id'] ) ? get_post_meta( $post_array['id'], 'dt_original_site_name', true ) : '';
 
 				if ( ! $site_name ) {
@@ -602,7 +602,7 @@ function register_endpoints() {
 
 				return esc_html( $site_name );
 			},
-			'update_callback' => function( $value, $post ) { },
+			'update_callback' => function ( $value, $post ) { },
 			'schema'          => array(
 				'description' => esc_html__( 'Original site name for Distributor.', 'distributor' ),
 				'type'        => 'string',
@@ -614,7 +614,7 @@ function register_endpoints() {
 		$post_types,
 		'distributor_original_site_url',
 		array(
-			'get_callback'    => function( $post_array ) {
+			'get_callback'    => function ( $post_array ) {
 				$site_url = isset( $post_array['id'] ) ? get_post_meta( $post_array['id'], 'dt_original_site_url', true ) : '';
 
 				if ( ! $site_url ) {
@@ -623,7 +623,7 @@ function register_endpoints() {
 
 				return esc_url_raw( $site_url );
 			},
-			'update_callback' => function( $value, $post ) { },
+			'update_callback' => function ( $value, $post ) { },
 			'schema'          => array(
 				'description' => esc_html__( 'Original site url for Distributor.', 'distributor' ),
 				'type'        => 'string',
@@ -641,7 +641,6 @@ function register_endpoints() {
 			'permission_callback' => '__return_true',
 		)
 	);
-
 }
 
 /**
@@ -874,7 +873,7 @@ function register_push_errors_field() {
 			$post_type,
 			'push-errors',
 			array(
-				'get_callback' => function( $params ) {
+				'get_callback' => function ( $params ) {
 					$media_errors = isset( $params['id'] ) ? get_transient( 'dt_media_errors_' . $params['id'] ) : '';
 
 					if ( ! empty( $media_errors ) ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -17,7 +17,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu', 20 );
 
 			if ( DT_IS_NETWORK ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -82,7 +82,7 @@ function plugin_update_styles() {
  * @param  string $status Plugin status.
  * @since  1.2
  */
-function update_notice( $plugin_file, $plugin_data, $status ) {
+function update_notice( $plugin_file, $plugin_data, $status ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- back compat.
 	if ( DT_PLUGIN_FILE !== $plugin_file ) {
 		return;
 	}
@@ -170,7 +170,7 @@ function maybe_notice() {
  * @param  string $hook WP hook.
  * @since  1.2
  */
-function admin_enqueue_scripts( $hook ) {
+function admin_enqueue_scripts( $hook ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- back compat.
 	if ( ! empty( $_GET['page'] ) && 'distributor-settings' === $_GET['page'] ) { // @codingStandardsIgnoreLine Nonce not required.
 		$asset_file = DT_PLUGIN_PATH . '/dist/js/admin-settings-css.min.asset.php';
 		// Fallback asset data.

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -7,7 +7,7 @@
 
 namespace Distributor\Subscriptions;
 
-use Distributor\ExternalConnection as ExternalConnection;
+use Distributor\ExternalConnection;
 use Distributor\Utils;
 
 /**
@@ -18,7 +18,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'init', __NAMESPACE__ . '\register_cpt' );
 			add_action( 'wp_after_insert_post', __NAMESPACE__ . '\send_notifications', 99 );
 			add_action( 'before_delete_post', __NAMESPACE__ . '\delete_subscriptions' );

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -18,7 +18,7 @@ use Distributor\Utils;
 function setup() {
 	add_action(
 		'plugins_loaded',
-		function() {
+		function () {
 			add_action( 'edit_form_top', __NAMESPACE__ . '\syndicated_message', 9, 1 );
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_post_scripts' );
 			add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_edit_scripts' );
@@ -83,19 +83,17 @@ function output_distributor_column( $column_name, $post_id ) {
 
 		if ( ( ( empty( $original_blog_id ) && empty( $original_source_id ) ) || $original_deleted ) && ! $connection_map ) {
 			echo '';
-		} else {
-			if ( $connection_map ) {
+		} elseif ( $connection_map ) {
 				// When a post is pushed from current site or pulled by other sites.
 				echo '<span title="' . esc_attr__( 'Pushed', 'distributor' ) . '" class="dashicons dashicons-admin-page"></span>';
-			} else {
-				$unlinked = (bool) get_post_meta( $post_id, 'dt_unlinked', true );
-				$post_url = get_post_meta( $post_id, 'dt_original_post_url', true );
+		} else {
+			$unlinked = (bool) get_post_meta( $post_id, 'dt_unlinked', true );
+			$post_url = get_post_meta( $post_id, 'dt_original_post_url', true );
 
-				if ( $unlinked ) {
-					echo '<a target="_blank" href="' . esc_url( $post_url ) . '"><span title="' . esc_attr__( 'Unlinked', 'distributor' ) . '" class="dashicons dashicons-editor-unlink"></span></span></a>';
-				} else {
-					echo '<a target="_blank" href="' . esc_url( $post_url ) . '"><span title="' . esc_attr__( 'Linked', 'distributor' ) . '" class="dashicons dashicons-admin-links"></span></a>';
-				}
+			if ( $unlinked ) {
+				echo '<a target="_blank" href="' . esc_url( $post_url ) . '"><span title="' . esc_attr__( 'Unlinked', 'distributor' ) . '" class="dashicons dashicons-editor-unlink"></span></span></a>';
+			} else {
+				echo '<a target="_blank" href="' . esc_url( $post_url ) . '"><span title="' . esc_attr__( 'Linked', 'distributor' ) . '" class="dashicons dashicons-admin-links"></span></a>';
 			}
 		}
 	}

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -19,7 +19,7 @@ function distributor_is_unlinked( $post_id = null ) {
 		$post_id = $post->ID;
 	}
 
-	$unlinked = get_post_meta( $post_id, 'dt_unlinked' );
+	$unlinked = get_post_meta( $post_id, 'dt_unlinked', true );
 
 	return (bool) $unlinked;
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1138,19 +1138,17 @@ function set_media( $post_id, $media, $args = [] ) {
 			}
 
 			$image_id = process_media( $media_item['source_url'], $post_id, $args );
-		} else {
-			if ( ! empty( $current_media[ $media_item['source_url'] ] ) ) {
+		} elseif ( ! empty( $current_media[ $media_item['source_url'] ] ) ) {
 				$image_id = $current_media[ $media_item['source_url'] ];
-			} elseif ( ! empty( $media_item['id'] ) && ! empty( $media_item['source_url'] ) ) {
-				// Check if the media is already existing on the site. If it is, return the media ID.
-				$image_id = get_attachment_id_by_original_data( $media_item['id'], $media_item['source_url'] );
+		} elseif ( ! empty( $media_item['id'] ) && ! empty( $media_item['source_url'] ) ) {
+			// Check if the media is already existing on the site. If it is, return the media ID.
+			$image_id = get_attachment_id_by_original_data( $media_item['id'], $media_item['source_url'] );
 
-				if ( ! $image_id ) {
-					$image_id = process_media( $media_item['source_url'], $post_id, $args );
-				}
-			} else {
+			if ( ! $image_id ) {
 				$image_id = process_media( $media_item['source_url'], $post_id, $args );
 			}
+		} else {
+			$image_id = process_media( $media_item['source_url'], $post_id, $args );
 		}
 
 		// Exit if the image ID is not valid.

--- a/templates/show-connections.php
+++ b/templates/show-connections.php
@@ -11,7 +11,7 @@
 	<div class="inner">
 	<# if ( ! _.isEmpty( connections ) ) { #>
 		<?php /* translators: %s the post title */ ?>
-		<p><?php echo sprintf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), '{{ postTitle }}' ); ?></p>
+		<p><?php printf( esc_html__( 'Distribute &quot;%s&quot; to other connections.', 'distributor' ), '{{ postTitle }}' ); ?></p>
 
 		<div class="connections-selector">
 			<div>

--- a/uninstall.php
+++ b/uninstall.php
@@ -94,7 +94,7 @@ if ( defined( 'DT_REMOVE_ALL_DATA' ) && true === DT_REMOVE_ALL_DATA ) {
 				$where_clause
 			),
 			array_map(
-				function( $prefix ) use ( $wpdb ) {
+				function ( $prefix ) use ( $wpdb ) {
 					return $wpdb->esc_like( $prefix ) . '%';
 				},
 				$option_prefixes 
@@ -150,7 +150,7 @@ if ( defined( 'DT_REMOVE_ALL_DATA' ) && true === DT_REMOVE_ALL_DATA ) {
 			array_merge(
 				[ $site_id ],
 				array_map(
-					function( $prefix ) use ( $wpdb ) {
+					function ( $prefix ) use ( $wpdb ) {
 						return $wpdb->esc_like( $prefix ) . '%';
 					},
 					$option_prefixes 
@@ -176,7 +176,7 @@ if ( defined( 'DT_REMOVE_ALL_DATA' ) && true === DT_REMOVE_ALL_DATA ) {
 			// Flush the site options cache.
 			$key_names = array_column( $sitemeta_to_delete, 'meta_key' );
 			$key_names = array_map(
-				function( $key ) use ( $site_id ) {
+				function ( $key ) use ( $site_id ) {
 					return $site_id . ':' . $key;
 				},
 				$key_names 
@@ -202,4 +202,3 @@ if ( defined( 'DT_REMOVE_ALL_DATA' ) && true === DT_REMOVE_ALL_DATA ) {
 		dt_delete_data();
 	}
 }
-


### PR DESCRIPTION
### Description of the Change

PHPCS 3.13.6 was just released and contains a fix for a security vulnerability: https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq .

This is blocking Composer installations.

Needs updating from 3.13.5 to 3.13.6.

> [!Note]
>
> E2E tests are failing for trunk. I think the cause is due to editor changes that need to be accounted for in the Cypress test suite. I've been unable to figure out what those changes need to be when looking at the package.

### How to test the Change

1. Run `composer i`
2. Ensure composer installs the packages.

### Changelog Entry
> Developer - Update PHPCS to 3.13.6.
> Developer - Composer dev packages now require PHP 8.0 or later.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
