### PR TITLE
Fix Distributor Icon on post edit screen header.

### DIFF
--- a/assets/css/admin-edit-table.css
+++ b/assets/css/admin-edit-table.css
@@ -16,8 +16,3 @@
 .distributor.column-distributor img {
 	width: 18px;
 }
-
-.column-distributor .dt-column-header {
-	display: none;
-}
-

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -60,7 +60,7 @@ function setup_columns() {
  */
 function add_distributor_column( $columns ) {
 	unset( $columns['date'] );
-	$columns['distributor'] = '<img src="' . esc_url( plugins_url( 'assets/img/icon.svg', __DIR__ ) ) . '" alt="' . esc_attr__( 'Posts distributed from another site.', 'distributor' ) . '" title="' . esc_attr__( 'Posts distributed from another site.', 'distributor' ) . '"> <span class="dt-column-header">Distributor</span>';
+	$columns['distributor'] = '<img src="' . esc_url( plugins_url( 'assets/img/icon.svg', __DIR__ ) ) . '" alt="' . esc_attr__( 'Posts distributed from another site.', 'distributor' ) . '" title="' . esc_attr__( 'Posts distributed from another site.', 'distributor' ) . '"> <span class="dt-column-header screen-reader-text">Distributor</span>';
 
 	$columns['date'] = esc_html__( 'Date', 'distributor' );
 

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -689,7 +689,7 @@ function enqueue_edit_scripts( $hook ) {
 		return;
 	}
 
-	$asset_file = DT_PLUGIN_PATH . '/dist/js/gadmin-edit-table-css.min.asset.php';
+	$asset_file = DT_PLUGIN_PATH . '/dist/js/admin-edit-table-css.min.asset.php';
 	// Fallback asset data.
 	$asset_data = array(
 		'version'      => DT_VERSION,

--- a/includes/syndicated-post-ui.php
+++ b/includes/syndicated-post-ui.php
@@ -699,5 +699,5 @@ function enqueue_edit_scripts( $hook ) {
 		$asset_data = require $asset_file;
 	}
 
-	wp_enqueue_style( 'dt-admin-syndicated-post', plugins_url( '/dist/css/admin-edit-table.min.css', __DIR__ ), array(), $asset_data['version'] );
+	wp_enqueue_style( 'dt-admin-edit-table', plugins_url( '/dist/css/admin-edit-table.min.css', __DIR__ ), array(), $asset_data['version'] );
 }


### PR DESCRIPTION
### Description of the Change

Fixes the post edit screen icon to display at the expected size.

| Before | After |
|--------|--------|
| <img width="569" height="289" alt="Screenshot 2026-08-21 at 12 52 45 pm" src="https://github.com/user-attachments/assets/50af3602-efce-48df-8d5e-61634e45fdbf" /> | <img width="317" height="103" alt="Screenshot 2026-08-21 at 12 53 25 pm" src="https://github.com/user-attachments/assets/123b90bc-86a6-4559-9cd3-e9b6ce196400" /> |

The cause was a duplicated style handle.

While making this change, I've also fixed an accessibility issue with how the screen reader only text was hidden.

Closes #1392 

### How to test the Change

1. Run `npm run build`
2. Navigate to the post edit screen
3. Ensure the Distributor icon in the header is displayed at the expected size
4. Ensure the text is hidden.

### Changelog Entry
> Fixed - Rename list table styles to avoid naming collision and resolve interaction with Distributor's Edit Remove Meta plugin.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
