### PR TITLE
Fix deprecation notices in test suite.

### DIFF
--- a/includes/classes/InternalConnections/NetworkSiteConnection.php
+++ b/includes/classes/InternalConnections/NetworkSiteConnection.php
@@ -98,6 +98,7 @@ class NetworkSiteConnection extends Connection {
 		$args = wp_parse_args(
 			$args,
 			array(
+				'post_title'  => '',
 				'post_status' => 'publish',
 			)
 		);

--- a/tests/php/NetworkSiteConnectionsTest.php
+++ b/tests/php/NetworkSiteConnectionsTest.php
@@ -76,6 +76,7 @@ class NetworkSiteConnectionsTest extends TestCase {
 					'post_excerpt'  => '',
 					'post_type'     => '',
 					'post_name'     => '',
+					'post_title'    => '',
 					'post_status'   => 'publish',
 					'post_date'     => '2020-01-01 00:00:00',
 					'post_date_gmt' => '2020-01-01 00:00:00',
@@ -116,7 +117,7 @@ class NetworkSiteConnectionsTest extends TestCase {
 		\WP_Mock::userFunction( 'switch_to_blog' );
 		\WP_Mock::userFunction( 'add_filter' );
 		\WP_Mock::userFunction( 'restore_current_blog' );
-		\WP_Mock::userFunction( 'get_the_title' );
+		\WP_Mock::userFunction( 'get_the_title', array( 'return' => '' ) );
 		\WP_Mock::userFunction( 'remove_filter' );
 		\WP_Mock::userFunction( 'get_option' );
 		\WP_Mock::passthruFunction( 'wp_slash' );

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -7,6 +7,20 @@ use WP_Mock\Tools\TestCase;
 
 class WordPressExternalConnectionTest extends TestCase {
 
+	/**
+	 * Basic auth object.
+	 *
+	 * @var WordPressBasicAuth
+	 */
+	public $auth;
+
+	/**
+	 * External connection object.
+	 *
+	 * @var WordPressExternalConnection
+	 */
+	public $connection;
+
 	public function setUp(): void {
 
 		$this->auth       = new WordPressBasicAuth( array() );

--- a/tests/php/WordPressExternalConnectionTest.php
+++ b/tests/php/WordPressExternalConnectionTest.php
@@ -96,7 +96,7 @@ class WordPressExternalConnectionTest extends TestCase {
 		$this->setup_post_meta_mock( array() );
 		\WP_Mock::userFunction( 'do_action_deprecated' );
 		\WP_Mock::userFunction( 'untrailingslashit' );
-		\WP_Mock::userFunction( 'get_the_title' );
+		\WP_Mock::userFunction( 'get_the_title', array( 'return' => '' ) );
 		\WP_Mock::userFunction( 'wp_remote_post' );
 		\WP_Mock::userFunction( 'esc_html__' );
 		\WP_Mock::userFunction( 'get_bloginfo' );
@@ -143,6 +143,7 @@ class WordPressExternalConnectionTest extends TestCase {
 			'post_type'     => $post_type,
 			'post_excerpt'  => 'post excerpt',
 			'post_name'     => 'slug',
+			'post_title'    => 'post title',
 			'post_status'   => 'publish',
 			'ID'            => 1,
 			'post_date'     => '2020-01-01 00:00:00',
@@ -424,7 +425,7 @@ class WordPressExternalConnectionTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction( 'wp_remote_request' );
-		\WP_Mock::userFunction( 'untrailingslashit' );
+		\WP_Mock::userFunction( 'untrailingslashit', array( 'return' => 'url' ) );
 
 		$check = $this->connection->check_connections();
 
@@ -450,7 +451,7 @@ class WordPressExternalConnectionTest extends TestCase {
 		);
 
 		\WP_Mock::userFunction( 'wp_remote_request' );
-		\WP_Mock::userFunction( 'untrailingslashit' );
+		\WP_Mock::userFunction( 'untrailingslashit', array( 'return' => 'url' ) );
 
 		\WP_Mock::userFunction(
 			'wp_remote_retrieve_response_code', [

--- a/tests/php/includes/common.php
+++ b/tests/php/includes/common.php
@@ -9,6 +9,7 @@
  *
  * @since  0.8
  */
+#[AllowDynamicProperties]
 class WP_Error {
 	public function __construct( $code = '', $message = '' ) {
 		$this->code    = $code;
@@ -101,6 +102,7 @@ function is_serialized( $data, $strict = true ) {
  *
  * @since  0.8
  */
+#[AllowDynamicProperties]
 class WP_Query {
 	public function __construct( $args = array() ) {
 
@@ -230,6 +232,7 @@ function remote_get_setup() {
  *
  * @since  1.0
  */
+#[AllowDynamicProperties]
 class WP_Post {
 	public function __construct( $post ) {
 		if ( ! empty( $post ) ) {
@@ -245,6 +248,7 @@ class WP_Post {
 /**
  * Mock WP_HTML_Tag_Processor
  */
+#[AllowDynamicProperties]
 class WP_HTML_Tag_Processor {
 	protected $html;
 
@@ -344,6 +348,7 @@ function remove_filter() { }
 /**
  * Classes for testing connections
  */
+#[AllowDynamicProperties]
 class TestExternalConnection extends \Distributor\ExternalConnection {
 	static $slug               = 'test-external-connection';
 	static $auth_handler_class = '\Distributor\Authentications\WordPressBasicAuth';
@@ -364,6 +369,7 @@ class TestExternalConnection extends \Distributor\ExternalConnection {
 	public function get_taxonomy_terms() { }
 }
 
+#[AllowDynamicProperties]
 class TestInternalConnection extends \Distributor\Connection {
 	static $slug = 'test-internal-connection';
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes various deprecation notices thrown in the test suite by ensuring mocks return an expected value.

### How to test the Change

Observe results of phpunit test suite run.

### Changelog Entry
> Developer - Remove deprecation warnings in test suite.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
